### PR TITLE
feat: add keyboard focus support (#461)

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -358,6 +358,7 @@
             }
         }
     ],
+    "supportsKeyboardFocus": true,
     "supportsLandingPage": true,
     "supportsMultiVisualSelection": true,
     "supportsEmptyDataView": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import {
     createCrossFilterClearHandler
 } from './lib/vega-embed';
 import { APPLICATION_NAME, APPLICATION_VERSION } from './lib/application';
+import { handleTabWrapAround } from './lib/keyboard-focus';
 
 /**
  * Centralize/report developer mode from environment.
@@ -106,6 +107,7 @@ export class Deneb implements IVisual {
             this.#applicationWrapper.id = 'deneb-application-wrapper';
             element.appendChild(this.#applicationWrapper);
             this.handleSuppressOnObjectFormatting();
+            this.bindTabCycling();
             this.#root = createRoot(this.#applicationWrapper);
             this.#root.render(createElement(App, { host }));
             element.oncontextmenu = (ev) => {
@@ -263,6 +265,27 @@ export class Deneb implements IVisual {
             fieldUsage: { dataset: trackedFieldsCurrent }
         } = getDenebState();
         updateFieldTracking(spec, trackedFieldsCurrent);
+    }
+
+    /**
+     * Cycle Tab focus within the visual's own tabbable elements to prevent focus from
+     * escaping the iframe into other visuals on the Power BI canvas. When the user
+     * reaches the last tabbable element, Tab wraps to the first; Shift+Tab on the first
+     * wraps to the last. Esc is not intercepted — Power BI handles exiting the visual.
+     */
+    private bindTabCycling() {
+        document.addEventListener('keydown', (event) => {
+            if (event.key !== 'Tab') return;
+            if (
+                handleTabWrapAround(
+                    this.#applicationWrapper,
+                    document.activeElement,
+                    event.shiftKey
+                )
+            ) {
+                event.preventDefault();
+            }
+        });
     }
 
     /**

--- a/src/lib/__test__/keyboard-focus.test.ts
+++ b/src/lib/__test__/keyboard-focus.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
     getTabbableElements,
@@ -7,68 +7,112 @@ import {
     TABBABLE_SELECTOR
 } from '../keyboard-focus';
 
+type ElementSpec = {
+    tag: string;
+    attrs?: Record<string, string>;
+    children?: ElementSpec[];
+    text?: string;
+};
+
 /**
- * Create a container with the given inner HTML and append it to the document
- * body so that focus operations work correctly.
+ * Build a DOM element tree from a spec and append it to document.body.
  */
-const createContainer = (innerHTML: string): HTMLElement => {
+const createContainer = (...specs: ElementSpec[]): HTMLElement => {
     const container = document.createElement('div');
-    container.innerHTML = innerHTML;
+    for (const spec of specs) {
+        container.appendChild(buildElement(spec));
+    }
     document.body.appendChild(container);
     return container;
 };
 
+const buildElement = (spec: ElementSpec): HTMLElement => {
+    const el = document.createElement(spec.tag);
+    if (spec.attrs) {
+        for (const [key, value] of Object.entries(spec.attrs)) {
+            el.setAttribute(key, value);
+        }
+    }
+    if (spec.text) {
+        el.textContent = spec.text;
+    }
+    if (spec.children) {
+        for (const child of spec.children) {
+            el.appendChild(buildElement(child));
+        }
+    }
+    return el;
+};
+
+afterEach(() => {
+    document.body.replaceChildren();
+});
+
 describe('TABBABLE_SELECTOR', () => {
     it('should match enabled input elements', () => {
         const container = createContainer(
-            '<input type="text" /><input type="range" />'
+            { tag: 'input', attrs: { type: 'text' } },
+            { tag: 'input', attrs: { type: 'range' } }
         );
         const matches = container.querySelectorAll(TABBABLE_SELECTOR);
         expect(matches.length).toBe(2);
     });
 
     it('should not match disabled input elements', () => {
-        const container = createContainer('<input type="text" disabled />');
+        const container = createContainer({
+            tag: 'input',
+            attrs: { type: 'text', disabled: '' }
+        });
         const matches = container.querySelectorAll(TABBABLE_SELECTOR);
         expect(matches.length).toBe(0);
     });
 
     it('should not match elements with tabindex="-1"', () => {
-        const container = createContainer(
-            '<input type="text" tabindex="-1" />'
-        );
+        const container = createContainer({
+            tag: 'input',
+            attrs: { type: 'text', tabindex: '-1' }
+        });
         const matches = container.querySelectorAll(TABBABLE_SELECTOR);
         expect(matches.length).toBe(0);
     });
 
     it('should match select elements', () => {
-        const container = createContainer(
-            '<select><option>A</option></select>'
-        );
+        const container = createContainer({
+            tag: 'select',
+            children: [{ tag: 'option', text: 'A' }]
+        });
         const matches = container.querySelectorAll(TABBABLE_SELECTOR);
         expect(matches.length).toBe(1);
     });
 
     it('should match buttons', () => {
-        const container = createContainer('<button>Click</button>');
+        const container = createContainer({ tag: 'button', text: 'Click' });
         const matches = container.querySelectorAll(TABBABLE_SELECTOR);
         expect(matches.length).toBe(1);
     });
 
     it('should match anchors with href', () => {
-        const container = createContainer('<a href="#">Link</a>');
+        const container = createContainer({
+            tag: 'a',
+            attrs: { href: '#' },
+            text: 'Link'
+        });
         const matches = container.querySelectorAll(TABBABLE_SELECTOR);
         expect(matches.length).toBe(1);
     });
 
     it('should not match anchors without href', () => {
-        const container = createContainer('<a>Link</a>');
+        const container = createContainer({ tag: 'a', text: 'Link' });
         const matches = container.querySelectorAll(TABBABLE_SELECTOR);
         expect(matches.length).toBe(0);
     });
 
     it('should match elements with tabindex="0"', () => {
-        const container = createContainer('<div tabindex="0">Focusable</div>');
+        const container = createContainer({
+            tag: 'div',
+            attrs: { tabindex: '0' },
+            text: 'Focusable'
+        });
         const matches = container.querySelectorAll(TABBABLE_SELECTOR);
         expect(matches.length).toBe(1);
     });
@@ -77,7 +121,12 @@ describe('TABBABLE_SELECTOR', () => {
 describe('getTabbableElements', () => {
     it('should return tabbable elements in DOM order', () => {
         const container = createContainer(
-            '<button>B</button><input type="text" /><select><option>A</option></select>'
+            { tag: 'button', text: 'B' },
+            { tag: 'input', attrs: { type: 'text' } },
+            {
+                tag: 'select',
+                children: [{ tag: 'option', text: 'A' }]
+            }
         );
         const elements = getTabbableElements(container);
         expect(elements.length).toBe(3);
@@ -87,14 +136,18 @@ describe('getTabbableElements', () => {
     });
 
     it('should return an empty array when no tabbable elements exist', () => {
-        const container = createContainer('<div>Not tabbable</div>');
+        const container = createContainer({
+            tag: 'div',
+            text: 'Not tabbable'
+        });
         const elements = getTabbableElements(container);
         expect(elements.length).toBe(0);
     });
 
     it('should exclude disabled elements', () => {
         const container = createContainer(
-            '<input type="text" /><input type="text" disabled />'
+            { tag: 'input', attrs: { type: 'text' } },
+            { tag: 'input', attrs: { type: 'text', disabled: '' } }
         );
         const elements = getTabbableElements(container);
         expect(elements.length).toBe(1);
@@ -103,14 +156,15 @@ describe('getTabbableElements', () => {
 
 describe('handleTabWrapAround', () => {
     it('should return false when no tabbable elements exist', () => {
-        const container = createContainer('<div>Empty</div>');
+        const container = createContainer({ tag: 'div', text: 'Empty' });
         const result = handleTabWrapAround(container, null, false);
         expect(result).toBe(false);
     });
 
     it('should wrap forward from the last element to the first', () => {
         const container = createContainer(
-            '<input id="first" /><input id="last" />'
+            { tag: 'input', attrs: { id: 'first' } },
+            { tag: 'input', attrs: { id: 'last' } }
         );
         const last = container.querySelector<HTMLElement>('#last')!;
         const first = container.querySelector<HTMLElement>('#first')!;
@@ -124,7 +178,8 @@ describe('handleTabWrapAround', () => {
 
     it('should wrap backward from the first element to the last', () => {
         const container = createContainer(
-            '<input id="first" /><input id="last" />'
+            { tag: 'input', attrs: { id: 'first' } },
+            { tag: 'input', attrs: { id: 'last' } }
         );
         const first = container.querySelector<HTMLElement>('#first')!;
         const last = container.querySelector<HTMLElement>('#last')!;
@@ -138,7 +193,9 @@ describe('handleTabWrapAround', () => {
 
     it('should not wrap when Tab is pressed on a middle element', () => {
         const container = createContainer(
-            '<input id="first" /><input id="middle" /><input id="last" />'
+            { tag: 'input', attrs: { id: 'first' } },
+            { tag: 'input', attrs: { id: 'middle' } },
+            { tag: 'input', attrs: { id: 'last' } }
         );
         const middle = container.querySelector<HTMLElement>('#middle')!;
 
@@ -149,7 +206,9 @@ describe('handleTabWrapAround', () => {
 
     it('should not wrap when Shift+Tab is pressed on a middle element', () => {
         const container = createContainer(
-            '<input id="first" /><input id="middle" /><input id="last" />'
+            { tag: 'input', attrs: { id: 'first' } },
+            { tag: 'input', attrs: { id: 'middle' } },
+            { tag: 'input', attrs: { id: 'last' } }
         );
         const middle = container.querySelector<HTMLElement>('#middle')!;
 
@@ -159,7 +218,10 @@ describe('handleTabWrapAround', () => {
     });
 
     it('should focus the first element on Tab when active element is outside the tabbable set', () => {
-        const container = createContainer('<input id="only" />');
+        const container = createContainer({
+            tag: 'input',
+            attrs: { id: 'only' }
+        });
         const only = container.querySelector<HTMLElement>('#only')!;
         const focusSpy = vi.spyOn(only, 'focus');
 
@@ -171,7 +233,8 @@ describe('handleTabWrapAround', () => {
 
     it('should focus the last element on Shift+Tab when active element is outside the tabbable set', () => {
         const container = createContainer(
-            '<input id="first" /><input id="last" />'
+            { tag: 'input', attrs: { id: 'first' } },
+            { tag: 'input', attrs: { id: 'last' } }
         );
         const last = container.querySelector<HTMLElement>('#last')!;
         const focusSpy = vi.spyOn(last, 'focus');
@@ -183,7 +246,10 @@ describe('handleTabWrapAround', () => {
     });
 
     it('should focus the first element on Tab when active element is null', () => {
-        const container = createContainer('<input id="only" />');
+        const container = createContainer({
+            tag: 'input',
+            attrs: { id: 'only' }
+        });
         const only = container.querySelector<HTMLElement>('#only')!;
         const focusSpy = vi.spyOn(only, 'focus');
 
@@ -194,11 +260,13 @@ describe('handleTabWrapAround', () => {
     });
 
     it('should handle a single tabbable element correctly for Tab', () => {
-        const container = createContainer('<input id="only" />');
+        const container = createContainer({
+            tag: 'input',
+            attrs: { id: 'only' }
+        });
         const only = container.querySelector<HTMLElement>('#only')!;
         const focusSpy = vi.spyOn(only, 'focus');
 
-        // Active is the only element, Tab should wrap to itself
         const result = handleTabWrapAround(container, only, false);
 
         expect(result).toBe(true);
@@ -206,7 +274,10 @@ describe('handleTabWrapAround', () => {
     });
 
     it('should handle a single tabbable element correctly for Shift+Tab', () => {
-        const container = createContainer('<input id="only" />');
+        const container = createContainer({
+            tag: 'input',
+            attrs: { id: 'only' }
+        });
         const only = container.querySelector<HTMLElement>('#only')!;
         const focusSpy = vi.spyOn(only, 'focus');
 

--- a/src/lib/__test__/keyboard-focus.test.ts
+++ b/src/lib/__test__/keyboard-focus.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+    getTabbableElements,
+    handleTabWrapAround,
+    TABBABLE_SELECTOR
+} from '../keyboard-focus';
+
+/**
+ * Create a container with the given inner HTML and append it to the document
+ * body so that focus operations work correctly.
+ */
+const createContainer = (innerHTML: string): HTMLElement => {
+    const container = document.createElement('div');
+    container.innerHTML = innerHTML;
+    document.body.appendChild(container);
+    return container;
+};
+
+describe('TABBABLE_SELECTOR', () => {
+    it('should match enabled input elements', () => {
+        const container = createContainer(
+            '<input type="text" /><input type="range" />'
+        );
+        const matches = container.querySelectorAll(TABBABLE_SELECTOR);
+        expect(matches.length).toBe(2);
+    });
+
+    it('should not match disabled input elements', () => {
+        const container = createContainer('<input type="text" disabled />');
+        const matches = container.querySelectorAll(TABBABLE_SELECTOR);
+        expect(matches.length).toBe(0);
+    });
+
+    it('should not match elements with tabindex="-1"', () => {
+        const container = createContainer(
+            '<input type="text" tabindex="-1" />'
+        );
+        const matches = container.querySelectorAll(TABBABLE_SELECTOR);
+        expect(matches.length).toBe(0);
+    });
+
+    it('should match select elements', () => {
+        const container = createContainer(
+            '<select><option>A</option></select>'
+        );
+        const matches = container.querySelectorAll(TABBABLE_SELECTOR);
+        expect(matches.length).toBe(1);
+    });
+
+    it('should match buttons', () => {
+        const container = createContainer('<button>Click</button>');
+        const matches = container.querySelectorAll(TABBABLE_SELECTOR);
+        expect(matches.length).toBe(1);
+    });
+
+    it('should match anchors with href', () => {
+        const container = createContainer('<a href="#">Link</a>');
+        const matches = container.querySelectorAll(TABBABLE_SELECTOR);
+        expect(matches.length).toBe(1);
+    });
+
+    it('should not match anchors without href', () => {
+        const container = createContainer('<a>Link</a>');
+        const matches = container.querySelectorAll(TABBABLE_SELECTOR);
+        expect(matches.length).toBe(0);
+    });
+
+    it('should match elements with tabindex="0"', () => {
+        const container = createContainer('<div tabindex="0">Focusable</div>');
+        const matches = container.querySelectorAll(TABBABLE_SELECTOR);
+        expect(matches.length).toBe(1);
+    });
+});
+
+describe('getTabbableElements', () => {
+    it('should return tabbable elements in DOM order', () => {
+        const container = createContainer(
+            '<button>B</button><input type="text" /><select><option>A</option></select>'
+        );
+        const elements = getTabbableElements(container);
+        expect(elements.length).toBe(3);
+        expect(elements[0].tagName).toBe('BUTTON');
+        expect(elements[1].tagName).toBe('INPUT');
+        expect(elements[2].tagName).toBe('SELECT');
+    });
+
+    it('should return an empty array when no tabbable elements exist', () => {
+        const container = createContainer('<div>Not tabbable</div>');
+        const elements = getTabbableElements(container);
+        expect(elements.length).toBe(0);
+    });
+
+    it('should exclude disabled elements', () => {
+        const container = createContainer(
+            '<input type="text" /><input type="text" disabled />'
+        );
+        const elements = getTabbableElements(container);
+        expect(elements.length).toBe(1);
+    });
+});
+
+describe('handleTabWrapAround', () => {
+    it('should return false when no tabbable elements exist', () => {
+        const container = createContainer('<div>Empty</div>');
+        const result = handleTabWrapAround(container, null, false);
+        expect(result).toBe(false);
+    });
+
+    it('should wrap forward from the last element to the first', () => {
+        const container = createContainer(
+            '<input id="first" /><input id="last" />'
+        );
+        const last = container.querySelector<HTMLElement>('#last')!;
+        const first = container.querySelector<HTMLElement>('#first')!;
+        const focusSpy = vi.spyOn(first, 'focus');
+
+        const result = handleTabWrapAround(container, last, false);
+
+        expect(result).toBe(true);
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it('should wrap backward from the first element to the last', () => {
+        const container = createContainer(
+            '<input id="first" /><input id="last" />'
+        );
+        const first = container.querySelector<HTMLElement>('#first')!;
+        const last = container.querySelector<HTMLElement>('#last')!;
+        const focusSpy = vi.spyOn(last, 'focus');
+
+        const result = handleTabWrapAround(container, first, true);
+
+        expect(result).toBe(true);
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it('should not wrap when Tab is pressed on a middle element', () => {
+        const container = createContainer(
+            '<input id="first" /><input id="middle" /><input id="last" />'
+        );
+        const middle = container.querySelector<HTMLElement>('#middle')!;
+
+        const result = handleTabWrapAround(container, middle, false);
+
+        expect(result).toBe(false);
+    });
+
+    it('should not wrap when Shift+Tab is pressed on a middle element', () => {
+        const container = createContainer(
+            '<input id="first" /><input id="middle" /><input id="last" />'
+        );
+        const middle = container.querySelector<HTMLElement>('#middle')!;
+
+        const result = handleTabWrapAround(container, middle, true);
+
+        expect(result).toBe(false);
+    });
+
+    it('should focus the first element on Tab when active element is outside the tabbable set', () => {
+        const container = createContainer('<input id="only" />');
+        const only = container.querySelector<HTMLElement>('#only')!;
+        const focusSpy = vi.spyOn(only, 'focus');
+
+        const result = handleTabWrapAround(container, document.body, false);
+
+        expect(result).toBe(true);
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it('should focus the last element on Shift+Tab when active element is outside the tabbable set', () => {
+        const container = createContainer(
+            '<input id="first" /><input id="last" />'
+        );
+        const last = container.querySelector<HTMLElement>('#last')!;
+        const focusSpy = vi.spyOn(last, 'focus');
+
+        const result = handleTabWrapAround(container, document.body, true);
+
+        expect(result).toBe(true);
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it('should focus the first element on Tab when active element is null', () => {
+        const container = createContainer('<input id="only" />');
+        const only = container.querySelector<HTMLElement>('#only')!;
+        const focusSpy = vi.spyOn(only, 'focus');
+
+        const result = handleTabWrapAround(container, null, false);
+
+        expect(result).toBe(true);
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it('should handle a single tabbable element correctly for Tab', () => {
+        const container = createContainer('<input id="only" />');
+        const only = container.querySelector<HTMLElement>('#only')!;
+        const focusSpy = vi.spyOn(only, 'focus');
+
+        // Active is the only element, Tab should wrap to itself
+        const result = handleTabWrapAround(container, only, false);
+
+        expect(result).toBe(true);
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it('should handle a single tabbable element correctly for Shift+Tab', () => {
+        const container = createContainer('<input id="only" />');
+        const only = container.querySelector<HTMLElement>('#only')!;
+        const focusSpy = vi.spyOn(only, 'focus');
+
+        const result = handleTabWrapAround(container, only, true);
+
+        expect(result).toBe(true);
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+});

--- a/src/lib/keyboard-focus.ts
+++ b/src/lib/keyboard-focus.ts
@@ -1,0 +1,57 @@
+/**
+ * CSS selector for elements that participate in the natural tab order.
+ * Covers standard interactive HTML elements (excluding disabled and tabindex="-1")
+ * and any element explicitly made tabbable via tabindex="0".
+ */
+export const TABBABLE_SELECTOR =
+    'input:not([disabled]):not([tabindex="-1"]), ' +
+    'select:not([disabled]):not([tabindex="-1"]), ' +
+    'textarea:not([disabled]):not([tabindex="-1"]), ' +
+    'button:not([disabled]):not([tabindex="-1"]), ' +
+    'a[href]:not([tabindex="-1"]), ' +
+    '[tabindex="0"]';
+
+/**
+ * Get all tabbable elements within a container, in DOM order.
+ */
+export const getTabbableElements = (container: HTMLElement): HTMLElement[] => [
+    ...container.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR)
+];
+
+/**
+ * Handle Tab/Shift+Tab wrap-around within a container's tabbable elements.
+ * Returns `true` if the event was handled (wrapped), `false` if the caller
+ * should let the browser handle it.
+ *
+ * When the active element is the last tabbable element and Tab is pressed,
+ * focus wraps to the first. When the active element is the first and
+ * Shift+Tab is pressed, focus wraps to the last. If the active element is
+ * outside the tabbable set, focus is directed to the first (Tab) or last
+ * (Shift+Tab) element.
+ */
+export const handleTabWrapAround = (
+    container: HTMLElement,
+    activeElement: Element | null,
+    shiftKey: boolean
+): boolean => {
+    const tabbable = getTabbableElements(container);
+    if (tabbable.length === 0) return false;
+
+    const first = tabbable[0];
+    const last = tabbable[tabbable.length - 1];
+    const isInsideTabbable = tabbable.includes(activeElement as HTMLElement);
+
+    if (shiftKey) {
+        if (!isInsideTabbable || activeElement === first) {
+            last.focus({ preventScroll: true });
+            return true;
+        }
+    } else {
+        if (!isInsideTabbable || activeElement === last) {
+            first.focus({ preventScroll: true });
+            return true;
+        }
+    }
+
+    return false;
+};


### PR DESCRIPTION
Enable supportsKeyboardFocus capability so users can navigate into the visual via Enter and exit via Esc. Add Tab wrap-around cycling within the visual's tabbable elements to prevent focus from escaping the iframe into other visuals on the canvas.