### PR TITLE
fix: restore keyboard navigation in modal dialogs

### DIFF
--- a/docs/brainstorms/2026-04-10-modal-dialog-keyboard-nav-requirements.md
+++ b/docs/brainstorms/2026-04-10-modal-dialog-keyboard-nav-requirements.md
@@ -1,0 +1,54 @@
+---
+date: 2026-04-10
+topic: modal-dialog-keyboard-navigation
+---
+
+# Modal Dialog Keyboard Navigation Fix
+
+## Problem Frame
+
+Keyboard users cannot fully navigate the import or export modal dialogs using Tab. In the import dialog, focus gets trapped on the "Create using..." radio group and cannot reach the template selection area. In the export dialog, Tab always returns to the Name field instead of cycling through all interactive elements. These issues make the dialogs inaccessible without a mouse. The editor itself handles tab navigation correctly — only the modal dialogs are affected.
+
+## Requirements
+
+**Import Dialog**
+- R1. Tab from the "Create using..." radio group must advance focus to the next interactive zone (template list or spec editor area, depending on the selected create mode)
+- R2. The template list should be a single tab stop with arrow key navigation between template cards (custom focus zone, not one tab stop per card)
+- R3. Shift+Tab must reverse through the same focus zones
+
+**Export Dialog**
+- R4. Tab must cycle through all interactive elements in visual order: Name → Description → Author → Include Preview checkbox → action buttons
+- R5. Focus must not return to Name after the last field — it should continue to the checkbox and buttons
+- R6. Shift+Tab must reverse through the same sequence
+
+**Version Change Dialog**
+- R7. Verify keyboard navigation works correctly in the version change dialog (may already be fine — needs testing)
+
+**General**
+- R8. Focus zones within each dialog should follow Fluent UI's focus management patterns (radio groups use arrow keys internally, tab stops move between zones)
+
+## Success Criteria
+
+- All interactive elements in import and export dialogs are reachable via Tab without a mouse
+- Tab order matches the visual layout (top-to-bottom, left-to-right within zones)
+- No focus traps — Tab always progresses, Shift+Tab always reverses
+
+## Scope Boundaries
+
+- NOT fixing: Remap dialog (no longer displayed)
+- NOT fixing: Editor keyboard navigation (already works correctly)
+- NOT adding: New keyboard shortcuts or hotkeys within the dialogs
+
+## Key Decisions
+
+- **Custom focus zones over flat tab order:** Template list in the import dialog should be one tab stop with arrow keys inside, not individual tab stops per template card. This matches standard listbox/grid keyboard patterns and keeps tab navigation efficient.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R2][Technical] How does Fluent UI's Dialog focus trap interact with custom focus zones? May need `tabster` or `FocusZone` configuration.
+- [Affects R7][Needs testing] Does the version change dialog have the same issues, or is its content simple enough that default Dialog focus management works?
+
+## Next Steps
+
+-> `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-10-002-fix-modal-dialog-keyboard-nav-plan.md
+++ b/docs/plans/2026-04-10-002-fix-modal-dialog-keyboard-nav-plan.md
@@ -1,0 +1,181 @@
+---
+title: "fix: Restore keyboard navigation in modal dialogs"
+type: fix
+status: active
+date: 2026-04-10
+origin: docs/brainstorms/2026-04-10-modal-dialog-keyboard-nav-requirements.md
+---
+
+# fix: Restore keyboard navigation in modal dialogs
+
+## Overview
+
+Fix Tab key navigation in the import (create) and export modal dialogs. Currently, Tab gets trapped on the radio group in the import dialog and loops back to the first field in the export dialog. The fix adds explicit focus zone configuration to the dialog content areas so Tab cycles through all interactive zones in visual order.
+
+## Problem Frame
+
+Keyboard users cannot navigate the import or export dialogs without a mouse. In the import dialog, focus traps on the "Create using..." radio group. In the export dialog, Tab returns to the Name field instead of cycling through all form fields and buttons. This makes these dialogs inaccessible via keyboard. (see origin: `docs/brainstorms/2026-04-10-modal-dialog-keyboard-nav-requirements.md`)
+
+## Requirements Trace
+
+- R1. Tab from radio group must advance to the next interactive zone in the import dialog
+- R2. Template list should be a single tab stop with arrow key navigation inside
+- R3. Shift+Tab must reverse through focus zones in the import dialog
+- R4. Tab must cycle through all interactive elements in visual order in the export dialog (Name → Description → Author → Preview checkbox → buttons)
+- R5. Focus must not return to Name after the last field — continue to checkbox and buttons
+- R6. Shift+Tab must reverse in the export dialog
+- R7. Verify version change dialog keyboard navigation (may already work)
+- R8. Focus zones should follow Fluent UI focus management patterns
+
+## Scope Boundaries
+
+- NOT fixing: Remap dialog (no longer displayed)
+- NOT fixing: Editor keyboard navigation (already works)
+- NOT adding: New keyboard shortcuts within dialogs
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/app-core/src/components/ui/modal-dialog/modal-dialog.tsx` — shared Dialog wrapper using Fluent UI v9's `Dialog` component with `modalType` prop
+- `packages/app-core/src/features/project-create/components/visual-create-pane.tsx` — import dialog content with conditional rendering based on create mode
+- `packages/app-core/src/features/project-create/components/create-method.tsx` — `RadioGroup` with three Radio options
+- `packages/app-core/src/features/project-export/components/export-pane.tsx` — export dialog content
+- `packages/app-core/src/features/project-export/components/export-information.tsx` — three `CappedTextField` components + one `Checkbox`
+- `packages/app-core/src/components/ui/modal-dialog/version-change-content.tsx` — version change dialog
+- `packages/app-core/src/components/ui/capped-text-field.tsx` — text field with `Input`/`Textarea` from Fluent UI
+
+### Current State
+
+- **No explicit `tabIndex`, `FocusZone`, or `tabster` usage** anywhere in `packages/app-core/`
+- Fluent UI v9's Dialog provides basic focus trapping via `@fluentui/react-tabster` (bundled internally), but no focus zone configuration is applied to dialog content
+- The conditional content rendering in the import dialog (template list appears/disappears based on radio selection) likely disrupts Fluent UI's automatic focus order
+- The export dialog's focus looping suggests Fluent UI's focus trap is wrapping around to the first focusable element instead of reaching the checkbox and buttons (possibly because they are in `DialogActions`, which is a separate child of `DialogBody`)
+
+## Key Technical Decisions
+
+- **Use Fluent UI v9's `tabster` attributes over custom `tabIndex` management:** Fluent UI v9 uses `tabster` under the hood for focus management. The `useFocusableGroup` hook and `data-tabster` attributes provide focus zone behavior that integrates with the existing Dialog focus trap. This is more maintainable than manual `tabIndex` values.
+- **Fix at the dialog content level, not the shared Dialog wrapper:** The focus issues are specific to how content is structured within each dialog, not a bug in the Dialog wrapper itself. Fixes should be in the feature-specific pane components.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q: Does Fluent UI v9 expose focus zone primitives?** → Yes, `@fluentui/react-tabster` exports `useFocusableGroup` and `useArrowNavigationGroup` hooks. The Dialog component already depends on this package internally.
+- **Q: Why does the export dialog loop to the first field?** → Likely because the `CappedTextField` components use Fluent `Input` which participates in the focus trap, but the `Checkbox` and `DialogActions` buttons may be outside the tabster-managed focus scope or in a separate DOM subtree that the focus trap skips.
+
+### Deferred to Implementation
+
+- **Exact `tabster` configuration needed for the template list arrow navigation:** Depends on how `SelectIncludedTemplate` renders its list items — may need `useArrowNavigationGroup` or a `role="listbox"` pattern.
+- **Whether the version change dialog needs changes:** Needs manual testing in the browser during implementation.
+
+## Implementation Units
+
+- [ ] **Unit 1: Fix export dialog tab order**
+
+**Goal:** Make Tab cycle through all interactive elements in the export dialog: Name → Description → Author → Preview checkbox → action buttons.
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/app-core/src/features/project-export/components/export-pane.tsx`
+- Modify: `packages/app-core/src/features/project-export/components/export-information.tsx`
+
+**Approach:**
+- Investigate why the Checkbox and DialogActions buttons are unreachable by Tab. The most likely cause is a DOM structure issue where these elements are outside the focus trap's effective scope.
+- If the issue is `DialogActions` being in a separate focus scope from `DialogContent`, the fix may involve restructuring how the content and actions relate within the `DialogBody`, or adding explicit `tabIndex={0}` to the unreachable elements.
+- If `CappedTextField` is capturing Tab (e.g., via the underlying `Input` or `Textarea`), check whether Fluent UI's `Input` component has a default behavior that prevents Tab from leaving.
+
+**Patterns to follow:**
+- Fluent UI v9 Dialog documentation for focus management
+- Existing `CappedTextField` props — check if any prop affects focus behavior
+
+**Test scenarios:**
+- Happy path: Tab from Name field → focus moves to Description → Author → Preview checkbox → Download button → Copy button → Close button → wraps to Name
+- Happy path: Shift+Tab reverses the above sequence
+- Edge case: Tab behavior when "Include Preview Image" checkbox is unchecked (preview image area hidden — should not affect tab order)
+
+**Verification:**
+- All interactive elements in the export dialog are reachable via Tab
+- Tab order matches visual layout
+- Shift+Tab reverses correctly
+
+---
+
+- [ ] **Unit 2: Fix import dialog tab navigation from radio group**
+
+**Goal:** Make Tab advance from the "Create using..." radio group to the content area (template list or spec editor) and then to the Create button.
+
+**Requirements:** R1, R2, R3, R8
+
+**Dependencies:** None (can be done in parallel with Unit 1)
+
+**Files:**
+- Modify: `packages/app-core/src/features/project-create/components/visual-create-pane.tsx`
+- Modify: `packages/app-core/src/features/project-create/components/create-method.tsx`
+
+**Approach:**
+- The radio group likely traps focus because Fluent UI's `RadioGroup` uses arrow key navigation internally (correct behavior) but Tab isn't advancing to the next focusable element outside the group. Investigate whether the conditional content (template list vs. spec editors) is rendered in a way that makes it unfocusable.
+- For the template list (`SelectIncludedTemplate`), configure it as a single tab stop with arrow key navigation between template cards. This may require `useArrowNavigationGroup` from `@fluentui/react-tabster` or a `role="listbox"` pattern with `role="option"` on each card.
+- Ensure that when the create mode changes (radio selection changes), the newly rendered content is included in the tab order without requiring a manual focus reset.
+
+**Patterns to follow:**
+- Fluent UI v9 RadioGroup behavior — Tab should exit the group, arrow keys navigate within
+- Fluent UI Listbox/ComboBox patterns for the template list focus zone
+
+**Test scenarios:**
+- Happy path: Tab from radio group → focus moves to template list (when "Import" is selected)
+- Happy path: Tab from radio group → focus moves to Create button (when "Vega" or "Vega-Lite" is selected, if no intermediate focusable content)
+- Happy path: Arrow keys navigate between template cards within the template list
+- Happy path: Tab from template list → focus moves to Create button
+- Happy path: Shift+Tab reverses the full sequence
+- Edge case: Switching radio selection while focus is in the template list — focus should move to the newly rendered content or remain in the radio group
+- Edge case: Template list is empty (no templates available) — Tab should skip to Create button
+
+**Verification:**
+- Tab exits the radio group and reaches the content area
+- Template list is one tab stop with arrow keys inside
+- Create button is reachable via Tab from any content area
+
+---
+
+- [ ] **Unit 3: Verify and fix version change dialog**
+
+**Goal:** Confirm keyboard navigation works in the version change dialog. Fix if needed, document as working if not.
+
+**Requirements:** R7
+
+**Dependencies:** None
+
+**Files:**
+- Possibly modify: `packages/app-core/src/components/ui/modal-dialog/version-change-content.tsx`
+
+**Approach:**
+- Manually test Tab navigation in the version change dialog in the browser
+- The version change dialog has simpler content (text + buttons) so it may already work correctly with Fluent UI's default focus management
+- If it needs fixes, apply the same patterns used in Units 1 and 2
+
+**Test scenarios:**
+- Happy path: Tab cycles through all interactive elements in visual order
+- Happy path: Shift+Tab reverses
+
+**Verification:**
+- All interactive elements reachable via Tab, or documented as already working
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Fluent UI's `tabster` may not be directly accessible without adding a new dependency | `@fluentui/react-tabster` is already bundled as a transitive dependency of the Dialog component. If direct import fails, fall back to explicit `tabIndex` attributes. |
+| Conditional content rendering may break focus order when content changes | Test radio selection changes with focus in the content area. May need to reset focus to the radio group when content type changes. |
+| Template list arrow navigation may conflict with existing click handlers on template cards | Test both keyboard and mouse selection paths after adding arrow key navigation. |
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-10-modal-dialog-keyboard-nav-requirements.md`
+- Modal dialog wrapper: `packages/app-core/src/components/ui/modal-dialog/modal-dialog.tsx`
+- Import dialog: `packages/app-core/src/features/project-create/components/`
+- Export dialog: `packages/app-core/src/features/project-export/components/`
+- Fluent UI v9 Dialog: `@fluentui/react-dialog` (^9.72.6)

--- a/docs/solutions/ui-bugs/modal-dialog-tab-trapped-by-keyboard-focus-handler-2026-04-10.md
+++ b/docs/solutions/ui-bugs/modal-dialog-tab-trapped-by-keyboard-focus-handler-2026-04-10.md
@@ -1,0 +1,90 @@
+---
+title: Modal dialog Tab navigation trapped by document-level keyboard focus handler
+date: 2026-04-10
+category: ui-bugs
+module: keyboard-focus
+problem_type: ui_bug
+component: tooling
+symptoms:
+  - Tab key trapped on first focusable element in modal dialogs (export, import, create)
+  - Focus cycles through only 3 elements instead of all dialog controls
+  - No visible focus change when pressing Tab in any modal dialog
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - keyboard-navigation
+  - tab-focus
+  - modal-dialog
+  - fluent-ui
+  - power-bi
+  - focus-trap
+  - accessibility
+---
+
+# Modal dialog Tab navigation trapped by document-level keyboard focus handler
+
+## Problem
+
+Tab key navigation was completely broken in all modal dialogs (export, import, version change). Focus was trapped on the first focusable element (e.g., the Name text field in the export dialog) and could not reach any other interactive elements — no other text fields, checkboxes, or buttons were reachable via keyboard.
+
+## Symptoms
+
+- Pressing Tab in the export dialog kept focus on the Name field — Description, Author, Checkbox, and buttons were unreachable
+- Pressing Tab in the import dialog kept focus trapped on the radio group — template selection was unreachable
+- Browser diagnostic showed focus cycling through only 3 elements: a toolbar button (outside dialog), a mystery `<i>` element, and the Name input — repeating endlessly
+- All 13 focusable elements inside the dialog were visible and enabled in the DOM, but Tab never reached them
+
+## What Didn't Work
+
+- **Adding `inertTrapFocus` prop to Fluent UI Dialog** — switches from tabster's JavaScript focus trap to the browser's native `inert`-based trap. Same result — the document-level handler intercepted Tab before either mechanism could act.
+- **Adding a manual `onKeyDown` / `onKeyDownCapture` Tab handler on DialogSurface** — attempted to programmatically cycle focus through all focusable elements. The document-level handler still fired first and called `preventDefault()`, preventing the event from reaching the dialog.
+- **Checking tabster configuration via `data-tabster` attributes** — the modalizer was correctly configured (`isTrapped: true`), and no child elements had interfering tabster configs. The issue was upstream of tabster entirely.
+
+## Solution
+
+The root cause was the `bindTabCycling` method in `src/index.ts`, introduced in PR #601 (keyboard focus support). It adds a **document-level `keydown` listener** that intercepts ALL Tab key events to prevent focus from escaping the custom visual's iframe into other Power BI canvas elements.
+
+When a modal dialog was open, this handler found the dialog's first focusable element, determined it was at a boundary position, and wrapped focus back — calling `event.preventDefault()` before the dialog's own focus management could act.
+
+The fix: skip the wrap-around when a modal dialog is present in the DOM.
+
+```typescript
+// src/index.ts — bindTabCycling method
+private bindTabCycling() {
+    document.addEventListener('keydown', (event) => {
+        if (event.key !== 'Tab') return;
+        // When a modal dialog is open, let the dialog manage its own
+        // focus cycling — the document-level wrap-around must not interfere.
+        if (document.querySelector('[role="dialog"]')) return;
+        if (
+            handleTabWrapAround(
+                this.#applicationWrapper,
+                document.activeElement,
+                event.shiftKey
+            )
+        ) {
+            event.preventDefault();
+        }
+    });
+}
+```
+
+## Why This Works
+
+The `handleTabWrapAround` function in `src/lib/keyboard-focus.ts` scans `#applicationWrapper` for all tabbable elements and wraps focus when Tab reaches the first or last element. When a dialog is open, the dialog's elements are inside `#applicationWrapper`, so they're included in the tabbable set. But the handler treats them as part of the overall visual's tab cycle, not as a separate focus scope — so it wraps focus back to the visual's first element instead of letting the dialog cycle through its own elements.
+
+By checking for `[role="dialog"]` and returning early, the document-level handler yields to Fluent UI's Dialog focus trap (tabster modalizer), which correctly cycles focus through all elements within the dialog surface.
+
+## Prevention
+
+- When adding document-level keyboard event handlers, check whether a modal dialog is open before intercepting navigation keys (Tab, Escape, arrow keys). Modal dialogs have their own focus management that should take priority.
+- The `[role="dialog"]` selector is a reliable way to detect open Fluent UI dialogs.
+
+## Related Issues
+
+- PR #601: feat: add report canvas keyboard focus support (#461)
+- Keyboard focus handler: `src/lib/keyboard-focus.ts`
+- Visual entry point: `src/index.ts` (`bindTabCycling` method)
+- Requirements: `docs/brainstorms/2026-04-10-modal-dialog-keyboard-nav-requirements.md`
+- Plan: `docs/plans/2026-04-10-002-fix-modal-dialog-keyboard-nav-plan.md`

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,6 +285,9 @@ export class Deneb implements IVisual {
     private bindTabCycling() {
         document.addEventListener('keydown', (event) => {
             if (event.key !== 'Tab') return;
+            // When a modal dialog is open, let the dialog manage its own
+            // focus cycling — the document-level wrap-around must not interfere.
+            if (document.querySelector('[role="dialog"]')) return;
             if (
                 handleTabWrapAround(
                     this.#applicationWrapper,

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,7 +287,7 @@ export class Deneb implements IVisual {
             if (event.key !== 'Tab') return;
             // When a modal dialog is open, let the dialog manage its own
             // focus cycling — the document-level wrap-around must not interfere.
-            if (document.querySelector('[role="dialog"]')) return;
+            if (document.querySelector('[role="dialog"], [role="alertdialog"]')) return;
             if (
                 handleTabWrapAround(
                     this.#applicationWrapper,


### PR DESCRIPTION
The document-level Tab wrap-around handler (from #601) intercepted Tab
before Fluent UI's Dialog could manage its own focus cycling, trapping
focus on the first tabbable element. Skip the wrap-around when a modal
dialog (role="dialog") is present so the dialog's native focus trap works.

Ref #461
