### PR TITLE
fix: resolve empty dataset fields in export dialog

### DIFF
--- a/packages/app-core/src/components/template-metadata/template-dataset.tsx
+++ b/packages/app-core/src/components/template-metadata/template-dataset.tsx
@@ -68,8 +68,7 @@ export const TemplateDataset = ({ datasetRole }: TemplateDatasetProps) => {
     );
     const tableBody = getTableFieldRows(datasetRole);
 
-    const { dataset } = createMetadata || {};
-    if (dataset?.length === 0 || 0) {
+    if (tableBody.length === 0) {
         return <></>;
     }
     return (

--- a/packages/app-core/src/components/ui/modal-dialog/modal-dialog.tsx
+++ b/packages/app-core/src/components/ui/modal-dialog/modal-dialog.tsx
@@ -25,13 +25,11 @@ import {
 } from '../../../features/project-create';
 import { ExportButtons, ExportPane } from '../../../features/project-export';
 import { VersionChangeContent } from './version-change-content';
-import { FieldRemapPane } from '../../../features/remap-fields';
 
 export const ModalDialog = () => {
     const {
         exportProcessingState,
         modalDialogRole,
-        remapState,
         clearMigrationDialog,
         setExportProcessingState,
         setModalDialogRole,
@@ -39,7 +37,6 @@ export const ModalDialog = () => {
     } = useDenebState((state) => ({
         exportProcessingState: state.interface.exportProcessingState,
         modalDialogRole: state.interface.modalDialogRole,
-        remapState: state.interface.remapState,
         clearMigrationDialog: state.migration.clearMigrationDialog,
         setExportProcessingState: state.interface.setExportProcessingState,
         setModalDialogRole: state.interface.setModalDialogRole,
@@ -78,9 +75,9 @@ export const ModalDialog = () => {
     };
     const shouldPreventClose = useMemo(
         () =>
-            (modalDialogRole === 'Remap' && remapState !== 'None') ||
-            (modalDialogRole === 'Export' && exportProcessingState !== 'None'),
-        [modalDialogRole, remapState]
+            modalDialogRole === 'Export' &&
+            exportProcessingState === 'Tokenizing',
+        [modalDialogRole, exportProcessingState]
     );
     const dialogType: DialogProps['modalType'] = shouldPreventClose
         ? 'alert'
@@ -128,9 +125,6 @@ const getDialogPrimaryButton = (dialogRole: ModalDialogRole) => {
     switch (dialogRole) {
         case 'Create':
             return <CreateButton />;
-        // Tracking is now only used for export (#486)
-        // case 'Remap':
-        //     return <RemapButton />;
         case 'Export':
             return <ExportButtons />;
         default:
@@ -147,8 +141,6 @@ const getDialogContent = (modalDialogRole: ModalDialogRole) => {
             return <VisualCreatePane />;
         case 'Version':
             return <VersionChangeContent />;
-        case 'Remap':
-            return <FieldRemapPane />;
         case 'Export':
             return <ExportPane />;
         default: {

--- a/packages/app-core/src/features/project-export/components/export-pane.tsx
+++ b/packages/app-core/src/features/project-export/components/export-pane.tsx
@@ -63,12 +63,7 @@ export const ExportPane = () => {
                         <div className={classes.paneContentSection}>
                             <StageProgressIndicator
                                 message={translate('Text_Export_Tokenizing')}
-                                isInProgress={
-                                    exportProcessingState === 'Tokenizing'
-                                }
-                                isCompleted={
-                                    exportProcessingState > 'Tokenizing'
-                                }
+                                isInProgress
                             />
                         </div>
                     )}

--- a/packages/app-core/src/features/project-export/components/export-pane.tsx
+++ b/packages/app-core/src/features/project-export/components/export-pane.tsx
@@ -98,26 +98,32 @@ const handleProcessing = async (signal: AbortSignal) => {
         project: { spec }
     } = getDenebState();
     setExportProcessingState('Tokenizing');
-    await updateFieldTracking(spec, dataset);
-    if (signal.aborted) return;
-    const {
-        fieldUsage: { dataset: trackedFieldsCurrent }
-    } = getDenebState();
-    logDebug('[handleProcessing] trackedFieldsCurrent', {
-        trackedFieldsInitial: dataset,
-        trackedFieldsCurrent
-    });
-    await updateFieldTokenization(spec, trackedFieldsCurrent);
-    if (signal.aborted) return;
-    const {
-        dataset: { fields },
-        export: { metadata, updateExportDataset }
-    } = getDenebState();
-    const freshFields = getDatasetTemplateFieldsFromMetadata(fields);
-    const reconciledDataset = reconcileExportDatasetFields(
-        freshFields,
-        metadata?.dataset
-    );
-    updateExportDataset(reconciledDataset);
-    setExportProcessingState('Complete');
+    try {
+        await updateFieldTracking(spec, dataset);
+        if (signal.aborted) return;
+        const {
+            fieldUsage: { dataset: trackedFieldsCurrent }
+        } = getDenebState();
+        logDebug('[handleProcessing] trackedFieldsCurrent', {
+            trackedFieldsInitial: dataset,
+            trackedFieldsCurrent
+        });
+        await updateFieldTokenization(spec, trackedFieldsCurrent);
+        if (signal.aborted) return;
+        const {
+            dataset: { fields },
+            export: { metadata, updateExportDataset }
+        } = getDenebState();
+        const freshFields = getDatasetTemplateFieldsFromMetadata(fields);
+        const reconciledDataset = reconcileExportDatasetFields(
+            freshFields,
+            metadata?.dataset
+        );
+        updateExportDataset(reconciledDataset);
+        setExportProcessingState('Complete');
+    } catch {
+        if (!signal.aborted) {
+            setExportProcessingState('None');
+        }
+    }
 };

--- a/packages/app-core/src/features/project-export/components/export-pane.tsx
+++ b/packages/app-core/src/features/project-export/components/export-pane.tsx
@@ -14,19 +14,26 @@ import {
     updateFieldTokenization,
     updateFieldTracking
 } from '../../../lib/field-processing';
+import { getDatasetTemplateFieldsFromMetadata } from '@deneb-viz/data-core/field';
+import { reconcileExportDatasetFields } from '../../../state/dataset';
 
 /**
  * Interface (pane) for exporting a existing visualization.
  */
 export const ExportPane = () => {
     const classes = useModalDialogStyles();
-    const { exportProcessingState, translate } = useDenebState((state) => ({
-        exportProcessingState: state.interface.exportProcessingState,
-        translate: state.i18n.translate
-    }));
+    const { datasetFields, exportProcessingState, translate } = useDenebState(
+        (state) => ({
+            datasetFields: state.dataset.fields,
+            exportProcessingState: state.interface.exportProcessingState,
+            translate: state.i18n.translate
+        })
+    );
     useEffect(() => {
-        handleProcessing();
-    }, []);
+        const abort = new AbortController();
+        handleProcessing(abort.signal);
+        return () => abort.abort();
+    }, [datasetFields]);
     logRender('VisualExportPane');
     return (
         <div className={classes.paneRoot}>
@@ -84,7 +91,7 @@ export const ExportPane = () => {
 /**
  * Do the necessary work to process the spec for the template fields when the dialog is loaded.
  */
-const handleProcessing = async () => {
+const handleProcessing = async (signal: AbortSignal) => {
     const {
         fieldUsage: { dataset },
         interface: { setExportProcessingState },
@@ -92,6 +99,7 @@ const handleProcessing = async () => {
     } = getDenebState();
     setExportProcessingState('Tokenizing');
     await updateFieldTracking(spec, dataset);
+    if (signal.aborted) return;
     const {
         fieldUsage: { dataset: trackedFieldsCurrent }
     } = getDenebState();
@@ -100,5 +108,16 @@ const handleProcessing = async () => {
         trackedFieldsCurrent
     });
     await updateFieldTokenization(spec, trackedFieldsCurrent);
+    if (signal.aborted) return;
+    const {
+        dataset: { fields },
+        export: { metadata, updateExportDataset }
+    } = getDenebState();
+    const freshFields = getDatasetTemplateFieldsFromMetadata(fields);
+    const reconciledDataset = reconcileExportDatasetFields(
+        freshFields,
+        metadata?.dataset
+    );
+    updateExportDataset(reconciledDataset);
     setExportProcessingState('Complete');
 };

--- a/packages/app-core/src/lib/interface/types.ts
+++ b/packages/app-core/src/lib/interface/types.ts
@@ -46,9 +46,4 @@ export type InterfaceType = 'viewer' | 'editor';
 /**
  * Represents modal dialog display state.
  */
-export type ModalDialogRole =
-    | 'None'
-    | 'Version'
-    | 'Create'
-    | 'Remap'
-    | 'Export';
+export type ModalDialogRole = 'None' | 'Version' | 'Create' | 'Export';

--- a/packages/app-core/src/state/export.ts
+++ b/packages/app-core/src/state/export.ts
@@ -1,6 +1,7 @@
 import { type StateCreator } from 'zustand';
 
 import { type UsermetaTemplate } from '@deneb-viz/template-usermeta';
+import { type UsermetaDatasetField } from '@deneb-viz/data-core/field';
 import { type DeepPath, updateDeep } from '@deneb-viz/utils/object';
 import { StateDependencies, type StoreState } from './state';
 import { getNewTemplateMetadata } from '@deneb-viz/json-processing';
@@ -23,6 +24,7 @@ export type ExportSliceProperties = {
         payload: ExportSliceSetMetadataPropertyBySelector
     ) => void;
     setPreviewImage: (payload: ExportSliceSetPreviewImage) => void;
+    updateExportDataset: (dataset: UsermetaDatasetField[]) => void;
 };
 
 /**
@@ -72,6 +74,12 @@ export const createExportSlice =
                         (state) => handleSetPreviewImage(state, payload),
                         false,
                         'export.setPreviewImage'
+                    ),
+                updateExportDataset: (dataset) =>
+                    set(
+                        (state) => handleUpdateExportDataset(state, dataset),
+                        false,
+                        'export.updateExportDataset'
                     )
             }
         };
@@ -116,3 +124,19 @@ const handleSetPreviewImage = (
         } as UsermetaTemplate
     }
 });
+
+const handleUpdateExportDataset = (
+    state: StoreState,
+    dataset: UsermetaDatasetField[]
+): Partial<StoreState> => {
+    if (!state.export.metadata) return {};
+    return {
+        export: {
+            ...state.export,
+            metadata: {
+                ...state.export.metadata,
+                dataset
+            }
+        }
+    };
+};

--- a/packages/app-core/src/state/field-usage.ts
+++ b/packages/app-core/src/state/field-usage.ts
@@ -1,7 +1,6 @@
 import {
     areAllRemapDataRequirementsMet,
-    getRemapEligibleFields,
-    isMappingDialogRequired
+    getRemapEligibleFields
 } from '@deneb-viz/json-processing';
 import {
     type TrackedDrilldownProperties,
@@ -175,19 +174,13 @@ const handleApplyTrackingChanges = (
         remapFields,
         drilldownProperties: trackedDrilldown
     });
-    const modalDialogRole: ModalDialogRole =
-        isMappingDialogRequired({
-            trackedFields,
-            drilldownProperties: trackedDrilldown
-        }) ||
-        (state.interface.modalDialogRole === 'Remap' &&
-            state.interface.remapState !== 'Complete')
-            ? 'Remap'
-            : getModalDialogRole(
-                  state.project.__isInitialized__,
-                  state.interface.type,
-                  state.interface.modalDialogRole
-              );
+    // Remap dialog removed (#486) — tracking is now only used for export.
+    // Never assign 'Remap' as modalDialogRole from tracking changes.
+    const modalDialogRole: ModalDialogRole = getModalDialogRole(
+        state.project.__isInitialized__,
+        state.interface.type,
+        state.interface.modalDialogRole
+    );
     return {
         commands: {
             ...state.commands,

--- a/packages/app-core/src/state/interface.ts
+++ b/packages/app-core/src/state/interface.ts
@@ -7,7 +7,6 @@ import {
 } from '../lib/interface';
 import { type RemapState } from '@deneb-viz/json-processing/field-tracking';
 import { StoreState } from './state';
-import { isMappingDialogRequired } from '@deneb-viz/json-processing';
 import { getNewUuid } from '@deneb-viz/utils/crypto';
 import { StateCreator } from 'zustand';
 import { getModalDialogRole } from '../lib/interface/state';
@@ -231,21 +230,12 @@ const handleSetRemapState = (
     state: StoreState,
     remapState: RemapState
 ): Partial<StoreState> => {
-    const modalDialogRole: ModalDialogRole =
-        state.interface.modalDialogRole === 'Remap' &&
-        remapState === 'None' &&
-        state.interface.remapState > 'None'
-            ? 'None'
-            : isMappingDialogRequired({
-                    trackedFields: state.fieldUsage.dataset,
-                    drilldownProperties: state.fieldUsage.drilldown
-                })
-              ? 'Remap'
-              : getModalDialogRole(
-                    state.project.__isInitialized__,
-                    state.interface.type,
-                    state.interface.modalDialogRole
-                );
+    // Remap dialog removed (#486) — tracking is now only used for export.
+    const modalDialogRole: ModalDialogRole = getModalDialogRole(
+        state.project.__isInitialized__,
+        state.interface.type,
+        state.interface.modalDialogRole
+    );
     return {
         interface: {
             ...state.interface,


### PR DESCRIPTION
TemplateDataset's empty-check guard was hardcoded to createMetadata.dataset regardless of role, causing the export table to render empty when the create template had no dataset fields. Additionally, export processing never synced tracked fields back to export.metadata.dataset.

- Fix TemplateDataset guard to check role-appropriate tableBody length
- Add updateExportDataset action to export slice and call it after tokenization with all dataset fields (not just spec-referenced ones)
- React to dataset field changes while dialog is open via useEffect dep
- Add AbortController to cancel stale processing on dataset changes
- Remove 'Remap' from ModalDialogRole type and all dead remap paths (handleSetRemapState, handleApplyTrackingChanges, shouldPreventClose)
- Fix shouldPreventClose to only lock during 'Tokenizing' state and add missing exportProcessingState dependency to useMemo
- Add null guard in handleUpdateExportDataset to avoid unsafe spread

Ref: #614
