### PR TITLE
feat(app-core): add complex object inspector popover in data/signal viewer (#450)

### DIFF
--- a/packages/app-core/src/features/compiled-vega/components/compiled-vega-pane.tsx
+++ b/packages/app-core/src/features/compiled-vega/components/compiled-vega-pane.tsx
@@ -17,7 +17,7 @@ import Editor from '@monaco-editor/react';
 import type { TopLevelSpec } from 'vega-lite';
 
 import { logRender } from '@deneb-viz/utils/logging';
-import { EDITOR_DEFAULTS } from '@deneb-viz/configuration';
+import { formatJson } from '@deneb-viz/utils/object';
 import {
     compileCleanVgSpec,
     parseJsonWithResult
@@ -106,7 +106,7 @@ export const CompiledVegaPane = ({
         const stripped = stripConfigFromSpec(
             stripSchemaFromSpec(vgSpec as Record<string, unknown>)
         );
-        return JSON.stringify(stripped, null, EDITOR_DEFAULTS.tabSize);
+        return formatJson(stripped);
     }, [provider, isCompiledVegaPaneVisible, specString, configString]);
 
     const [popoverOpen, setPopoverOpen] = useState(false);

--- a/packages/app-core/src/features/compiled-vega/components/compiled-vega-pane.tsx
+++ b/packages/app-core/src/features/compiled-vega/components/compiled-vega-pane.tsx
@@ -106,7 +106,7 @@ export const CompiledVegaPane = ({
         const stripped = stripConfigFromSpec(
             stripSchemaFromSpec(vgSpec as Record<string, unknown>)
         );
-        return formatJson(stripped);
+        return formatJson(stripped) ?? '';
     }, [provider, isCompiledVegaPaneVisible, specString, configString]);
 
     const [popoverOpen, setPopoverOpen] = useState(false);

--- a/packages/app-core/src/features/debug-area/components/data-table/complex-value-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/complex-value-cell.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    Button,
+    makeStyles,
+    Popover,
+    PopoverSurface,
+    PopoverTrigger,
+    tokens,
+    Tooltip
+} from '@fluentui/react-components';
+import { MoreHorizontalRegular } from '@fluentui/react-icons';
+import Editor from '@monaco-editor/react';
+
+import { formatJson } from '@deneb-viz/utils/object';
+import { POPOVER_Z_INDEX } from '../../../../lib';
+import { getDenebState, useDenebState } from '../../../../state';
+import { buildEditorProps } from '../../../../components/code-editor/editor-configuration';
+import { useDataTableTooltip } from './data-table-tooltip-context';
+
+const useComplexValueCellStyles = makeStyles({
+    popoverSurface: {
+        zIndex: POPOVER_Z_INDEX
+    },
+    editorContainer: {
+        width: '450px',
+        height: '350px',
+        border: `${tokens.strokeWidthThin} solid ${tokens.colorNeutralStroke2}`
+    }
+});
+
+type ComplexValueCellProps = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rawValue: any;
+};
+
+export const ComplexValueCell = ({ rawValue }: ComplexValueCellProps) => {
+    const classes = useComplexValueCellStyles();
+    const { translate } = getDenebState().i18n;
+    const { fontSize, theme } = useDenebState((state) => ({
+        fontSize: state.editorPreferences.jsonEditorFontSize,
+        theme: state.editorPreferences.theme
+    }));
+    const tooltipMountNode = useDataTableTooltip();
+    const editorContainerRef = useRef<HTMLDivElement>(null);
+    const [popoverOpen, setPopoverOpen] = useState(false);
+
+    const formattedValue = useMemo(
+        () =>
+            rawValue != null
+                ? formatJson(rawValue)
+                : '',
+        [rawValue]
+    );
+
+    const handleOpenChange = useCallback(
+        (_e: unknown, data: { open: boolean }) => {
+            setPopoverOpen(data.open);
+        },
+        []
+    );
+
+    // Dismiss popover on any ancestor scroll, but ignore scrolling
+    // within the popover's Monaco editor.
+    useEffect(() => {
+        if (!popoverOpen) return;
+        const dismiss = (e: Event) => {
+            if (editorContainerRef.current?.contains(e.target as Node)) return;
+            setPopoverOpen(false);
+        };
+        window.addEventListener('scroll', dismiss, true);
+        return () => window.removeEventListener('scroll', dismiss, true);
+    }, [popoverOpen]);
+
+    return (
+        <Popover open={popoverOpen} onOpenChange={handleOpenChange} withArrow>
+            <Tooltip
+                content={translate('Table_Tooltip_TooLong')}
+                relationship='description'
+                withArrow
+                mountNode={tooltipMountNode}
+            >
+                <PopoverTrigger>
+                    <Button
+                        appearance='subtle'
+                        size='small'
+                        icon={<MoreHorizontalRegular />}
+                    />
+                </PopoverTrigger>
+            </Tooltip>
+            <PopoverSurface className={classes.popoverSurface}>
+                <div
+                    ref={editorContainerRef}
+                    className={classes.editorContainer}
+                >
+                    <Editor
+                        {...buildEditorProps({
+                            theme,
+                            fontSize,
+                            readOnly: true,
+                            showLineNumbers: false,
+                            wordWrap: false
+                        })}
+                        value={formattedValue}
+                    />
+                </div>
+            </PopoverSurface>
+        </Popover>
+    );
+};

--- a/packages/app-core/src/features/debug-area/components/data-table/complex-value-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/complex-value-cell.tsx
@@ -44,13 +44,14 @@ export const ComplexValueCell = ({ rawValue }: ComplexValueCellProps) => {
     const editorContainerRef = useRef<HTMLDivElement>(null);
     const [popoverOpen, setPopoverOpen] = useState(false);
 
-    const formattedValue = useMemo(
-        () =>
-            rawValue != null
-                ? formatJson(rawValue)
-                : '',
-        [rawValue]
-    );
+    const formattedValue = useMemo(() => {
+        if (rawValue == null) return '';
+        try {
+            return formatJson(rawValue) ?? '';
+        } catch {
+            return '';
+        }
+    }, [rawValue]);
 
     const handleOpenChange = useCallback(
         (_e: unknown, data: { open: boolean }) => {

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
@@ -14,6 +14,7 @@ import {
     type DataPointSelectionStatus
 } from '@deneb-viz/data-core/value';
 import { getDenebState } from '../../../../state';
+import { ComplexValueCell } from './complex-value-cell';
 
 type DataTableCellProps = {
     displayValue: string;
@@ -31,6 +32,9 @@ export const DataTableCell = ({
     field,
     rawValue
 }: DataTableCellProps) => {
+    if (isValuePlaceholderComplex(displayValue)) {
+        return <ComplexValueCell rawValue={rawValue} />;
+    }
     const tooltipValue = getCellTooltip(field, rawValue);
     return <div title={tooltipValue}>{displayValue}</div>;
 };

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-tooltip-context.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-tooltip-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, type ReactNode } from 'react';
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
 
 import { TooltipCustomMount } from '../../../../components/ui';
 
@@ -20,8 +20,9 @@ export const DataTableTooltipProvider = ({
     children: ReactNode;
 }) => {
     const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
+    const contextValue = useMemo(() => ({ mountNode }), [mountNode]);
     return (
-        <DataTableTooltipContext.Provider value={{ mountNode }}>
+        <DataTableTooltipContext.Provider value={contextValue}>
             {children}
             <TooltipCustomMount setRef={setMountNode} />
         </DataTableTooltipContext.Provider>

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-tooltip-context.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-tooltip-context.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+import { TooltipCustomMount } from '../../../../components/ui';
+
+type DataTableTooltipContextValue = {
+    mountNode: HTMLElement | null;
+};
+
+const DataTableTooltipContext =
+    createContext<DataTableTooltipContextValue | null>(null);
+
+export const useDataTableTooltip = () => {
+    const ctx = useContext(DataTableTooltipContext);
+    return ctx?.mountNode ?? null;
+};
+
+export const DataTableTooltipProvider = ({
+    children
+}: {
+    children: ReactNode;
+}) => {
+    const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
+    return (
+        <DataTableTooltipContext.Provider value={{ mountNode }}>
+            {children}
+            <TooltipCustomMount setRef={setMountNode} />
+        </DataTableTooltipContext.Provider>
+    );
+};

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -6,6 +6,7 @@ import { StyleSheetManager } from 'styled-components';
 
 import { logRender } from '@deneb-viz/utils/logging';
 import { DataTableStatusBar } from './data-table-status-bar';
+import { DataTableTooltipProvider } from './data-table-tooltip-context';
 import {
     DATA_TABLE_FONT_FAMILY,
     DATA_TABLE_FONT_SIZE,
@@ -43,8 +44,9 @@ export const DataTableViewer = ({
     // Filter compact prop that RDT passes to column cells but shouldn't reach DOM
     const shouldForwardProp = (propName: string) => propName !== 'compact';
     return (
-        <div className={classes.enclosure}>
-            <StyleSheetManager shouldForwardProp={shouldForwardProp}>
+        <DataTableTooltipProvider>
+            <div className={classes.enclosure}>
+                <StyleSheetManager shouldForwardProp={shouldForwardProp}>
                 <DataTable
                     columns={columns}
                     data={data}
@@ -121,7 +123,8 @@ export const DataTableViewer = ({
                     dense
                     {...props}
                 />
-            </StyleSheetManager>
-        </div>
+                </StyleSheetManager>
+            </div>
+        </DataTableTooltipProvider>
     );
 };

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/signal-value.tsx
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/signal-value.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { usePrevious } from '@uidotdev/usehooks';
 
 import { logDebug, logRender } from '@deneb-viz/utils/logging';
@@ -98,7 +98,7 @@ export const SignalValue = ({ signalName, renderId }: SignalValueProps) => {
         setSignalValue(() => value);
         logDebug(`[${renderId}] Signal value for ${name} has changed`, value);
     };
-    const getSignalValues = () => {
+    const getSignalValues = useCallback(() => {
         try {
             const raw = getPrunedObject(
                 VegaViewServices.getSignalByName(signalName),
@@ -116,7 +116,7 @@ export const SignalValue = ({ signalName, renderId }: SignalValueProps) => {
             );
             return { raw: null, display: '' };
         }
-    };
+    }, [signalName, translate]);
     /**
      * Ensure that listener is added/removed when the view changes between renders.
      */
@@ -139,7 +139,7 @@ export const SignalValue = ({ signalName, renderId }: SignalValueProps) => {
         return () => {
             removeListener();
         };
-    }, [signalName]);
+    }, [signalName, getSignalValues]);
     const currentValues = getSignalValues();
     logRender('SignalValue', {
         signalName,

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/signal-value.tsx
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/signal-value.tsx
@@ -98,26 +98,24 @@ export const SignalValue = ({ signalName, renderId }: SignalValueProps) => {
         setSignalValue(() => value);
         logDebug(`[${renderId}] Signal value for ${name} has changed`, value);
     };
-    const getRawSignalValue = () => {
+    const getSignalValues = () => {
         try {
-            return getPrunedObject(
+            const raw = getPrunedObject(
                 VegaViewServices.getSignalByName(signalName),
                 { maxDepth: DATA_TABLE_VALUE_MAX_DEPTH }
             );
+            const stringified = stringifyPruned(raw);
+            const display =
+                stringified?.length > DATA_TABLE_VALUE_MAX_LENGTH
+                    ? translate('Table_Placeholder_TooLong')
+                    : stringified;
+            return { raw, display };
         } catch {
             logDebug(
                 `Could not retrieve value for signal ${signalName}. It may not exist in the current view scope.`
             );
-            return null;
+            return { raw: null, display: '' };
         }
-    };
-    const getSignalDisplayValue = () => {
-        const raw = getRawSignalValue();
-        if (raw == null) return '';
-        const value = stringifyPruned(raw);
-        return value?.length > DATA_TABLE_VALUE_MAX_LENGTH
-            ? translate('Table_Placeholder_TooLong')
-            : value;
     };
     /**
      * Ensure that listener is added/removed when the view changes between renders.
@@ -136,22 +134,23 @@ export const SignalValue = ({ signalName, renderId }: SignalValueProps) => {
         logDebug(
             `Signal name has changed from ${previousSignalName} to ${signalName}. Updating...`
         );
-        setSignalValue(() => getSignalDisplayValue());
+        setSignalValue(() => getSignalValues().display);
         cycleListeners();
         return () => {
             removeListener();
         };
     }, [signalName]);
+    const currentValues = getSignalValues();
     logRender('SignalValue', {
         signalName,
         signalValue,
-        viewValue: getSignalDisplayValue()
+        viewValue: currentValues.display
     });
     return (
         <DataTableCell
             field={signalName}
-            displayValue={getSignalDisplayValue()}
-            rawValue={getRawSignalValue()}
+            displayValue={currentValues.display}
+            rawValue={currentValues.raw}
         />
     );
 };

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/signal-value.tsx
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/signal-value.tsx
@@ -2,9 +2,12 @@ import { useEffect, useState } from 'react';
 import { usePrevious } from '@uidotdev/usehooks';
 
 import { logDebug, logRender } from '@deneb-viz/utils/logging';
-import { stringifyPruned } from '@deneb-viz/utils/object';
+import { getPrunedObject, stringifyPruned } from '@deneb-viz/utils/object';
 import { VegaViewServices } from '@deneb-viz/vega-runtime/view';
-import { DATA_TABLE_VALUE_MAX_LENGTH } from '../../constants';
+import {
+    DATA_TABLE_VALUE_MAX_DEPTH,
+    DATA_TABLE_VALUE_MAX_LENGTH
+} from '../../constants';
 import { DataTableCell } from '../data-table/data-table-cell';
 import { useDenebState } from '../../../../state';
 
@@ -95,20 +98,26 @@ export const SignalValue = ({ signalName, renderId }: SignalValueProps) => {
         setSignalValue(() => value);
         logDebug(`[${renderId}] Signal value for ${name} has changed`, value);
     };
-    const getSignalValue = () => {
+    const getRawSignalValue = () => {
         try {
-            const value = stringifyPruned(
-                VegaViewServices.getSignalByName(signalName)
+            return getPrunedObject(
+                VegaViewServices.getSignalByName(signalName),
+                { maxDepth: DATA_TABLE_VALUE_MAX_DEPTH }
             );
-            return value?.length > DATA_TABLE_VALUE_MAX_LENGTH
-                ? translate('Table_Placeholder_TooLong')
-                : value;
         } catch {
             logDebug(
                 `Could not retrieve value for signal ${signalName}. It may not exist in the current view scope.`
             );
-            return '';
+            return null;
         }
+    };
+    const getSignalDisplayValue = () => {
+        const raw = getRawSignalValue();
+        if (raw == null) return '';
+        const value = stringifyPruned(raw);
+        return value?.length > DATA_TABLE_VALUE_MAX_LENGTH
+            ? translate('Table_Placeholder_TooLong')
+            : value;
     };
     /**
      * Ensure that listener is added/removed when the view changes between renders.
@@ -127,7 +136,7 @@ export const SignalValue = ({ signalName, renderId }: SignalValueProps) => {
         logDebug(
             `Signal name has changed from ${previousSignalName} to ${signalName}. Updating...`
         );
-        setSignalValue(() => getSignalValue());
+        setSignalValue(() => getSignalDisplayValue());
         cycleListeners();
         return () => {
             removeListener();
@@ -136,13 +145,13 @@ export const SignalValue = ({ signalName, renderId }: SignalValueProps) => {
     logRender('SignalValue', {
         signalName,
         signalValue,
-        viewValue: getSignalValue()
+        viewValue: getSignalDisplayValue()
     });
     return (
         <DataTableCell
             field={signalName}
-            displayValue={getSignalValue()}
-            rawValue={getSignalValue()}
+            displayValue={getSignalDisplayValue()}
+            rawValue={getRawSignalValue()}
         />
     );
 };

--- a/packages/app-core/src/features/debug-area/constants.ts
+++ b/packages/app-core/src/features/debug-area/constants.ts
@@ -23,7 +23,7 @@ export const DATA_TABLE_ROW_PADDING_LEFT = 10;
 /**
  * The maximum level of recursion to use when evaluating a table value (in case it's a complex object).
  */
-export const DATA_TABLE_VALUE_MAX_DEPTH = 3;
+export const DATA_TABLE_VALUE_MAX_DEPTH = 4;
 
 /**
  * The maximum permitted length of a value for a table cell before 'truncating' it for display.

--- a/packages/app-core/src/i18n/en-US.json
+++ b/packages/app-core/src/i18n/en-US.json
@@ -49,7 +49,7 @@
     "Table_Placeholder_Infinity": "Infinity",
     "Table_Placeholder_Object": "[Object]",
     "Table_Placeholder_TooLong": "{...}",
-    "Table_Tooltip_TooLong": "This is a complex object, or is too large to display.",
+    "Table_Tooltip_TooLong": "This is a complex object, or is too large to display. Click to inspect a shallow representation.",
     "Template_Description_Optional_Placeholder": "Optional description for end-user",
     "Template_Export_Author_Name": "Author",
     "Template_Export_Author_Name_Empty": "[No Author Details Provided]",

--- a/packages/utils/src/lib/__tests__/object.test.ts
+++ b/packages/utils/src/lib/__tests__/object.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+    formatJson,
     getPrunedObject,
     matchesObjectKeyValues,
     omit,
@@ -287,5 +288,45 @@ describe('stringifyPruned', () => {
             const matcher = matchesObjectKeyValues(source);
             expect(matcher(object)).toBe(true);
         });
+    });
+});
+
+describe('formatJson', () => {
+    it('should format an object with default 2-space indentation', () => {
+        const obj = { a: 1, b: 2 };
+        const result = formatJson(obj);
+        expect(result).toBe('{\n  "a": 1,\n  "b": 2\n}');
+    });
+
+    it('should format nested objects with correct indentation', () => {
+        const obj = { a: { b: 1 } };
+        const result = formatJson(obj);
+        expect(result).toBe('{\n  "a": {\n    "b": 1\n  }\n}');
+    });
+
+    it('should accept a custom indent size', () => {
+        const obj = { a: 1 };
+        const result = formatJson(obj, 4);
+        expect(result).toBe('{\n    "a": 1\n}');
+    });
+
+    it('should format arrays', () => {
+        const arr = [1, 2, 3];
+        const result = formatJson(arr);
+        expect(result).toBe('[\n  1,\n  2,\n  3\n]');
+    });
+
+    it('should return "null" for null input', () => {
+        expect(formatJson(null)).toBe('null');
+    });
+
+    it('should return undefined for undefined input', () => {
+        expect(formatJson(undefined)).toBeUndefined();
+    });
+
+    it('should format primitive values', () => {
+        expect(formatJson('hello')).toBe('"hello"');
+        expect(formatJson(42)).toBe('42');
+        expect(formatJson(true)).toBe('true');
     });
 });

--- a/packages/utils/src/lib/object.ts
+++ b/packages/utils/src/lib/object.ts
@@ -55,6 +55,11 @@ const DEFAULT_WHITESPACE_CHAR = ' ';
 const DEFAULT_LINE_LENGTH = 40;
 
 /**
+ * Default indentation size for JSON formatting.
+ */
+const DEFAULT_JSON_FORMAT_INDENT_CHARS = 2;
+
+/**
  * Prune an object at a specified level of depth.
  */
 export const getPrunedObject = (
@@ -101,6 +106,14 @@ export const matchesObjectKeyValues =
         }
         return true;
     };
+
+/**
+ * Format a value as indented JSON. Suitable for display in read-only editors.
+ */
+export const formatJson = (
+    value: unknown,
+    indent = DEFAULT_JSON_FORMAT_INDENT_CHARS
+): string | undefined => JSON.stringify(value, null, indent);
 
 /**
  * Create a stringified representation of an object, pruned at a specified level of depth.


### PR DESCRIPTION
Add a clickable inspect button (MoreHorizontalRegular icon) for complex values in data and signal viewer table cells. Clicking opens a Popover with a read-only Monaco editor showing formatted JSON of the pruned object structure.

- Extract ComplexValueCell component with Popover, Tooltip, and Monaco editor using buildEditorProps for consistent configuration
- Add DataTableTooltipProvider context for tooltip mount node at table level, preventing tooltip rendering issues in narrow cells
- Dismiss popover on ancestor scroll (capture phase) while allowing scrolling within the editor itself
- Add formatJson utility in @deneb-viz/utils/object with tests, replacing inline JSON.stringify calls in compiled-vega-pane
- Increase DATA_TABLE_VALUE_MAX_DEPTH from 3 to 4 for richer inspection
- Update Table_Tooltip_TooLong i18n text with click instruction