### PR TITLE
refactor: migrate usermeta.dataset to usermeta.datasets (multi-dataset schema)

### DIFF
--- a/docs/brainstorms/2026-04-14-multi-dataset-template-structure-requirements.md
+++ b/docs/brainstorms/2026-04-14-multi-dataset-template-structure-requirements.md
@@ -1,0 +1,82 @@
+---
+date: 2026-04-14
+topic: multi-dataset-template-structure
+---
+
+# Multi-Dataset Template and State Structure
+
+## Problem Frame
+
+Deneb's template infrastructure uses a singular `usermeta.dataset` (a flat array of field definitions). While Power BI only supports a single query today, future features (e.g., map layers via conditional formatting) may need additional named datasets. Since v2 is unreleased, this is the right time to restructure the template schema to support a keyed dataset map — avoiding a breaking v2→v3 schema migration later.
+
+This change is scoped to the **template serialization format only** — the external contract that ships with v2. Internal runtime state (`state.dataset`) is unchanged and will be restructured when multi-dataset functionality is actually built. This separation keeps the blast radius small while stabilizing the schema before release.
+
+## Requirements
+
+**Template Usermeta Schema**
+
+- R1. `usermeta.dataset` (array) is replaced by `usermeta.datasets` (object), where each key is a dataset name and each value is `UsermetaDatasetField[]`. The default dataset uses key `'dataset'` (matching `DATASET_DEFAULT_NAME`). Note: `TEMPLATE_USERMETA_VERSION` remains 2 — v2 is unreleased, safe to modify in-place.
+- R2. The JSON schema for template validation is updated: `datasets` is an object property (not array), key validation is updated to allow the dataset-scoped placeholder pattern.
+
+**V1 Template Migration**
+
+- R3. V1 templates with `usermeta.dataset` (array) are migrated to `usermeta.datasets.dataset` during import. Migration must occur **before** schema validation (matching the existing pattern for legacy version and config migrations in `getValidatedTemplate`).
+- R4. V1 placeholder keys (`__0__`, `__1__`, etc.) are rewritten to dataset-scoped form (`__dataset.0__`, `__dataset.1__`) during import.
+- R5. A template with both `usermeta.dataset` AND `usermeta.datasets` present is treated as malformed. Note: the JSON schema's `additionalProperties: false` on `UsermetaTemplate` will reject this automatically once `dataset` is removed and `datasets` is added — no bespoke validation logic needed.
+
+**Placeholder Scheme**
+
+- R6. Field placeholders become dataset-scoped: `__[datasetName].[N]__` (e.g., `__dataset.0__`, `__dataset.1__`). Dot separator is used between dataset name and index to avoid ambiguity with dataset names containing underscores. This applies to export, import token substitution, and field tracking.
+- R7. The placeholder key regex in the schema is updated to match the new pattern (e.g., `^__[a-zA-Z0-9_]+\.\d+__$`).
+- R8. Placeholder replacement logic becomes **key-based** (matching the field's `key` property directly) rather than the current **index-based** approach (replacing by array position). This provides actual namespace isolation between datasets, not just cosmetic prefixing.
+
+**Serialization Boundary Adapter**
+
+- R9. Code that reads/writes `usermeta.dataset` is updated to read/write `usermeta.datasets.[datasetName]`. For the current single-dataset case, this always targets `usermeta.datasets[DATASET_DEFAULT_NAME]`. Internal state (`state.dataset` in Zustand stores) remains singular and unchanged.
+
+## Success Criteria
+
+- V1 templates import correctly into the new structure with placeholders migrated
+- V2 templates use the new `datasets` structure natively
+- All existing tests pass with the structural change (field tracking, export/import round-trip)
+- A template with both `dataset` and `datasets` fails schema validation
+- A template containing multiple keys in `usermeta.datasets` (e.g., `dataset` + a hypothetical second dataset) passes schema validation — confirming forward compatibility
+- The single "dataset" dataset continues to work identically to current behavior for all user-facing functionality
+- Internal state shape (`state.dataset`) is unchanged — no consumer of the Zustand dataset slice is modified
+
+## Scope Boundaries
+
+- **No new dataset types** — No spatial, map layer, or CF-driven datasets are added. Only the template serialization format changes.
+- **No multi-dataset UI** — The template editor, export dialog, and field assignment UI continue to show a single dataset.
+- **No internal state restructuring** — `state.dataset` in both the root visual store and app-core store remains singular. Restructuring to `state.datasets` is deferred to when multi-dataset functionality is actually built.
+- **No v1→v2 migration outside of template import** — The current branch is v2 development. v1 template import is the only migration path needed.
+- **No changes to Power BI data role** — `DATASET_DEFAULT_NAME` stays `'dataset'`, capabilities.json is unchanged.
+- **No incremental update changes** — `performIncrementalUpdate` continues to target the single default dataset. Multi-dataset incremental updates are deferred.
+
+## Key Decisions
+
+- **Keep 'dataset' as the default key**: Changing to 'primary' or 'main' would ripple into capabilities.json and existing specs. Not worth the churn — future datasets will have their own descriptive keys.
+- **Dot separator for placeholders**: `__dataset.0__` not `__dataset_0__`. Dot cannot appear in dataset names, making the separator unambiguous regardless of dataset name content. Natural namespace convention.
+- **Dataset-scoped placeholders now**: Prevents a breaking template format change when multi-dataset actually ships. Low migration cost since only v1 templates need rewriting.
+- **Key-based replacement**: Placeholder replacement matches the field's `key` property directly rather than array index. This provides real namespace isolation, not cosmetic prefixing.
+- **Schema-only scope**: Template schema (external contract) changes now. Internal state restructuring (69+ references across 28+ files, two separate Zustand stores) is deferred until multi-dataset is actually needed — the blast radius is not justified for speculative preparation.
+- **Error on ambiguous templates**: Templates with both `dataset` and `datasets` are rejected via the schema's existing `additionalProperties: false` constraint.
+- **TabularDataset shape unchanged**: Each dataset entry remains `{ fields, values }`. Future dataset types (spatial etc.) will be addressed when relevant.
+
+## Dependencies / Assumptions
+
+- V2 templates are not in the wild — modifying the v2 schema in-place is safe. No workspace packages are published to npm with the current v2 template types.
+- All v1 templates use `usermeta.dataset` as a flat `UsermetaDatasetField[]` array.
+- V1 placeholders follow the `__[N]__` pattern (sequential numeric).
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R6][Technical] Final regex pattern for dataset-scoped placeholders — `^__[a-zA-Z0-9_]+\.\d+__$` is proposed but needs validation against edge cases (e.g., dataset names with leading/trailing underscores).
+- [Affects R9][Technical] How `getPublishableUsermeta` (which uses dynamic key access `usermeta?.[DATASET_DEFAULT_NAME]`) and `getUpdatedExportMetadata` transition to the new `usermeta.datasets` structure.
+- [Affects R8][Technical] Whether `getTemplateReplacedForDataset` needs a full rewrite for key-based replacement or can be adapted incrementally from the current index-based approach.
+
+## Next Steps
+
+-> `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-14-001-refactor-multi-dataset-template-schema-plan.md
+++ b/docs/plans/2026-04-14-001-refactor-multi-dataset-template-schema-plan.md
@@ -1,0 +1,408 @@
+---
+title: "refactor: Multi-dataset template schema"
+type: refactor
+status: active
+date: 2026-04-14
+origin: docs/brainstorms/2026-04-14-multi-dataset-template-structure-requirements.md
+---
+
+# refactor: Multi-dataset template schema
+
+## Overview
+
+Restructure the template usermeta from singular `usermeta.dataset` (flat array) to plural `usermeta.datasets` (keyed object), with dataset-scoped placeholders using dot separators (`__dataset.0__`). Internal runtime state is unchanged — only the template serialization format and related pipeline code are modified. This stabilizes the external template contract before v2 ships.
+
+## Problem Frame
+
+The template schema currently supports only one dataset. Future multi-dataset features would require a breaking schema change. Since v2 is unreleased, restructuring now avoids a v2→v3 migration later. The scope is limited to the template serialization format — internal state (`state.dataset`) is untouched. (see origin: `docs/brainstorms/2026-04-14-multi-dataset-template-structure-requirements.md`)
+
+## Requirements Trace
+
+- R1. `usermeta.dataset` (array) → `usermeta.datasets` (object keyed by dataset name). Default key: `'dataset'`
+- R2. JSON schema auto-regenerated from updated TypeScript types; key regex allows dot-separated placeholders
+- R3. V1 `usermeta.dataset` migrated to `usermeta.datasets.dataset` during import, before schema validation
+- R4. V1 placeholders `__0__` rewritten to `__dataset.0__` during import
+- R5. Templates with both `dataset` and `datasets` rejected via `additionalProperties: false`
+- R6. Placeholders become `__[datasetName].[N]__` with dot separator
+- R7. Schema key regex updated: `^__[a-zA-Z0-9_]+\.\d+__$`
+- R8. Placeholder replacement becomes key-based (matching field's `key` property) not index-based
+- R9. Serialization boundary adapter: code reading/writing `usermeta.dataset` updated to `usermeta.datasets[DATASET_DEFAULT_NAME]`
+
+## Scope Boundaries
+
+- **No internal state restructuring** — `state.dataset` in Zustand stores remains singular
+- **No incremental update changes** — `performIncrementalUpdate` continues to target single dataset
+- **No new dataset types** — only structural foundation changes
+- **No multi-dataset UI** — template editor, export dialog, field assignment show single dataset
+- **No capabilities.json changes** — `DATASET_DEFAULT_NAME` stays `'dataset'`
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**Type and schema generation:**
+- `packages/template-usermeta/src/types.ts` — `UsermetaTemplate` type (schema source of truth)
+- `packages/template-usermeta/bin/generate-project-schema.js` — `ts-json-schema-generator` auto-generates JSON schema from types
+- `packages/template-usermeta/src/constants.ts` — `TEMPLATE_USERMETA_VERSION`
+
+**Placeholder pipeline (three generation sites — must all be updated):**
+- `packages/data-core/src/lib/field/tokenization.ts` — `getPlaceholderKey(i)` (canonical)
+- `packages/data-core/src/lib/field/extraction.ts` — hardcoded `` `__${i}__` `` (line 29)
+- `packages/data-core/src/lib/field/template-metadata.ts` — hardcoded `` `__${i}__` `` (line 87)
+
+**Import pipeline (order matters):**
+1. `getTemplateResolvedForLegacyVersions` (patches v1.0 providerVersion)
+2. `getTemplateResolvedForLegacyConfig` (moves v1.7 config into usermeta)
+3. **[NEW: dataset migration goes here]** — before schema validation
+4. Schema validation via AJV-compiled validator
+5. `getTemplateResolvedForPlaceholderAssignment` (splits spec/config)
+
+**Export pipeline:**
+- `getPublishableUsermeta` — reads `usermeta?.[DATASET_DEFAULT_NAME]` (dynamic key access)
+- `getExportTemplate` — orchestrates tokenization and usermeta injection
+- `getNewTemplateMetadata` — creates blank template with `dataset: []`
+
+**Field tracking:**
+- `packages/json-processing/src/lib/spec-processing/workers/field-tracking.ts` — assigns `placeholder: getPlaceholderKey(fieldIndex)` dynamically
+
+**Built-in templates (8 files):**
+- `packages/app-core/src/catalog/vega-lite/vl-bar-simple.ts`, `vl-bar-interactive.ts`, `vl-empty.ts`, `vl-empty-config.ts`
+- `packages/app-core/src/catalog/vega/v-bar-simple.ts`, `v-bar-interactive.ts`, `v-empty.ts`, `v-empty-config.ts`
+- All embed `dataset: UsermetaDatasetField[]` with `__0__`/`__1__` keys and spec references
+
+### Institutional Learnings
+
+- **Export pipeline awareness** (`docs/solutions/ui-bugs/export-dialog-empty-dataset-fields-2026-04-13.md`): Field tracking and export metadata are separate pipelines with a reconciliation step (`reconcileExportDatasetFields`). Changes must maintain this sync.
+
+## Key Technical Decisions
+
+- **Dot separator for placeholders**: `__dataset.0__` not `__dataset_0__`. Dot cannot appear in dataset names, making parsing unambiguous. Regex: `^__[a-zA-Z0-9_]+\.\d+__$`.
+- **Key-based replacement**: `getTemplateReplacedForDataset` changes from `dataset.reduce((result, value, index) => getFieldPattern(index))` to matching each field's `key` property directly. This provides real namespace isolation.
+- **Consolidate placeholder generation**: Three sites hardcode the `__N__` pattern — consolidate all through `getPlaceholderKey` before changing the format. This prevents inconsistency.
+- **Migration before validation**: New `getTemplateResolvedForLegacyDataset` function runs in the import pipeline before schema validation, matching the pattern of existing legacy migrations.
+- **Schema auto-generates from types**: Changing `UsermetaTemplate.dataset` to `UsermetaTemplate.datasets` and running `npm run build:schema` in `packages/template-usermeta` produces the correct JSON schema automatically. No hand-editing needed.
+- **`getPlaceholderKey` gains a dataset name parameter**: Signature becomes `getPlaceholderKey(datasetName: string, index: number)`. Callers currently pass `DATASET_DEFAULT_NAME` as the dataset name.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **`getPublishableUsermeta` dynamic key access**: Currently reads `usermeta?.[DATASET_DEFAULT_NAME]` (equals `usermeta['dataset']`). Changes to `usermeta?.datasets?.[DATASET_DEFAULT_NAME]` — resolves the accidental coupling between property name and constant value.
+- **Schema key regex**: `^__[a-zA-Z0-9_]+\.\d+__$` — allows alphanumeric + underscore dataset names, dot separator, numeric index. Validated against `__dataset.0__`, `__map_layer.0__`, rejects `__0__` (no dot).
+- **`metaVersion` range**: The `@minimum 1` / `@maximum 2` JSDoc annotations on `UsermetaDeneb.metaVersion` remain unchanged — v2 is being modified in-place, not bumped.
+
+- **`reconcileExportDatasetFields` signature**: Unchanged — callers extract `metadata.datasets[DATASET_DEFAULT_NAME]` and pass the dataset array. The function itself continues to receive `UsermetaDatasetField[]` without needing a dataset name parameter.
+- **Field tracking placeholder assignment**: Field tracking MUST generate dataset-scoped placeholders (`__dataset.N__`), not internal `__N__`. Reason: `getPublishableUsermeta` propagates `tracked?.placeholder` directly to `item.key` in the exported template (line 227). If tracking uses `__N__` while the schema requires `__dataset.N__`, exports would fail schema validation.
+
+### Deferred to Implementation
+
+- **`ts-json-schema-generator` cross-package resolution**: Whether the generator follows `@deneb-viz/data-core/field` import paths when generating the schema from `template-usermeta/src/types.ts`. Verify after `npm run build:schema` that the `@pattern` annotation from `data-core/types.ts` appears in the generated schema.
+
+## Implementation Units
+
+- [ ] **Unit 1: Consolidate placeholder generation through `getPlaceholderKey`**
+
+**Goal:** Eliminate hardcoded `` `__${i}__` `` patterns so there's a single function to change.
+
+**Requirements:** Prerequisite for R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/data-core/src/lib/field/tokenization.ts`
+- Modify: `packages/data-core/src/lib/field/extraction.ts`
+- Modify: `packages/data-core/src/lib/field/template-metadata.ts`
+- Test: `packages/data-core/src/lib/field/__tests__/tokenization.test.ts`
+- Test: `packages/data-core/src/lib/field/__tests__/template-metadata.test.ts`
+- Test: `packages/data-core/src/lib/field/__tests__/extraction.test.ts`
+
+**Approach:**
+- Replace inline `` `__${i}__` `` in `extraction.ts` (line 29) and `template-metadata.ts` (line 87) with calls to `getPlaceholderKey(i)`
+- Verify existing tests still pass — this is a no-behavior-change refactor
+
+**Execution note:** Characterization-first — run existing tests to confirm they pass before and after the consolidation.
+
+**Patterns to follow:**
+- `field-tracking.ts` line 230 already calls `getPlaceholderKey(fieldIndex)` — follow this pattern
+
+**Test scenarios:**
+- Happy path: `getDatasetTemplateFieldsFromMetadata` with 3 fields → produces `__0__`, `__1__`, `__2__` keys (unchanged behavior)
+- Happy path: `toUsermetaDatasetFields` with 2 entries → produces `__0__`, `__1__` keys (unchanged behavior)
+- Integration: Full export round-trip produces identical output before and after consolidation
+
+**Verification:**
+- All existing tests pass without modification
+- Grep confirms no remaining inline `__${i}__` patterns outside `getPlaceholderKey`
+
+---
+
+- [ ] **Unit 2: Update `getPlaceholderKey` to dataset-scoped format**
+
+**Goal:** Change placeholder generation from `__N__` to `__datasetName.N__` format.
+
+**Requirements:** R6, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/data-core/src/lib/field/tokenization.ts`
+- Modify: `packages/data-core/src/lib/field/extraction.ts` (pass dataset name)
+- Modify: `packages/data-core/src/lib/field/template-metadata.ts` (pass dataset name)
+- Test: `packages/data-core/src/lib/field/__tests__/tokenization.test.ts`
+- Test: `packages/data-core/src/lib/field/__tests__/template-metadata.test.ts`
+- Test: `packages/data-core/src/lib/field/__tests__/extraction.test.ts`
+
+**Approach:**
+- Add `datasetName` parameter to `getPlaceholderKey`: signature becomes `(datasetName: string, index: number) => string`
+- Output format: `__${datasetName}.${index}__`
+- Update `getEscapedReplacerPattern` if needed (dot needs escaping in regex)
+- Update all callers to pass `DATASET_DEFAULT_NAME` as the dataset name
+- Update `getDatasetTemplateFieldsFromMetadata` and `toUsermetaDatasetFields` to accept and forward a dataset name parameter
+
+**Patterns to follow:**
+- Existing `getPlaceholderKey` pattern — extend, don't replace
+
+**Test scenarios:**
+- Happy path: `getPlaceholderKey('dataset', 0)` → `'__dataset.0__'`
+- Happy path: `getPlaceholderKey('dataset', 5)` → `'__dataset.5__'`
+- Happy path: `getPlaceholderKey('map_layer', 0)` → `'__map_layer.0__'`
+- Edge case: `getPlaceholderKey('dataset', -3)` → `'__dataset.3__'` (abs applied, matching existing behavior)
+- Happy path: `getDatasetTemplateFieldsFromMetadata` with 3 fields → produces `__dataset.0__`, `__dataset.1__`, `__dataset.2__`
+- Happy path: `toUsermetaDatasetFields` with dataset name 'dataset' → produces dot-separated keys
+- Edge case: `getEscapedReplacerPattern('__dataset.0__')` → properly escaped regex (dot literal, not wildcard)
+
+**Verification:**
+- All placeholder generation produces `__datasetName.N__` format
+- Existing tokenizer and remapper tests updated and passing with new format
+
+---
+
+- [ ] **Unit 3: Update `UsermetaTemplate` type and regenerate schema**
+
+**Goal:** Change the template type from `dataset: UsermetaDatasetField[]` to `datasets: Record<string, UsermetaDatasetField[]>` and update the key regex.
+
+**Requirements:** R1, R2, R5, R7
+
+**Dependencies:** Unit 2 (placeholder format must be finalized)
+
+**Files:**
+- Modify: `packages/template-usermeta/src/types.ts`
+- Modify: `packages/data-core/src/lib/field/types.ts` (key pattern annotation)
+- Regenerate: `packages/template-usermeta/dist/schema.deneb-template-usermeta.json` (via `npm run build:schema`)
+
+**Approach:**
+- In `UsermetaTemplate`, replace `dataset: UsermetaDatasetField[]` with `datasets: Record<string, UsermetaDatasetField[]>`
+- Add explicit `@additionalProperties false` JSDoc annotation to `UsermetaTemplate` (currently relies on implicit `ts-json-schema-generator` default — make it explicit as a tripwire against config changes, matching the pattern on `UsermetaInteractivity` and `UsermetaDeneb`)
+- Update the `@pattern` JSDoc annotation on `UsermetaDatasetField.key` from `^__[a-zA-Z0-9]+__$` to `^__[a-zA-Z0-9_]+\.\d+__$`
+- Run `npm run build:schema` in `packages/template-usermeta` to regenerate the JSON schema
+- Verify the generated schema has `datasets` as an object property with `additionalProperties` allowing `UsermetaDatasetField[]` values
+- Verify the generated schema has `additionalProperties: false` on `UsermetaTemplate` (explicit annotation ensures this)
+- Verify the `@pattern` from `data-core/types.ts` propagated into the generated schema (grep for old pattern to confirm absence)
+- Note: `Record<string, T[]>` produces `additionalProperties` in the schema, which allows any string key for dataset names. Dataset name validation (alphanumeric + underscore only) is enforced at import time, not by the schema — document this in the approach
+
+**Patterns to follow:**
+- Existing type → schema generation pipeline via `ts-json-schema-generator`
+
+**Test scenarios:**
+- Happy path: Generated schema accepts `{ datasets: { dataset: [{ key: "__dataset.0__", name: "Field", type: "text" }] } }`
+- Happy path: Generated schema accepts `{ datasets: { dataset: [...], mapLayer: [...] } }` (forward compatibility)
+- Error path: Generated schema rejects `{ dataset: [{ key: "__0__", ... }] }` (old singular form)
+- Error path: Generated schema rejects `{ datasets: { dataset: [{ key: "__0__", ... }] } }` (old key format)
+- Edge case: Generated schema rejects template with both `dataset` and `datasets` (via `additionalProperties: false`)
+
+**Verification:**
+- `npm run build:schema` completes
+- Schema validation tests updated and passing with new structure
+
+---
+
+- [ ] **Unit 4: V1 template migration in import pipeline**
+
+**Goal:** Add legacy migration that converts `usermeta.dataset` to `usermeta.datasets.dataset` and rewrites V1 placeholders, running before schema validation.
+
+**Requirements:** R3, R4
+
+**Dependencies:** Unit 3 (new schema must exist)
+
+**Files:**
+- Modify: `packages/json-processing/src/template-usermeta.ts`
+- Test: `packages/json-processing/src/__test__/template-usermeta.test.ts`
+
+**Approach:**
+- Create `getTemplateResolvedForLegacyDataset(template)` function:
+  - If template has `usermeta.dataset` (array) and NOT `usermeta.datasets`: wrap into `{ datasets: { [DATASET_DEFAULT_NAME]: dataset } }`, remove `dataset` property, rewrite placeholder keys from `__N__` to `__${DATASET_DEFAULT_NAME}.N__`
+  - If template has `usermeta.datasets` already: pass through unchanged
+  - If template has both: pass through unchanged (schema validation will reject via `additionalProperties: false`)
+- Insert the call in `getValidatedTemplate` after `getTemplateResolvedForLegacyConfig` and before `getTemplateMetadata` / schema validation — matching the existing legacy migration pattern
+- The placeholder rewriting in the migration must also search-and-replace `__N__` references in the spec body (not just the field key), converting them to `__${DATASET_DEFAULT_NAME}.N__`
+- **Validation flow note:** The JSON schema only validates the v2 `datasets` shape — it does NOT need version-discriminated logic (if metaVersion=1 then `dataset`, if metaVersion=2 then `datasets`). This works because `getValidatedTemplate` is the sole validation entry point (called only from `import-dropzone.tsx`) and migration always runs before validation. By the time the schema validator executes, any v1 template has already been converted to v2 form. Built-in catalog templates are TypeScript objects that bypass schema validation entirely and are updated to v2 format in Unit 7.
+
+**Patterns to follow:**
+- `getTemplateResolvedForLegacyVersions` and `getTemplateResolvedForLegacyConfig` in the same file — follow the same pure-function pattern
+
+**Test scenarios:**
+- Happy path: V1 template with `usermeta.dataset: [{key: "__0__", name: "Sales", type: "numeric"}]` → migrated to `usermeta.datasets.dataset: [{key: "__dataset.0__", name: "Sales", type: "numeric"}]`
+- Happy path: V1 template with spec containing `"field": "__0__"` → spec updated to `"field": "__dataset.0__"`
+- Happy path: V1 template with multiple fields → all placeholders migrated sequentially
+- Happy path: V2 template with `usermeta.datasets` → passes through unchanged
+- Edge case: V1 template with empty `dataset: []` → migrated to `datasets: { dataset: [] }`
+- Edge case: V1 template with compound placeholder `__1____highlight` in spec → migrated to `__dataset.1____highlight` (support field suffix preserved, not treated as separate placeholder)
+- Edge case: V1 template with compound placeholders `__0____format` and `__0____formatted` → both migrated correctly
+- Edge case: V1 template with 11+ fields (indices 0–10) → all placeholders migrated correctly, no partial matches between `__1__` and `__10__` (use `getEscapedReplacerPattern`-based regex; process replacements in reverse index order to prevent `__1__` matching within `__10__`)
+- Edge case: Vega expression string `datum['__0__']` in spec → migrated to `datum['__dataset.0__']`
+- Integration: Full V1 import round-trip: migrate → validate → resolve for assignment → all steps succeed
+- Integration: Migration runs before schema validation — verified by a V1 template that would fail the new schema without migration
+
+**Verification:**
+- V1 templates import successfully through the full pipeline
+- V2 templates continue to import without modification
+- All existing import tests pass (updated for new structure)
+
+---
+
+- [ ] **Unit 5: Update export pipeline and serialization boundary**
+
+**Goal:** Update all code that reads/writes `usermeta.dataset` to use `usermeta.datasets[DATASET_DEFAULT_NAME]`.
+
+**Requirements:** R9
+
+**Dependencies:** Unit 3 (type must be updated)
+
+**Files:**
+- Modify: `packages/json-processing/src/template-usermeta.ts` (`getPublishableUsermeta`, `getNewTemplateMetadata`, `getExportTemplate`)
+- Modify: `packages/json-processing/src/template-dataset.ts`
+- Modify: `packages/app-core/src/state/project.ts` (3 access sites: `initializeFromTemplate`, `setSupportFieldConfiguration`, `handleSyncProjectData`)
+- Modify: `packages/app-core/src/state/dataset.ts` (`reconcileExportDatasetFields` — receives dataset array from `metadata.datasets[DATASET_DEFAULT_NAME]` instead of `metadata.dataset`; signature unchanged, caller extracts the right dataset)
+- Modify: `packages/app-core/src/state/export.ts` (`handleUpdateExportDataset` — spreads `dataset` on metadata, must change to write into `datasets[DATASET_DEFAULT_NAME]`)
+- Modify: `packages/app-core/src/features/project-create/components/create-button.tsx`
+- Modify: `packages/app-core/src/features/project-export/components/export-pane.tsx`
+- Modify: `packages/app-core/src/components/template-metadata/data-name-column-field.tsx` (string selector `${DATASET_DEFAULT_NAME}.${index}.name` → `datasets.${DATASET_DEFAULT_NAME}.${index}.name` — TypeScript cannot catch this)
+- Modify: `packages/app-core/src/components/template-metadata/data-description-column-field.tsx` (same string selector pattern)
+- Test: `packages/json-processing/src/__test__/template-usermeta.test.ts`
+- Test: `packages/json-processing/src/__test__/template-dataset.test.ts`
+
+**Approach:**
+- `getNewTemplateMetadata`: change `dataset: []` to `datasets: { [DATASET_DEFAULT_NAME]: [] }`
+- `getPublishableUsermeta`: change read path from `usermeta?.[DATASET_DEFAULT_NAME]` to `usermeta?.datasets?.[DATASET_DEFAULT_NAME]`; change output structure from `{ ...usermeta, dataset: [...] }` to `{ ...usermeta, datasets: { [DATASET_DEFAULT_NAME]: [...] } }` (nested object, not simple rename)
+- `handleUpdateExportDataset` in `export.ts`: change from spreading `dataset` directly on metadata to writing into `datasets[DATASET_DEFAULT_NAME]`
+- `reconcileExportDatasetFields`: signature unchanged — callers extract `metadata.datasets[DATASET_DEFAULT_NAME]` and pass the array
+- Deep path selectors in `data-name-column-field.tsx` and `data-description-column-field.tsx`: update from `${DATASET_DEFAULT_NAME}.${index}.name` to `datasets.${DATASET_DEFAULT_NAME}.${index}.name` — these are **string selectors split by '.' in `handleSetMetadataPropertyBySelector`**, invisible to TypeScript
+- All consumer sites reading `metadata?.dataset` change to `metadata?.datasets?.[DATASET_DEFAULT_NAME]`
+- TypeScript compiler surfaces most remaining references, but string-based selectors must be found manually
+
+**Patterns to follow:**
+- Existing `getPublishableUsermeta` structure — update the access path, preserve the map/filter logic
+
+**Test scenarios:**
+- Happy path: `getNewTemplateMetadata()` → returns template with `datasets: { dataset: [] }` not `dataset: []`
+- Happy path: `getPublishableUsermeta` with 2 tracked fields → produces `datasets.dataset` array with `__dataset.0__`, `__dataset.1__` keys
+- Happy path: Export round-trip: create metadata → update with fields → publish → produces valid v2 template with `datasets` structure
+- Edge case: `getPublishableUsermeta` with empty metadata → `datasets.dataset` defaults to `[]`
+- Integration: Full export pipeline produces a template that passes schema validation (Unit 3's schema)
+
+**Verification:**
+- Export produces templates with `datasets` (plural) structure
+- TypeScript compilation clean (`tsc --noEmit`)
+- All existing export tests updated and passing
+
+---
+
+- [ ] **Unit 6: Update key-based replacement and import substitution**
+
+**Goal:** Change `getTemplateReplacedForDataset` from index-based to key-based placeholder replacement, and update for the `datasets` structure.
+
+**Requirements:** R8
+
+**Dependencies:** Unit 4 (migration must work), Unit 5 (export must produce new format)
+
+**Files:**
+- Modify: `packages/json-processing/src/template-usermeta.ts` (`getTemplateReplacedForDataset`, `getFieldPattern`)
+- Test: `packages/json-processing/src/__test__/template-usermeta.test.ts`
+
+**Approach:**
+- `getTemplateReplacedForDataset` currently iterates `dataset.reduce((result, value, index) => ...)` and uses `getFieldPattern(index)` to match `__<index>__`
+- Change to: accept `datasets` object, iterate each dataset's fields, use `value.key` (e.g., `__dataset.0__`) to build the regex pattern instead of deriving from array index
+- `getFieldPattern` changes from `(index: number)` to `(key: string)` — builds regex from the field's actual key property
+- This provides real namespace isolation: each field's placeholder is matched by its explicit key, not positional index
+
+**Patterns to follow:**
+- Existing `getFieldPattern` / `getEscapedReplacerPattern` chain — extend for key-based matching
+
+**Test scenarios:**
+- Happy path: Template with `__dataset.0__` in spec + field with `key: "__dataset.0__"` and `suppliedObjectName: "Sales"` → `__dataset.0__` replaced with `Sales` in output
+- Happy path: Template with two fields → both replaced correctly by key, not by position
+- Edge case: Field key containing regex-special characters (dot) → properly escaped in regex
+- Edge case: Spec contains both `__dataset.0__` and the literal string `"__dataset.0__"` → both replaced (matching existing behavior)
+- Integration: Full import flow: V1 template → migrate (Unit 4) → assign fields → replace → produces correct output with actual field names
+
+**Verification:**
+- Import substitution works correctly with key-based matching
+- Reordering fields in the dataset array does not affect replacement (key-based, not position-based)
+
+---
+
+- [ ] **Unit 7: Update built-in templates and field tracking**
+
+**Goal:** Update built-in catalog templates and field tracking worker for the new placeholder format and `datasets` structure.
+
+**Requirements:** R1, R6
+
+**Dependencies:** Unit 2 (new placeholder format), Unit 3 (new type)
+
+**Files:**
+- Modify: `packages/app-core/src/catalog/vega-lite/vl-bar-simple.ts`
+- Modify: `packages/app-core/src/catalog/vega-lite/vl-bar-interactive.ts`
+- Modify: `packages/app-core/src/catalog/vega-lite/vl-empty.ts`
+- Modify: `packages/app-core/src/catalog/vega-lite/vl-empty-config.ts`
+- Modify: `packages/app-core/src/catalog/vega/v-bar-simple.ts`
+- Modify: `packages/app-core/src/catalog/vega/v-bar-interactive.ts`
+- Modify: `packages/app-core/src/catalog/vega/v-empty.ts`
+- Modify: `packages/app-core/src/catalog/vega/v-empty-config.ts`
+- Modify: `packages/json-processing/src/lib/spec-processing/workers/field-tracking.ts`
+- Modify: `packages/json-processing/src/lib/spec-processing/workers/tokenizer.ts` (if needed)
+- Test: `packages/json-processing/src/lib/spec-processing/workers/__tests__/tokenizer.test.ts`
+
+**Approach:**
+- Built-in templates: change `dataset: UsermetaDatasetField[]` to `datasets: { [DATASET_DEFAULT_NAME]: UsermetaDatasetField[] }`. Update placeholder keys from `__0__` to `__dataset.0__`. Update spec body references from `__0__` to `__dataset.0__`.
+- Field tracking: update `getPlaceholderKey` call to pass `DATASET_DEFAULT_NAME` as the dataset name
+- Tokenizer/remapper: these use `TrackedFieldProperties.placeholder` which already carries the full placeholder string — should work automatically once field tracking generates the new format
+
+**Patterns to follow:**
+- Existing built-in template structure in `vl-bar-simple.ts`
+
+**Test scenarios:**
+- Happy path: `getIncludedTemplates()` returns templates with `datasets` structure
+- Happy path: Built-in template placeholders match the new `__dataset.N__` format
+- Happy path: Field tracking assigns `__dataset.N__` placeholders to tracked fields
+- Integration: Creating a visual from a built-in template → field assignment works → spec renders with correct field names
+
+**Verification:**
+- All built-in templates use `datasets` structure and `__dataset.N__` placeholders
+- Field tracking produces scoped placeholders
+- Tokenizer and remapper round-trip correctly with new format
+
+## System-Wide Impact
+
+- **Interaction graph:** Changes flow through: types → schema generation → import migration → export pipeline → field tracking → tokenizer → remapper → built-in templates. No new callbacks or middleware.
+- **Error propagation:** V1 import failures surface as schema validation errors (existing mechanism). No new error surfaces.
+- **State lifecycle risks:** Internal Zustand state (`state.dataset`) is unchanged. The `reconcileExportDatasetFields` function receives the dataset array from `metadata.datasets[DATASET_DEFAULT_NAME]` instead of `metadata.dataset` — the array shape is identical.
+- **API surface parity:** Template import, export, and create-from-template all consume the same `UsermetaTemplate` type. Changing the type once propagates to all surfaces via TypeScript.
+- **Unchanged invariants:** Internal dataset state, Vega view data binding, incremental updates, compilation pipeline, and Power BI data role are not modified. The serialization adapter ensures the internal/external boundary is clean.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Missed `metadata.dataset` reference after type change | TypeScript compiler surfaces all remaining references. Run `tsc --noEmit` after Unit 3. |
+| Schema generation produces unexpected output for `Record<string, T[]>` | Verify generated schema after `npm run build:schema`. The generator handles `Record` types as `additionalProperties` objects. |
+| V1 placeholder rewriting misses references in spec body | Import migration searches spec body string, not just field keys. Test with realistic V1 templates containing inline placeholder references. |
+| Built-in template updates missed in one of 8 files | TypeScript enforces `UsermetaTemplate` shape — any template with `dataset` instead of `datasets` fails to compile. |
+| `getEscapedReplacerPattern` doesn't escape dot in new placeholder format | Dot must be escaped as `\\.` in regex. Add explicit test for this. |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-14-multi-dataset-template-structure-requirements.md](docs/brainstorms/2026-04-14-multi-dataset-template-structure-requirements.md)
+- Related code: `packages/template-usermeta/src/types.ts` (UsermetaTemplate type)
+- Related code: `packages/data-core/src/lib/field/tokenization.ts` (getPlaceholderKey)
+- Related code: `packages/json-processing/src/template-usermeta.ts` (import/export pipeline)
+- Export pipeline awareness: `docs/solutions/ui-bugs/export-dialog-empty-dataset-fields-2026-04-13.md`

--- a/docs/solutions/best-practices/type-widening-requires-call-site-audit-2026-04-16.md
+++ b/docs/solutions/best-practices/type-widening-requires-call-site-audit-2026-04-16.md
@@ -1,0 +1,221 @@
+---
+title: Type widening (array to keyed record) requires a call-site audit, not just a type-check
+date: 2026-04-16
+category: best-practices
+module: template-usermeta, app-core state, json-processing
+problem_type: best_practice
+component: tooling
+severity: high
+applies_when:
+    - Widening a type from single to many (array to keyed record, scalar to array, one value to Map)
+    - Refactoring a shared schema/type where multiple call sites perform state writes
+    - Reviewing a PR where the compiler passes but writes construct the container from scratch
+    - Adding a new key dimension (e.g. dataset name, tenant id) to an existing data shape
+    - Working with Zustand or similar immutable-update stores where set() replaces shape fragments
+tags:
+    - typescript
+    - type-widening
+    - state-management
+    - immutability
+    - refactor-audit
+    - code-review
+    - zustand
+    - schema-evolution
+related_components:
+    - frontend_stimulus
+    - testing_framework
+---
+
+# Type widening (array to keyed record) requires a call-site audit, not just a type-check
+
+## Context
+
+During the `feat/template-dataset-changes` refactor ([PR #619](https://github.com/deneb-viz/deneb/pull/619)), the template usermeta type was widened from a single-array shape to a keyed-map shape to make the external template contract multi-dataset-ready:
+
+```typescript
+// Before
+interface UsermetaTemplate {
+    dataset: UsermetaDatasetField[];
+}
+
+// After
+interface UsermetaTemplate {
+    datasets: Record<string, UsermetaDatasetField[]>;
+}
+```
+
+The type signature was updated everywhere. Read sites compiled cleanly. Tests passed. Then during `/ce:review`, three independent reviewer agents (correctness, adversarial, kieran-typescript) surfaced **the same class of bug at six separate state-mutation sites**: writes were replacing the whole `datasets` record instead of spreading existing entries.
+
+The compiler accepted the code because `{ [DATASET_DEFAULT_NAME]: dataset }` is a structurally valid `Record<string, UsermetaDatasetField[]>` — it just happens to be one with every other key dropped. TypeScript has no concept of "preserve existing keys"; a one-key record is as valid as a thousand-key record.
+
+Only `DATASET_DEFAULT_NAME` (`'dataset'`) is populated today (Power BI provides a single query; multi-dataset support is a future feature such as map-layer datasets). The bug was latent. The moment a second dataset key is introduced, every unfixed write site would silently wipe it. (session history: the plan anticipated the read-side slice in `reconcileExportDatasetFields` but did not enumerate the write-side sites — the `Object.entries().map()` pattern in `getPublishableUsermeta` was even explicitly left as an open question during planning.)
+
+## Guidance
+
+**Rule:** When widening a type from "one X" to "many X" (array → record, scalar → collection, single-key → multi-key), the type signature is the _easy_ part. The hard part is auditing **every write site** to confirm it preserves the other Xs it didn't mean to touch.
+
+### Anti-pattern — replacing the whole container
+
+```typescript
+// WRONG — structurally valid, semantically destructive
+metadata: {
+    ...state.export.metadata,
+    datasets: { [DATASET_DEFAULT_NAME]: dataset } // drops every other key
+}
+```
+
+### Correct pattern — spread-preserve existing entries
+
+```typescript
+// RIGHT — preserves sibling keys
+metadata: {
+    ...state.export.metadata,
+    datasets: {
+        ...state.export.metadata?.datasets, // keep existing
+        [DATASET_DEFAULT_NAME]: dataset     // overwrite this one
+    }
+}
+```
+
+### Checklist for type-widening PRs
+
+1. **Grep every literal write** of the widened field. For this refactor: `datasets:\s*\{` across the affected packages.
+2. For each hit, ask: _does this construct the container from scratch, or mutate one entry?_ If it's the latter, it **must** spread the existing container first.
+3. Identify **iteration opportunities** — if the new type is a collection, is there a place where the old code hardcoded the one-and-only entry and the new code should iterate all entries? (See `getPublishableUsermeta` below.)
+4. Add a test that writes to a non-default key, then writes to the default key, and asserts the non-default key survives. This is the only test that catches the anti-pattern at runtime — single-key tests all pass.
+5. In review, treat "the type still compiles" as zero evidence the write is correct. Ask for the spread explicitly.
+
+Per functional-programming preference (auto memory [claude]): prefer pure, spread-based updates over reassignment, and prefer `Object.entries(...).map(...)` iteration over hardcoded single-key access whenever the type admits many keys.
+
+## Why This Matters
+
+**TypeScript structurally cannot catch this.** `Record<string, T>` is "any string keys map to T". There is no type-level way to express "at least the keys that were there before". Phantom types, branded types, and `Exact<T>` are impractical here because we are talking about runtime object identity, not static shape.
+
+**The failure mode is silent data loss at runtime.** The spec compiles, the tests (which exercise one dataset) pass, the visual renders, and exports look right — until a user saves a template with two datasets, triggers a dataset update, and half their template is gone with no error. There is no stack trace, no warning, no type error. The data simply isn't there when it's next read.
+
+**It requires disciplined call-site audit, not better types.** When you widen a type to admit more possibilities, you have implicitly declared that every existing write was making a narrowing assumption. Those narrowing assumptions are now bugs. The compiler cannot tell you where they are because they were _never encoded_ — they lived in the dev's head and in the old type's shape. The only way to find them is to read each write.
+
+This is also why three independent reviewers found the same bug: it's exactly the kind of latent issue human reviewers and adversarial agents catch and type-checkers miss.
+
+## When to Apply
+
+Trigger this audit any time you make one of these changes:
+
+- **Array → Record/Map widening**: `T[]` → `Record<string, T[]>` or `Map<K, T>`
+- **Scalar → collection widening**: `layout: Layout` → `layouts: Layout[]` or `Record<string, Layout>`
+- **Single-key object → multi-key object**: anything that was implicitly "the one" becoming "one of many"
+- **Adding a new dimension to an existing type**: introducing multi-tenant, multi-layer, multi-locale, multi-dataset, or multi-version variants on a type that was previously singular
+- **Optional → required collection**: `field?: T` → `fields: T[]`, where old code patterns like `{ field: x }` now replace the array
+
+The common thread: **the old type had an implicit cardinality-of-one that the new type lifts, and every write site was written against that implicit cardinality.**
+
+## Examples
+
+All code below is the fixed version from the current branch.
+
+### Example A — `handleUpdateExportDataset`
+
+[packages/app-core/src/state/export.ts:135-152](../../../packages/app-core/src/state/export.ts#L135-L152)
+
+```typescript
+// WRONG — pre-fix:
+datasets: { [DATASET_DEFAULT_NAME]: dataset }
+
+// RIGHT — current:
+datasets: {
+    ...state.export.metadata.datasets, // preserve siblings
+    [DATASET_DEFAULT_NAME]: dataset
+}
+```
+
+### Example B — project slice (three sites in one file)
+
+[packages/app-core/src/state/project.ts](../../../packages/app-core/src/state/project.ts)
+
+`handleSyncProjectData`, `setSupportFieldConfiguration`, and `initializeFromTemplate` all pass the widened field to `getUpdatedExportMetadata`. The fix pattern is consistent: spread the current record, then overwrite the one key you mean to change. Example from `handleSyncProjectData`:
+
+```typescript
+const exportMetadata = getUpdatedExportMetadata(
+    state.export.metadata as UsermetaTemplate,
+    {
+        /* ... */
+        datasets: {
+            ...state.export.metadata?.datasets, // preserve siblings
+            [DATASET_DEFAULT_NAME]: datasetWithConfig
+        }
+        /* ... */
+    }
+);
+```
+
+Note the read side is explicitly keyed (`state.export.metadata?.datasets?.[DATASET_DEFAULT_NAME] ?? []`). That intentional narrowness at the read site makes the write-side breadth (spread-then-overwrite) obvious.
+
+### Example C — `getPublishableUsermeta` (iterate, don't hardcode)
+
+[packages/json-processing/src/template-usermeta.ts:193-253](../../../packages/json-processing/src/template-usermeta.ts#L193-L253)
+
+This is the deeper refactor. The old code processed the one-and-only dataset; the new code must iterate **all** dataset keys. A naive fix that hardcoded `DATASET_DEFAULT_NAME` would compile and pass tests but silently drop every other dataset from exported templates. The correct pattern is `Object.entries(...).map(...)`:
+
+```typescript
+datasets: (() => {
+    const sourceDatasets = usermeta?.datasets ?? {
+        [DATASET_DEFAULT_NAME]: []
+    };
+    return Object.fromEntries(
+        Object.entries(sourceDatasets).map(([name, fields]) => [
+            name,
+            (fields ?? []).map(processField)
+        ])
+    );
+})();
+```
+
+Key points:
+
+- `Object.entries(sourceDatasets).map(...)` processes **every** key, not just the default.
+- `Object.fromEntries(...)` rebuilds the record with all keys preserved.
+- `processField` is a pure, per-field transform — composition over single-key specialisation.
+- The default fallback `{ [DATASET_DEFAULT_NAME]: [] }` is applied only when `usermeta.datasets` is entirely missing, not when writing back — so the default never shadows user data.
+
+Compare to the anti-pattern that would have compiled:
+
+```typescript
+// WRONG — hardcodes the single-key assumption the new type no longer implies
+datasets: {
+    [DATASET_DEFAULT_NAME]: (
+        usermeta.datasets?.[DATASET_DEFAULT_NAME] ?? []
+    ).map(processField);
+}
+```
+
+Both shapes are `Record<string, UsermetaDatasetField[]>`. Only one of them actually publishes the user's other datasets.
+
+### Example D — coverage grep
+
+The audit that catches this class of bug is mechanical:
+
+```text
+Grep "datasets:\s*\{" in packages/app-core/src/state/ and packages/json-processing/src/
+```
+
+Every hit should either:
+
+1. Spread an existing `datasets` record before overwriting a key, or
+2. Construct the record fresh from iteration over all keys (Example C), or
+3. Be an initializer where "fresh construction" is the intended semantics — e.g. `getNewTemplateMetadata` in `template-usermeta.ts` is correct because it is the factory for a brand-new template with no prior keys to preserve.
+
+Any hit that does none of these three is a bug.
+
+## Prevention
+
+- For any PR that widens a collection type, add a **"type widening" line to the PR description** listing every write site grepped and how each was handled (spread vs. fresh construction vs. iteration).
+- When reviewing such PRs, set the default mental model to **"the type check proves nothing about preservation"**.
+- Ship a **non-default-key test** alongside the type change. Single-key tests will pass for both correct and broken implementations; only a test that writes two keys and asserts both survive distinguishes them.
+
+## Related
+
+- [docs/brainstorms/2026-04-14-multi-dataset-template-structure-requirements.md](../../brainstorms/2026-04-14-multi-dataset-template-structure-requirements.md) — the requirements that drove the type widen, including the design decisions about dataset key naming and placeholder format.
+- [docs/plans/2026-04-14-001-refactor-multi-dataset-template-schema-plan.md](../../plans/2026-04-14-001-refactor-multi-dataset-template-schema-plan.md) — the implementation plan (session history: the plan explicitly called out the read-side slice but did not enumerate the write-side sites; the review filled that gap).
+- [docs/solutions/ui-bugs/export-dialog-empty-dataset-fields-2026-04-13.md](../ui-bugs/export-dialog-empty-dataset-fields-2026-04-13.md) — sibling bug in the same template-dataset/export subsystem. Note: its code snippets reference the pre-refactor singular `metadata.dataset` paths; the underlying diagnosis is still valid but the field names are now `metadata.datasets[DATASET_DEFAULT_NAME]`.
+- [PR #619](https://github.com/deneb-viz/deneb/pull/619) — the refactor PR, including the `/ce:review` synthesis that surfaced the six-site pattern.
+- [PR #615](https://github.com/deneb-viz/deneb/pull/615) — prior fix that introduced `updateExportDataset`; one of the six write sites corrected in #619 (session history).

--- a/docs/solutions/ui-bugs/export-dialog-empty-dataset-fields-2026-04-13.md
+++ b/docs/solutions/ui-bugs/export-dialog-empty-dataset-fields-2026-04-13.md
@@ -1,6 +1,7 @@
 ---
 title: Export dialog shows empty dataset fields
 date: 2026-04-13
+last_updated: 2026-04-16
 category: ui-bugs
 module: app-core
 problem_type: ui_bug
@@ -20,6 +21,8 @@ tags:
   - remap-removal
   - field-tracking
 ---
+
+> **Path drift note (2026-04-16, [PR #619](https://github.com/deneb-viz/deneb/pull/619)):** The template schema was widened from `usermeta.dataset: UsermetaDatasetField[]` to `usermeta.datasets: Record<string, UsermetaDatasetField[]>`. The code snippets and path references below still use the pre-refactor singular form (`createMetadata.dataset`, `export.metadata.dataset`). In current source those are `createMetadata.datasets[DATASET_DEFAULT_NAME]` and `export.metadata.datasets[DATASET_DEFAULT_NAME]`. The internal `state.dataset` / `fieldUsage.dataset` paths were deliberately kept singular and are unchanged. The underlying diagnosis and fixes are still valid. See [best-practices/type-widening-requires-call-site-audit](../best-practices/type-widening-requires-call-site-audit-2026-04-16.md) for the audit pattern that surfaced in the same refactor.
 
 # Export dialog shows empty dataset fields
 

--- a/packages/app-core/src/catalog/vega-lite/vl-bar-interactive.ts
+++ b/packages/app-core/src/catalog/vega-lite/vl-bar-interactive.ts
@@ -7,9 +7,10 @@ import {
     SELECTED_ROW_FIELD_NAME,
     type UsermetaDatasetField
 } from '@deneb-viz/data-core/field';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 const dataset: UsermetaDatasetField[] = [
     {
-        key: '__0__',
+        key: `__${DATASET_DEFAULT_NAME}.0__`,
         name: 'Category',
         description:
             "Select a column that will be displayed on the chart's Y-Axis",
@@ -17,7 +18,7 @@ const dataset: UsermetaDatasetField[] = [
         kind: 'column'
     },
     {
-        key: '__1__',
+        key: `__${DATASET_DEFAULT_NAME}.1__`,
         name: 'Measure',
         description:
             "Select a measure that will be displayed on the chart's X-Axis",
@@ -45,7 +46,7 @@ export const vlBarInteractive = (): TopLevelSpec => ({
             },
             encoding: {
                 x: {
-                    field: '__1__'
+                    field: `__${DATASET_DEFAULT_NAME}.1__`
                 }
             }
         },
@@ -56,7 +57,7 @@ export const vlBarInteractive = (): TopLevelSpec => ({
             },
             encoding: {
                 x: {
-                    field: '__1____highlight'
+                    field: `__${DATASET_DEFAULT_NAME}.1____highlight`
                 },
                 opacity: {
                     condition: {
@@ -73,12 +74,12 @@ export const vlBarInteractive = (): TopLevelSpec => ({
     ],
     encoding: {
         y: {
-            field: '__0__',
+            field: `__${DATASET_DEFAULT_NAME}.0__`,
             type: 'nominal'
         },
         x: {
             type: 'quantitative',
-            axis: { title: '__1__' }
+            axis: { title: `__${DATASET_DEFAULT_NAME}.1__` }
         }
     },
     usermeta: {
@@ -88,15 +89,13 @@ export const vlBarInteractive = (): TopLevelSpec => ({
             'An evolution of the simple bar chart, with tooltips, cross-filtering and cross-highlighting, compatible with Power BI.',
             'vlBarInteractive'
         ),
-        ...{
-            dataset,
-            interactivity: {
-                tooltip: true,
-                contextMenu: true,
-                highlight: true,
-                selection: true,
-                dataPointLimit: INTERACTIVITY_DEFAULTS.selectionMaxDataPoints
-            }
+        datasets: { [DATASET_DEFAULT_NAME]: dataset },
+        interactivity: {
+            tooltip: true,
+            contextMenu: true,
+            highlight: true,
+            selection: true,
+            dataPointLimit: INTERACTIVITY_DEFAULTS.selectionMaxDataPoints
         }
     }
 });

--- a/packages/app-core/src/catalog/vega-lite/vl-bar-simple.ts
+++ b/packages/app-core/src/catalog/vega-lite/vl-bar-simple.ts
@@ -3,10 +3,11 @@ import { TopLevelSpec } from 'vega-lite';
 import { VEGA_LITE_SCHEMA_URL } from '.';
 import { getDenebTemplateDatasetRef, getNewIncludedTemplateMetadata } from '..';
 import { type UsermetaDatasetField } from '@deneb-viz/data-core/field';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 const dataset: UsermetaDatasetField[] = [
     {
-        key: '__0__',
+        key: `__${DATASET_DEFAULT_NAME}.0__`,
         name: 'Category',
         description:
             "Select a column that will be displayed on the chart's Y-Axis",
@@ -14,7 +15,7 @@ const dataset: UsermetaDatasetField[] = [
         kind: 'column'
     },
     {
-        key: '__1__',
+        key: `__${DATASET_DEFAULT_NAME}.1__`,
         name: 'Measure',
         description:
             "Select a measure that will be displayed on the chart's X-Axis",
@@ -31,11 +32,11 @@ export const vlBarSimple = (): TopLevelSpec => ({
     },
     encoding: {
         y: {
-            field: '__0__',
+            field: `__${DATASET_DEFAULT_NAME}.0__`,
             type: 'nominal'
         },
         x: {
-            field: '__1__',
+            field: `__${DATASET_DEFAULT_NAME}.1__`,
             type: 'quantitative'
         }
     },
@@ -46,6 +47,6 @@ export const vlBarSimple = (): TopLevelSpec => ({
             'A simple bar chart for a category and a measure.',
             'vlBarSimple'
         ),
-        ...{ dataset }
+        datasets: { [DATASET_DEFAULT_NAME]: dataset }
     }
 });

--- a/packages/app-core/src/catalog/vega-lite/vl-empty-config.ts
+++ b/packages/app-core/src/catalog/vega-lite/vl-empty-config.ts
@@ -2,6 +2,7 @@ import { TopLevelSpec } from 'vega-lite';
 
 import { VEGA_LITE_SCHEMA_URL, getTemplatePowerBiConfigVl } from '.';
 import { getDenebTemplateDatasetRef, getNewIncludedTemplateMetadata } from '..';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 export const vlEmptyConfig = (): TopLevelSpec => ({
     $schema: VEGA_LITE_SCHEMA_URL,
@@ -13,6 +14,7 @@ export const vlEmptyConfig = (): TopLevelSpec => ({
             '[empty (with Power BI theming)]',
             'Bare-minimum Vega-Lite template, with data-binding pre-populated. Contains configuration defaults for marks and axes to provide a Power BI-like look and feel.'
         ),
+        datasets: { [DATASET_DEFAULT_NAME]: [] },
         config: getTemplatePowerBiConfigVl()
     }
 });

--- a/packages/app-core/src/catalog/vega-lite/vl-empty.ts
+++ b/packages/app-core/src/catalog/vega-lite/vl-empty.ts
@@ -2,14 +2,18 @@ import { TopLevelSpec } from 'vega-lite';
 
 import { VEGA_LITE_SCHEMA_URL } from '.';
 import { getDenebTemplateDatasetRef, getNewIncludedTemplateMetadata } from '..';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 export const vlEmpty = (): TopLevelSpec => ({
     $schema: VEGA_LITE_SCHEMA_URL,
     data: getDenebTemplateDatasetRef(),
     layer: [],
-    usermeta: getNewIncludedTemplateMetadata(
-        'vegaLite',
-        '[empty]',
-        'Bare-minimum Vega-Lite template, with data-binding pre-populated. Has no additional configuration for styling.'
-    )
+    usermeta: {
+        ...getNewIncludedTemplateMetadata(
+            'vegaLite',
+            '[empty]',
+            'Bare-minimum Vega-Lite template, with data-binding pre-populated. Has no additional configuration for styling.'
+        ),
+        datasets: { [DATASET_DEFAULT_NAME]: [] }
+    }
 });

--- a/packages/app-core/src/catalog/vega/v-bar-interactive.ts
+++ b/packages/app-core/src/catalog/vega/v-bar-interactive.ts
@@ -15,7 +15,7 @@ import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 const dataset: UsermetaDatasetField[] = [
     {
-        key: '__0__',
+        key: `__${DATASET_DEFAULT_NAME}.0__`,
         name: 'Category',
         description:
             "Select a column that will be displayed on the chart's Y-Axis",
@@ -23,7 +23,7 @@ const dataset: UsermetaDatasetField[] = [
         kind: 'column'
     },
     {
-        key: '__1__',
+        key: `__${DATASET_DEFAULT_NAME}.1__`,
         name: 'Measure',
         description:
             "Select a measure that will be displayed on the chart's X-Axis",
@@ -49,7 +49,7 @@ export const vBarInteractive = (): Spec => ({
             type: 'band',
             domain: {
                 data: DATASET_DEFAULT_NAME,
-                field: '__0__'
+                field: `__${DATASET_DEFAULT_NAME}.0__`
             },
             range: 'height',
             padding: 0.1,
@@ -59,7 +59,7 @@ export const vBarInteractive = (): Spec => ({
             name: 'xscale',
             domain: {
                 data: DATASET_DEFAULT_NAME,
-                field: '__1__'
+                field: `__${DATASET_DEFAULT_NAME}.1__`
             },
             nice: true,
             range: 'width'
@@ -69,13 +69,13 @@ export const vBarInteractive = (): Spec => ({
         {
             scale: 'xscale',
             orient: 'bottom',
-            title: '__1__',
+            title: `__${DATASET_DEFAULT_NAME}.1__`,
             tickCount: 5
         },
         {
             orient: 'left',
             scale: 'yscale',
-            title: '__0__'
+            title: `__${DATASET_DEFAULT_NAME}.0__`
         }
     ],
     marks: [
@@ -87,11 +87,11 @@ export const vBarInteractive = (): Spec => ({
             encode: {
                 enter: {
                     tooltip: {
-                        signal: "{'__0__': datum['__0__'], '__1__': datum['__1__']}"
+                        signal: `{'__${DATASET_DEFAULT_NAME}.0__': datum['__${DATASET_DEFAULT_NAME}.0__'], '__${DATASET_DEFAULT_NAME}.1__': datum['__${DATASET_DEFAULT_NAME}.1__']}`
                     },
                     x: {
                         scale: 'xscale',
-                        field: '__1__'
+                        field: `__${DATASET_DEFAULT_NAME}.1__`
                     },
                     x2: {
                         scale: 'xscale',
@@ -99,7 +99,7 @@ export const vBarInteractive = (): Spec => ({
                     },
                     y: {
                         scale: 'yscale',
-                        field: '__0__'
+                        field: `__${DATASET_DEFAULT_NAME}.0__`
                     },
                     height: {
                         scale: 'yscale',
@@ -117,11 +117,11 @@ export const vBarInteractive = (): Spec => ({
             encode: {
                 enter: {
                     tooltip: {
-                        signal: "{'__0__': datum['__0__'], '__1__': datum['__1__']}"
+                        signal: `{'__${DATASET_DEFAULT_NAME}.0__': datum['__${DATASET_DEFAULT_NAME}.0__'], '__${DATASET_DEFAULT_NAME}.1__': datum['__${DATASET_DEFAULT_NAME}.1__']}`
                     },
                     x: {
                         scale: 'xscale',
-                        field: '__1____highlight'
+                        field: `__${DATASET_DEFAULT_NAME}.1____highlight`
                     },
                     x2: {
                         scale: 'xscale',
@@ -129,7 +129,7 @@ export const vBarInteractive = (): Spec => ({
                     },
                     y: {
                         scale: 'yscale',
-                        field: '__0__'
+                        field: `__${DATASET_DEFAULT_NAME}.0__`
                     },
                     height: {
                         scale: 'yscale',
@@ -152,16 +152,14 @@ export const vBarInteractive = (): Spec => ({
             'An evolution of the simple bar chart, with tooltips, cross-filtering and cross-highlighting, compatible with Power BI.',
             'vBarInteractive'
         ),
-        ...{
-            dataset,
-            interactivity: {
-                tooltip: true,
-                contextMenu: true,
-                highlight: true,
-                selection: true,
-                dataPointLimit: INTERACTIVITY_DEFAULTS.selectionMaxDataPoints
-            },
-            config: getDenebTemplateVegaSpecificConfig()
-        }
+        datasets: { [DATASET_DEFAULT_NAME]: dataset },
+        interactivity: {
+            tooltip: true,
+            contextMenu: true,
+            highlight: true,
+            selection: true,
+            dataPointLimit: INTERACTIVITY_DEFAULTS.selectionMaxDataPoints
+        },
+        config: getDenebTemplateVegaSpecificConfig()
     }
 });

--- a/packages/app-core/src/catalog/vega/v-bar-simple.ts
+++ b/packages/app-core/src/catalog/vega/v-bar-simple.ts
@@ -11,7 +11,7 @@ import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 const dataset: UsermetaDatasetField[] = [
     {
-        key: '__0__',
+        key: `__${DATASET_DEFAULT_NAME}.0__`,
         name: 'Category',
         description:
             "Select a column that will be displayed on the chart's Y-Axis",
@@ -19,7 +19,7 @@ const dataset: UsermetaDatasetField[] = [
         kind: 'column'
     },
     {
-        key: '__1__',
+        key: `__${DATASET_DEFAULT_NAME}.1__`,
         name: 'Measure',
         description:
             "Select a measure that will be displayed on the chart's X-Axis",
@@ -37,7 +37,7 @@ export const vBarSimple = (): Spec => ({
             type: 'band',
             domain: {
                 data: DATASET_DEFAULT_NAME,
-                field: '__0__'
+                field: `__${DATASET_DEFAULT_NAME}.0__`
             },
             range: 'height',
             padding: 0.1,
@@ -47,7 +47,7 @@ export const vBarSimple = (): Spec => ({
             name: 'xscale',
             domain: {
                 data: DATASET_DEFAULT_NAME,
-                field: '__1__'
+                field: `__${DATASET_DEFAULT_NAME}.1__`
             },
             nice: true,
             range: 'width'
@@ -57,13 +57,13 @@ export const vBarSimple = (): Spec => ({
         {
             scale: 'xscale',
             orient: 'bottom',
-            title: '__1__',
+            title: `__${DATASET_DEFAULT_NAME}.1__`,
             tickCount: 5
         },
         {
             orient: 'left',
             scale: 'yscale',
-            title: '__0__'
+            title: `__${DATASET_DEFAULT_NAME}.0__`
         }
     ],
     marks: [
@@ -76,7 +76,7 @@ export const vBarSimple = (): Spec => ({
                 enter: {
                     x: {
                         scale: 'xscale',
-                        field: '__1__'
+                        field: `__${DATASET_DEFAULT_NAME}.1__`
                     },
                     x2: {
                         scale: 'xscale',
@@ -84,7 +84,7 @@ export const vBarSimple = (): Spec => ({
                     },
                     y: {
                         scale: 'yscale',
-                        field: '__0__'
+                        field: `__${DATASET_DEFAULT_NAME}.0__`
                     },
                     height: {
                         scale: 'yscale',
@@ -101,6 +101,7 @@ export const vBarSimple = (): Spec => ({
             'A simple bar chart for a category and a measure.',
             'vBarSimple'
         ),
-        ...{ dataset, config: getDenebTemplateVegaSpecificConfig() }
+        datasets: { [DATASET_DEFAULT_NAME]: dataset },
+        config: getDenebTemplateVegaSpecificConfig()
     }
 });

--- a/packages/app-core/src/catalog/vega/v-empty-config.ts
+++ b/packages/app-core/src/catalog/vega/v-empty-config.ts
@@ -6,6 +6,7 @@ import {
     VEGA_SCHEMA_URL
 } from '.';
 import { getNewIncludedTemplateMetadata } from '..';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 export const vEmptyConfig = (): Spec => ({
     $schema: VEGA_SCHEMA_URL,
@@ -17,6 +18,7 @@ export const vEmptyConfig = (): Spec => ({
             '[empty (with Power BI theming)]',
             'Bare-minimum Vega template, with data-binding pre-populated. Contains configuration defaults for marks and axes to provide a Power BI-like look and feel.'
         ),
+        datasets: { [DATASET_DEFAULT_NAME]: [] },
         config: getDenebTemplateVegaSpecificConfig(true)
     }
 });

--- a/packages/app-core/src/catalog/vega/v-empty.ts
+++ b/packages/app-core/src/catalog/vega/v-empty.ts
@@ -6,6 +6,7 @@ import {
     VEGA_SCHEMA_URL
 } from '.';
 import { getNewIncludedTemplateMetadata } from '..';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 export const vEmpty = (): Spec => ({
     $schema: VEGA_SCHEMA_URL,
@@ -17,6 +18,7 @@ export const vEmpty = (): Spec => ({
             '[empty]',
             'Bare-minimum Vega template, with data-binding pre-populated. Has no additional configuration for styling.'
         ),
+        datasets: { [DATASET_DEFAULT_NAME]: [] },
         config: getDenebTemplateVegaSpecificConfig()
     }
 });

--- a/packages/app-core/src/components/template-metadata/data-description-column-field.tsx
+++ b/packages/app-core/src/components/template-metadata/data-description-column-field.tsx
@@ -17,7 +17,7 @@ export const DataDescriptionColumnField = ({
     return (
         <TableCell>
             <CappedTextField
-                id={`${DATASET_DEFAULT_NAME}.${index}.description`}
+                id={`datasets.${DATASET_DEFAULT_NAME}.${index}.description`}
                 i18nLabel='Field Description'
                 i18nPlaceholder='Template_Description_Optional_Placeholder'
                 maxLength={TEMPLATE_DATASET_FIELD_PROPS.description.maxLength}

--- a/packages/app-core/src/components/template-metadata/data-name-column-field.tsx
+++ b/packages/app-core/src/components/template-metadata/data-name-column-field.tsx
@@ -32,7 +32,7 @@ export const DataNameColumnField = ({
     return (
         <TableCell className={classes.root}>
             <CappedTextField
-                id={`${DATASET_DEFAULT_NAME}.${index}.name`}
+                id={`datasets.${DATASET_DEFAULT_NAME}.${index}.name`}
                 i18nLabel={`${item.name}`}
                 i18nPlaceholder={`${item?.namePlaceholder}`}
                 maxLength={TEMPLATE_DATASET_FIELD_PROPS.name.maxLength}

--- a/packages/app-core/src/components/template-metadata/template-dataset.tsx
+++ b/packages/app-core/src/components/template-metadata/template-dataset.tsx
@@ -14,6 +14,7 @@ import { logDebug } from '@deneb-viz/utils/logging';
 import { TemplateDatasetRow } from './template-dataset-row';
 import { useCallback } from 'react';
 import { type UsermetaDatasetField } from '@deneb-viz/data-core/field';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 type TemplateDatasetProps = {
     datasetRole: ModalDialogType;
@@ -45,13 +46,19 @@ export const TemplateDataset = ({ datasetRole }: TemplateDatasetProps) => {
             let items: UsermetaDatasetField[] = [];
             switch (role) {
                 case 'new':
-                    items = createMetadata?.dataset.slice() || [];
+                    items =
+                        createMetadata?.datasets?.[
+                            DATASET_DEFAULT_NAME
+                        ]?.slice() || [];
                     break;
                 case 'mapping':
                     items = fieldUsage.remapFields.slice() || [];
                     break;
                 case 'export':
-                    items = exportMetadata?.dataset.slice() || [];
+                    items =
+                        exportMetadata?.datasets?.[
+                            DATASET_DEFAULT_NAME
+                        ]?.slice() || [];
                     break;
             }
             logDebug('getTableFieldRows', { items });

--- a/packages/app-core/src/features/project-create/components/create-button.tsx
+++ b/packages/app-core/src/features/project-create/components/create-button.tsx
@@ -9,6 +9,7 @@ import { useDenebPlatformProvider } from '../../../components/deneb-platform';
 import { useSpecificationEditor } from '../../specification-editor';
 import { getDenebState, useDenebState } from '../../../state';
 import { PROJECT_DEFAULTS } from '@deneb-viz/configuration';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 /**
  * Displays the content for creating a specification using the selected
@@ -42,18 +43,20 @@ export const CreateButton = () => {
         }
         const spec = getTemplateReplacedForDataset(
             candidates?.spec ?? PROJECT_DEFAULTS.spec,
-            metadata?.dataset ?? []
+            metadata?.datasets ?? {}
         );
         const config = candidates?.config ?? PROJECT_DEFAULTS.config;
         // Remap support field configuration keys from inline dataset entries
         // to actual field names supplied by the user. Computed once and shared with both the
         // platform persistence callback and the project state initialisation.
         const supportFieldConfiguration =
-            remapSupportFieldConfigurationForImport(metadata?.dataset ?? []);
+            remapSupportFieldConfigurationForImport(
+                metadata?.datasets?.[DATASET_DEFAULT_NAME] ?? []
+            );
         // Auto-flag treatAsParameter for regular fields assigned to parameter placeholders
         let needsConsolidation = false;
         const datasetFields = getDenebState().dataset.fields;
-        for (const entry of metadata?.dataset ?? []) {
+        for (const entry of metadata?.datasets?.[DATASET_DEFAULT_NAME] ?? []) {
             if (entry.kind === 'parameter' && entry.suppliedObjectName) {
                 const suppliedField = datasetFields[entry.suppliedObjectName];
                 const suppliedRole = suppliedField?.role ?? 'grouping';

--- a/packages/app-core/src/features/project-create/components/template-placeholder-message.tsx
+++ b/packages/app-core/src/features/project-create/components/template-placeholder-message.tsx
@@ -1,6 +1,7 @@
 import { Caption1, makeStyles, tokens } from '@fluentui/react-components';
 
 import { type UsermetaTemplate } from '@deneb-viz/template-usermeta';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 import { useDenebState } from '../../../state';
 
 export const useTemplatePlaceholderMessageStyles = makeStyles({
@@ -40,4 +41,4 @@ export const TemplatePlaceholderMessage = () => {
  */
 const templateHasPlaceholders = (
     template: UsermetaTemplate | undefined | null
-) => (template?.dataset?.length ?? 0) > 0;
+) => (template?.datasets?.[DATASET_DEFAULT_NAME]?.length ?? 0) > 0;

--- a/packages/app-core/src/features/project-export/components/export-pane.tsx
+++ b/packages/app-core/src/features/project-export/components/export-pane.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../lib/field-processing';
 import { getDatasetTemplateFieldsFromMetadata } from '@deneb-viz/data-core/field';
 import { reconcileExportDatasetFields } from '../../../state/dataset';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 /**
  * Interface (pane) for exporting a existing visualization.
@@ -112,7 +113,7 @@ const handleProcessing = async (signal: AbortSignal) => {
         const freshFields = getDatasetTemplateFieldsFromMetadata(fields);
         const reconciledDataset = reconcileExportDatasetFields(
             freshFields,
-            metadata?.dataset
+            metadata?.datasets?.[DATASET_DEFAULT_NAME]
         );
         updateExportDataset(reconciledDataset);
         setExportProcessingState('Complete');

--- a/packages/app-core/src/state/create.ts
+++ b/packages/app-core/src/state/create.ts
@@ -14,6 +14,7 @@ import {
     getNewCreateFromTemplateSliceProperties
 } from '@deneb-viz/json-processing';
 import { type UsermetaDatasetField } from '@deneb-viz/data-core/field';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 /**
  * Represents the create slice in the visual store.
@@ -142,24 +143,26 @@ const handleSetFieldAssignment = (
     state: StoreState,
     payload: CreateSliceSetFieldAssignment
 ): Partial<StoreState> => {
-    const { dataset } = state.create?.metadata || {};
+    const dataset = state.create?.metadata?.datasets?.[DATASET_DEFAULT_NAME];
     if (dataset) {
-        const phIndex =
-            dataset.findIndex((ph) => ph.key === payload.key) ?? dataset.length;
+        const phIndex = dataset.findIndex((ph) => ph.key === payload.key);
         const metadata = {
             ...state.create.metadata,
-            dataset:
-                phIndex === -1
-                    ? [...dataset]
-                    : [
-                          ...dataset.slice(0, phIndex),
-                          <UsermetaDatasetField>{
-                              ...dataset[phIndex],
-                              suppliedObjectKey: payload.suppliedObjectKey,
-                              suppliedObjectName: payload.suppliedObjectName
-                          },
-                          ...dataset.slice(phIndex + 1, dataset.length)
-                      ]
+            datasets: {
+                ...state.create.metadata?.datasets,
+                [DATASET_DEFAULT_NAME]:
+                    phIndex === -1
+                        ? [...dataset]
+                        : [
+                              ...dataset.slice(0, phIndex),
+                              <UsermetaDatasetField>{
+                                  ...dataset[phIndex],
+                                  suppliedObjectKey: payload.suppliedObjectKey,
+                                  suppliedObjectName: payload.suppliedObjectName
+                              },
+                              ...dataset.slice(phIndex + 1, dataset.length)
+                          ]
+            }
         } as UsermetaTemplate;
         const {
             metadataAllDependenciesAssigned = false,

--- a/packages/app-core/src/state/dataset.ts
+++ b/packages/app-core/src/state/dataset.ts
@@ -12,6 +12,7 @@ import {
 } from '@deneb-viz/json-processing';
 import { type UsermetaTemplate } from '@deneb-viz/template-usermeta';
 import {
+    DATASET_DEFAULT_NAME,
     type TabularDataset,
     type TabularDatasetInput
 } from '@deneb-viz/data-core/dataset';
@@ -101,10 +102,13 @@ const handleUpdateDataset = (
     const exportMetadata = getUpdatedExportMetadata(
         state.export.metadata as UsermetaTemplate,
         {
-            dataset: reconcileExportDatasetFields(
-                getDatasetTemplateFieldsFromMetadata(normalizedFields),
-                state.export.metadata?.dataset
-            )
+            datasets: {
+                ...state.export.metadata?.datasets,
+                [DATASET_DEFAULT_NAME]: reconcileExportDatasetFields(
+                    getDatasetTemplateFieldsFromMetadata(normalizedFields),
+                    state.export.metadata?.datasets?.[DATASET_DEFAULT_NAME]
+                )
+            }
         }
     );
     logTimeEnd('dataset.updateDataset.getUpdatedExportMetadata');

--- a/packages/app-core/src/state/export.ts
+++ b/packages/app-core/src/state/export.ts
@@ -89,7 +89,13 @@ const handleSetMetadataPropertyBySelector = (
     state: StoreState,
     payload: ExportSliceSetMetadataPropertyBySelector
 ): Partial<StoreState> => {
-    // TODO: make the id/selector system better to avoid this hack
+    // TODO: make the id/selector system better to avoid this hack.
+    // Dataset-name coupling: selectors are split on '.', so path segments
+    // that represent dataset names in `usermeta.datasets` MUST NOT contain
+    // dots. Today this is safe because DATASET_DEFAULT_NAME = 'dataset'.
+    // If multi-dataset support is added with user-supplied names, this
+    // selector scheme will silently produce wrong paths for names like
+    // 'my.layer' and needs to be revisited alongside the id convention.
     const path: DeepPath = payload.selector
         .split('.')
         .map((key) => (/^\d+$/.test(key) ? Number(key) : key));

--- a/packages/app-core/src/state/export.ts
+++ b/packages/app-core/src/state/export.ts
@@ -5,6 +5,7 @@ import { type UsermetaDatasetField } from '@deneb-viz/data-core/field';
 import { type DeepPath, updateDeep } from '@deneb-viz/utils/object';
 import { StateDependencies, type StoreState } from './state';
 import { getNewTemplateMetadata } from '@deneb-viz/json-processing';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 import { logDebug } from '@deneb-viz/utils/logging';
 
 /**
@@ -135,7 +136,10 @@ const handleUpdateExportDataset = (
             ...state.export,
             metadata: {
                 ...state.export.metadata,
-                dataset
+                datasets: {
+                    ...state.export.metadata.datasets,
+                    [DATASET_DEFAULT_NAME]: dataset
+                }
             }
         }
     };

--- a/packages/app-core/src/state/project.ts
+++ b/packages/app-core/src/state/project.ts
@@ -15,6 +15,7 @@ import {
 } from '@deneb-viz/template-usermeta';
 import { logDebug } from '@deneb-viz/utils/logging';
 import { type SupportFieldConfiguration } from '@deneb-viz/data-core/support-fields';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 export type ProjectSliceProperties = SyncableSlice &
     DenebProject & {
@@ -128,7 +129,9 @@ export const createProjectSlice =
                         };
                         // Embed support field config into dataset entries for export metadata
                         const datasetWithConfig = (
-                            state.export.metadata?.dataset ?? []
+                            state.export.metadata?.datasets?.[
+                                DATASET_DEFAULT_NAME
+                            ] ?? []
                         ).map((d) => {
                             const fieldConfig =
                                 updatedProject.supportFieldConfiguration?.[
@@ -146,7 +149,10 @@ export const createProjectSlice =
                             state.export.metadata as UsermetaTemplate,
                             {
                                 config: payload.config,
-                                dataset: datasetWithConfig,
+                                datasets: {
+                                    ...state.export.metadata?.datasets,
+                                    [DATASET_DEFAULT_NAME]: datasetWithConfig
+                                },
                                 provider,
                                 providerVersion,
                                 interactivity: updatedProject.interactivity
@@ -269,7 +275,9 @@ export const createProjectSlice =
                 set(
                     (state) => {
                         const currentDataset =
-                            state.export.metadata?.dataset ?? [];
+                            state.export.metadata?.datasets?.[
+                                DATASET_DEFAULT_NAME
+                            ] ?? [];
                         const updatedDataset = currentDataset.map((d) => {
                             const fieldConfig =
                                 config[d.namePlaceholder ?? d.name];
@@ -285,7 +293,12 @@ export const createProjectSlice =
                         });
                         const exportMetadata = getUpdatedExportMetadata(
                             state.export.metadata as UsermetaTemplate,
-                            { dataset: updatedDataset }
+                            {
+                                datasets: {
+                                    ...state.export.metadata?.datasets,
+                                    [DATASET_DEFAULT_NAME]: updatedDataset
+                                }
+                            }
                         );
                         return {
                             project: {
@@ -375,7 +388,8 @@ const handleSyncProjectData = (
     };
 
     // Embed support field config into dataset entries for export metadata
-    const currentDataset = state.export.metadata?.dataset ?? [];
+    const currentDataset =
+        state.export.metadata?.datasets?.[DATASET_DEFAULT_NAME] ?? [];
     const datasetWithConfig = currentDataset.map((d) => {
         const fieldConfig =
             updatedProject.supportFieldConfiguration?.[
@@ -391,7 +405,10 @@ const handleSyncProjectData = (
         state.export.metadata as UsermetaTemplate,
         {
             config: payload.config ?? state.export.metadata?.config,
-            dataset: datasetWithConfig,
+            datasets: {
+                ...state.export.metadata?.datasets,
+                [DATASET_DEFAULT_NAME]: datasetWithConfig
+            },
             provider: updatedProject.provider as SpecProvider,
             providerVersion: updatedProject.providerVersion,
             interactivity: updatedProject.interactivity

--- a/packages/data-core/src/lib/field/__tests__/extraction.test.ts
+++ b/packages/data-core/src/lib/field/__tests__/extraction.test.ts
@@ -115,8 +115,8 @@ describe('getDatasetTemplateFieldsFromMetadata', () => {
             b: { id: 'id-b', role: 'aggregation', dataType: 'numeric' }
         };
         const result = getDatasetTemplateFieldsFromMetadata(fields);
-        expect(result[0].key).toBe('__0__');
-        expect(result[1].key).toBe('__1__');
+        expect(result[0].key).toBe('__dataset.0__');
+        expect(result[1].key).toBe('__dataset.1__');
     });
 
     it('should exclude support fields', () => {
@@ -151,7 +151,11 @@ describe('getDatasetTemplateFieldsFromMetadata', () => {
 
     it('should use record key as name in result', () => {
         const fields: DatasetFields = {
-            'my-field': { id: 'internal-id', role: 'grouping', dataType: 'text' }
+            'my-field': {
+                id: 'internal-id',
+                role: 'grouping',
+                dataType: 'text'
+            }
         };
         const result = getDatasetTemplateFieldsFromMetadata(fields);
         expect(result[0].name).toBe('my-field');

--- a/packages/data-core/src/lib/field/__tests__/template-metadata.test.ts
+++ b/packages/data-core/src/lib/field/__tests__/template-metadata.test.ts
@@ -71,9 +71,9 @@ describe('toUsermetaDatasetField', () => {
 
     it('should use placeholder when provided', () => {
         const result = toUsermetaDatasetField('Field Name', baseField, {
-            placeholder: '__0__'
+            placeholder: '__dataset.0__'
         });
-        expect(result.key).toBe('__0__');
+        expect(result.key).toBe('__dataset.0__');
     });
 
     it('should use field id when no placeholder provided', () => {
@@ -140,8 +140,8 @@ describe('toUsermetaDatasetFields', () => {
     it('should transform array of field entries with sequential placeholders', () => {
         const result = toUsermetaDatasetFields(entries);
         expect(result).toHaveLength(2);
-        expect(result[0].key).toBe('__0__');
-        expect(result[1].key).toBe('__1__');
+        expect(result[0].key).toBe('__dataset.0__');
+        expect(result[1].key).toBe('__dataset.1__');
     });
 
     it('should preserve field properties in transformation', () => {

--- a/packages/data-core/src/lib/field/__tests__/tokenization.test.ts
+++ b/packages/data-core/src/lib/field/__tests__/tokenization.test.ts
@@ -28,17 +28,20 @@ describe('getEscapedReplacerPattern', () => {
 });
 
 describe('getPlaceholderKey', () => {
-    it('should return a placeholder key', () => {
-        expect(getPlaceholderKey(0)).toBe('__0__');
+    it('should return a dataset-scoped placeholder key', () => {
+        expect(getPlaceholderKey('dataset', 0)).toBe('__dataset.0__');
     });
     it('should return a placeholder key with positive number', () => {
-        expect(getPlaceholderKey(5)).toBe('__5__');
+        expect(getPlaceholderKey('dataset', 5)).toBe('__dataset.5__');
     });
     it('should return a placeholder key with negative number', () => {
-        expect(getPlaceholderKey(-3)).toBe('__3__');
+        expect(getPlaceholderKey('dataset', -3)).toBe('__dataset.3__');
     });
     it('should return a placeholder key with decimal number floored down', () => {
-        expect(getPlaceholderKey(2.5)).toBe('__2__');
+        expect(getPlaceholderKey('dataset', 2.5)).toBe('__dataset.2__');
+    });
+    it('should scope placeholder to the given dataset name', () => {
+        expect(getPlaceholderKey('map_layer', 0)).toBe('__map_layer.0__');
     });
 });
 
@@ -250,7 +253,7 @@ describe('__names suffix tokenization', () => {
 
     it('getTokenPatternsReplacement should produce correct replacer for __names suffix', () => {
         const fieldName = 'Dynamic Category';
-        const placeholder = '__0__';
+        const placeholder = '__dataset.0__';
         const result = getTokenPatternsReplacement(fieldName, placeholder);
         const parameterAlternation = getParameterRegExpAlternation();
         const escapedName = getEscapedReplacerPattern(fieldName);

--- a/packages/data-core/src/lib/field/extraction.ts
+++ b/packages/data-core/src/lib/field/extraction.ts
@@ -1,5 +1,7 @@
 import { pickBy } from '@deneb-viz/utils/object';
+import { DATASET_DEFAULT_NAME } from '../dataset/constants';
 import { toUsermetaDatasetField } from './template-metadata';
+import { getPlaceholderKey } from './tokenization';
 import type { DatasetFields, UsermetaDatasetField } from './types';
 
 /**
@@ -18,7 +20,8 @@ export function getDatasetFieldsInclusive(fields: DatasetFields | undefined) {
  * Transforms DatasetFields to UsermetaDatasetFields with sequential placeholders.
  */
 export const getDatasetTemplateFieldsFromMetadata = (
-    metadata: DatasetFields | undefined
+    metadata: DatasetFields | undefined,
+    datasetName: string = DATASET_DEFAULT_NAME
 ): UsermetaDatasetField[] =>
     Object.entries(getDatasetFieldsInclusive(metadata))
         .filter(
@@ -26,5 +29,7 @@ export const getDatasetTemplateFieldsFromMetadata = (
                 entry[1] !== undefined
         )
         .map(([key, field], i) =>
-            toUsermetaDatasetField(key, field, { placeholder: `__${i}__` })
+            toUsermetaDatasetField(key, field, {
+                placeholder: getPlaceholderKey(datasetName, i)
+            })
         );

--- a/packages/data-core/src/lib/field/template-metadata.ts
+++ b/packages/data-core/src/lib/field/template-metadata.ts
@@ -1,3 +1,5 @@
+import { DATASET_DEFAULT_NAME } from '../dataset/constants';
+import { getPlaceholderKey } from './tokenization';
 import type {
     DatasetField,
     DatasetFieldRole,
@@ -77,13 +79,17 @@ export const toUsermetaDatasetField = <T = object>(
  * Transforms an array of DatasetField entries to UsermetaDatasetFields with sequential placeholders.
  *
  * @param entries - Array of [key, field] entries to transform
- * @returns Array of UsermetaDatasetFields with placeholders `__0__`, `__1__`, etc.
+ * @param datasetName - The dataset name for scoped placeholders (defaults to DATASET_DEFAULT_NAME)
+ * @returns Array of UsermetaDatasetFields with placeholders `__dataset.0__`, `__dataset.1__`, etc.
  */
 export const toUsermetaDatasetFields = <T = object>(
-    entries: [string, DatasetField<T>][]
+    entries: [string, DatasetField<T>][],
+    datasetName: string = DATASET_DEFAULT_NAME
 ): UsermetaDatasetField[] =>
     entries.map(([key, field], i) =>
-        toUsermetaDatasetField(key, field, { placeholder: `__${i}__` })
+        toUsermetaDatasetField(key, field, {
+            placeholder: getPlaceholderKey(datasetName, i)
+        })
     );
 
 /**

--- a/packages/data-core/src/lib/field/tokenization.ts
+++ b/packages/data-core/src/lib/field/tokenization.ts
@@ -33,9 +33,10 @@ export const getParameterRegExpAlternation = () => PARAMETER_NAMES_SUFFIX;
  * fields in the specification, so that they can be replaced with the actual values when the dataset is accessible.
  * - Decimal values are floored to the nearest integer.
  * - Negative values are converted to positive values.
+ * - Placeholders are scoped by dataset name using a dot separator: `__datasetName.N__`
  */
-export const getPlaceholderKey = (i: number) => {
-    return `__${Math.floor(Math.abs(i))}__`;
+export const getPlaceholderKey = (datasetName: string, i: number) => {
+    return `__${datasetName}.${Math.floor(Math.abs(i))}__`;
 };
 
 /**

--- a/packages/data-core/src/lib/field/types.ts
+++ b/packages/data-core/src/lib/field/types.ts
@@ -96,10 +96,10 @@ export type FieldPatternReplacer = {
  */
 export type UsermetaDatasetField = {
     /**
-     * Field identifier. In exported templates, this is a placeholder name matching the
-     * `@pattern` below (e.g., `__0__`). In runtime tracking contexts, this is the field's
-     * actual identifier (e.g., queryName or record key).
-     * @pattern ^__[a-zA-Z0-9]+__$
+     * Field identifier. In exported templates, this is a dataset-scoped placeholder matching
+     * the `@pattern` below (e.g., `__dataset.0__`). In runtime tracking contexts, this is
+     * the field's actual identifier (e.g., queryName or record key).
+     * @pattern ^__[a-zA-Z0-9_]+\.\d+__$
      * @maxLength 30
      */
     key: string;

--- a/packages/json-processing/src/__test__/template-dataset.test.ts
+++ b/packages/json-processing/src/__test__/template-dataset.test.ts
@@ -18,7 +18,7 @@ import { type SelectionMode } from '@deneb-viz/powerbi-compat/interactivity';
 const INCOMPLETE_FIELD: UsermetaDatasetField[] = [
     {
         name: 'Field 0',
-        key: '__0__',
+        key: '__dataset.0__',
         kind: 'column',
         type: 'text'
     }
@@ -26,7 +26,7 @@ const INCOMPLETE_FIELD: UsermetaDatasetField[] = [
 const COMPLETE_FIELD: UsermetaDatasetField[] = [
     {
         name: 'Field 1',
-        key: '__0__',
+        key: '__dataset.0__',
         kind: 'measure',
         type: 'numeric',
         suppliedObjectKey: 'Field1'
@@ -67,7 +67,7 @@ const MOCK_TEMPLATE_METADATA_BASE: UsermetaTemplate = {
         dataPointLimit: INTERACTIVITY_DEFAULTS.selectionMaxDataPoints,
         highlight: INTERACTIVITY_DEFAULTS.enableHighlight
     },
-    dataset: [],
+    datasets: { dataset: [] },
     config: '{}'
 };
 
@@ -92,7 +92,7 @@ describe('areAllCreateDataRequirementsMet', () => {
     it('should return true if all dependencies are assigned', () => {
         const metadata: UsermetaTemplate = {
             ...MOCK_TEMPLATE_METADATA_BASE,
-            dataset: COMPLETE_FIELD
+            datasets: { dataset: COMPLETE_FIELD }
         };
         const result = areAllCreateDataRequirementsMet(metadata);
         expect(result.metadataAllDependenciesAssigned).toBe(true);
@@ -100,7 +100,7 @@ describe('areAllCreateDataRequirementsMet', () => {
     it('should return false if not all fields are assigned', () => {
         const metadata: UsermetaTemplate = {
             ...MOCK_TEMPLATE_METADATA_BASE,
-            dataset: INCOMPLETE_FIELD
+            datasets: { dataset: INCOMPLETE_FIELD }
         };
         const result = areAllCreateDataRequirementsMet(metadata);
         expect(result.metadataAllDependenciesAssigned).toBe(false);

--- a/packages/json-processing/src/__test__/template-usermeta.test.ts
+++ b/packages/json-processing/src/__test__/template-usermeta.test.ts
@@ -9,6 +9,7 @@ import {
     getTemplateProvider,
     getTemplateReplacedForDataset,
     getTemplateResolvedForLegacyConfig,
+    getTemplateResolvedForLegacyDataset,
     getTemplateResolvedForLegacyVersions,
     getTemplateResolvedForPlaceholderAssignment,
     getUpdatedExportMetadata,
@@ -64,7 +65,7 @@ const MOCK_TEMPLATE_METADATA_BASE = `{
             "dataPointLimit": ${INTERACTIVITY_DEFAULTS.selectionMaxDataPoints},
             "highlight": ${INTERACTIVITY_DEFAULTS.enableHighlight}
         },
-        "dataset": [],
+        "datasets": { "dataset": [] },
         "config": "{}"
     }
 }`;
@@ -94,7 +95,7 @@ const MOCK_TEMPLATE_METADATA_NO_PROVIDER_VERSION = `{
             "dataPointLimit": ${INTERACTIVITY_DEFAULTS.selectionMaxDataPoints},
             "highlight": ${INTERACTIVITY_DEFAULTS.enableHighlight}
         },
-        "dataset": [],
+        "datasets": { "dataset": [] },
         "config": "{}"
     }
 }`;
@@ -123,13 +124,13 @@ const EXPECTED_METADATA_BASE = {
         dataPointLimit: INTERACTIVITY_DEFAULTS.selectionMaxDataPoints,
         highlight: INTERACTIVITY_DEFAULTS.enableHighlight
     },
-    dataset: [],
+    datasets: { dataset: [] },
     config: '{}'
 };
 
 const TRACKED_FIELDS: TrackedFields = {
     'Date.Date': {
-        placeholder: '__0__',
+        placeholder: '__dataset.0__',
         paths: [
             ['signals', 0, 'on', 0, 'update'],
             ['data', 1, 'transform', 0, 'expr'],
@@ -161,7 +162,7 @@ const TRACKED_FIELDS: TrackedFields = {
         }
     },
     'Financials.$ Sales': {
-        placeholder: '__1__',
+        placeholder: '__dataset.1__',
         paths: [
             ['data', 1, 'transform', 1, 'expr'],
             ['marks', 0, 'encode', 'update', 'description', 'signal'],
@@ -218,7 +219,7 @@ describe('getExportTemplate', () => {
     };
     const MOCK_METADATA: UsermetaTemplate = {
         ...EXPECTED_METADATA_BASE,
-        dataset: TEMPLATE_DATASET
+        datasets: { dataset: TEMPLATE_DATASET }
     };
     const MOCK_TOKENIZED_SPEC =
         '{"config": {}, "data": {"values": [] }, "mark": "bar"}';
@@ -250,22 +251,24 @@ describe('getExportTemplate', () => {
       "dataPointLimit": ${INTERACTIVITY_DEFAULTS.selectionMaxDataPoints},
       "highlight": ${INTERACTIVITY_DEFAULTS.enableHighlight}
     },
-    "dataset": [
-      {
-        "key": "__0__",
-        "name": "Date",
-        "description": "",
-        "kind": "column",
-        "type": "dateTime"
-      },
-      {
-        "key": "__1__",
-        "name": "$ Sales",
-        "description": "",
-        "kind": "measure",
-        "type": "numeric"
-      }
-    ],
+    "datasets": {
+      "dataset": [
+        {
+          "key": "__dataset.0__",
+          "name": "Date",
+          "description": "",
+          "kind": "column",
+          "type": "dateTime"
+        },
+        {
+          "key": "__dataset.1__",
+          "name": "$ Sales",
+          "description": "",
+          "kind": "measure",
+          "type": "numeric"
+        }
+      ]
+    },
     "config": "{}"
   },
   "config": {},
@@ -331,7 +334,7 @@ describe('getNewTemplateMetadata', () => {
 describe('getPublishableUsermeta ', () => {
     const MOCK_USERMETA: UsermetaTemplate = {
         ...EXPECTED_METADATA_BASE,
-        dataset: TEMPLATE_DATASET
+        datasets: { dataset: TEMPLATE_DATASET }
     };
     const MOCK_OPTIONS = {
         informationTranslationPlaceholders: {
@@ -351,22 +354,24 @@ describe('getPublishableUsermeta ', () => {
                 description: 'description-placeholder',
                 author: 'author-placeholder'
             },
-            dataset: [
-                {
-                    key: '__0__',
-                    name: 'Date',
-                    description: '',
-                    kind: 'column',
-                    type: 'dateTime'
-                },
-                {
-                    key: '__1__',
-                    name: '$ Sales',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                }
-            ]
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: 'Date',
+                        description: '',
+                        kind: 'column',
+                        type: 'dateTime'
+                    },
+                    {
+                        key: '__dataset.1__',
+                        name: '$ Sales',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    }
+                ]
+            }
         };
 
         const result = getPublishableUsermeta(MOCK_USERMETA, MOCK_OPTIONS);
@@ -419,43 +424,46 @@ describe('getTemplateProvider', () => {
 });
 
 describe('getTemplateReplacedForDataset', () => {
-    const spec = 'This is a sample spec with __0__ and __1__ placeholders.';
-    const dataset: UsermetaDatasetField[] = [
-        {
-            key: '__0__',
-            name: 'Date',
-            namePlaceholder: 'Date',
-            description: '',
-            kind: 'column',
-            type: 'dateTime',
-            suppliedObjectKey: 'Date.Date',
-            suppliedObjectName: 'Date'
-        },
-        {
-            key: '__1__',
-            name: '$ Sales',
-            namePlaceholder: '$ Sales',
-            description: '',
-            kind: 'measure',
-            type: 'numeric',
-            suppliedObjectKey: 'Financials.$ Sales',
-            suppliedObjectName: '$ Sales'
-        }
-    ];
+    const spec =
+        'This is a sample spec with __dataset.0__ and __dataset.1__ placeholders.';
+    const datasets: Record<string, UsermetaDatasetField[]> = {
+        dataset: [
+            {
+                key: '__dataset.0__',
+                name: 'Date',
+                namePlaceholder: 'Date',
+                description: '',
+                kind: 'column',
+                type: 'dateTime',
+                suppliedObjectKey: 'Date.Date',
+                suppliedObjectName: 'Date'
+            },
+            {
+                key: '__dataset.1__',
+                name: '$ Sales',
+                namePlaceholder: '$ Sales',
+                description: '',
+                kind: 'measure',
+                type: 'numeric',
+                suppliedObjectKey: 'Financials.$ Sales',
+                suppliedObjectName: '$ Sales'
+            }
+        ]
+    };
     it('should replace the placeholders in the spec with the corresponding dataset values', () => {
         const expectedSpec =
             'This is a sample spec with Date and $ Sales placeholders.';
-        const result = getTemplateReplacedForDataset(spec, dataset);
+        const result = getTemplateReplacedForDataset(spec, datasets);
         expect(result).toEqual(expectedSpec);
     });
     it('should replace multiple occurrences of the same placeholder in the spec', () => {
         const specWithDuplicatePlaceholder =
-            'This is a sample spec with __0__ and __0__ placeholders.';
+            'This is a sample spec with __dataset.0__ and __dataset.0__ placeholders.';
         const expectedSpec =
             'This is a sample spec with Date and Date placeholders.';
         const result = getTemplateReplacedForDataset(
             specWithDuplicatePlaceholder,
-            dataset
+            datasets
         );
         expect(result).toEqual(expectedSpec);
     });
@@ -464,33 +472,44 @@ describe('getTemplateReplacedForDataset', () => {
             'This is a sample spec without any placeholders.';
         const result = getTemplateReplacedForDataset(
             specWithoutPlaceholders,
-            dataset
+            datasets
         );
         expect(result).toEqual(specWithoutPlaceholders);
     });
-    it('should return the original spec if the dataset is empty', () => {
-        const emptyDataset: UsermetaDatasetField[] = [];
-        const result = getTemplateReplacedForDataset(spec, emptyDataset);
+    it('should return the original spec if the datasets are empty', () => {
+        const emptyDatasets: Record<string, UsermetaDatasetField[]> = {
+            dataset: []
+        };
+        const result = getTemplateReplacedForDataset(spec, emptyDatasets);
         expect(result).toEqual(spec);
+    });
+    it('should match by field key, not by array position', () => {
+        const reorderedDatasets: Record<string, UsermetaDatasetField[]> = {
+            dataset: [datasets.dataset[1], datasets.dataset[0]]
+        };
+        const result = getTemplateReplacedForDataset(spec, reorderedDatasets);
+        expect(result).toEqual(
+            'This is a sample spec with Date and $ Sales placeholders.'
+        );
     });
     it('should migrate legacy pbiContainer signal references to denebContainer', () => {
         const specWithLegacySignal =
             '{ "signals": [{ "name": "myWidth", "update": "pbiContainerWidth" }] }';
         const expectedSpec =
             '{ "signals": [{ "name": "myWidth", "update": "denebContainer.width" }] }';
-        const result = getTemplateReplacedForDataset(specWithLegacySignal, []);
+        const result = getTemplateReplacedForDataset(specWithLegacySignal, {});
         expect(result).toEqual(expectedSpec);
     });
     it('should migrate pbiContainerHeight to denebContainer.height', () => {
         const specWithLegacySignal = '{ "update": "pbiContainerHeight - 50" }';
         const expectedSpec = '{ "update": "denebContainer.height - 50" }';
-        const result = getTemplateReplacedForDataset(specWithLegacySignal, []);
+        const result = getTemplateReplacedForDataset(specWithLegacySignal, {});
         expect(result).toEqual(expectedSpec);
     });
     it('should migrate pbiContainer to denebContainer', () => {
         const specWithLegacySignal = '{ "update": "pbiContainer.scrollTop" }';
         const expectedSpec = '{ "update": "denebContainer.scrollTop" }';
-        const result = getTemplateReplacedForDataset(specWithLegacySignal, []);
+        const result = getTemplateReplacedForDataset(specWithLegacySignal, {});
         expect(result).toEqual(expectedSpec);
     });
 });
@@ -744,7 +763,7 @@ describe('getTemplateResolvedForPlaceholderAssignment', () => {
 describe('getUpdatedExportMetadata', () => {
     const MOCK_USERMETA: UsermetaTemplate = {
         ...EXPECTED_METADATA_BASE,
-        dataset: TEMPLATE_DATASET
+        datasets: { dataset: TEMPLATE_DATASET }
     };
     it('should return the updated metadata with the provided options', () => {
         const options = {
@@ -758,7 +777,7 @@ describe('getUpdatedExportMetadata', () => {
                 dataPointLimit: 50,
                 highlight: false
             },
-            dataset: TEMPLATE_DATASET,
+            datasets: { dataset: TEMPLATE_DATASET },
             config: '{"key": "value"}'
         };
 
@@ -777,7 +796,7 @@ describe('getUpdatedExportMetadata', () => {
                 dataPointLimit: 50,
                 highlight: false
             },
-            dataset: TEMPLATE_DATASET,
+            datasets: { dataset: TEMPLATE_DATASET },
             config: '{"key": "value"}'
         };
 
@@ -798,7 +817,7 @@ describe('getUpdatedExportMetadata', () => {
                 dataPointLimit: 50,
                 highlight: false
             },
-            dataset: TEMPLATE_DATASET,
+            datasets: { dataset: TEMPLATE_DATASET },
             config: '{"key": "value"}'
         };
         const expectedMetadata = {
@@ -811,11 +830,136 @@ describe('getUpdatedExportMetadata', () => {
                 dataPointLimit: 50,
                 highlight: false
             },
-            dataset: TEMPLATE_DATASET,
+            datasets: { dataset: TEMPLATE_DATASET },
             config: '{"key": "value"}'
         };
         const result = getUpdatedExportMetadata(MOCK_USERMETA, options);
         expect(result).toEqual(expectedMetadata);
+    });
+});
+
+describe('getTemplateResolvedForLegacyDataset', () => {
+    it('migrates v1 dataset array to datasets.dataset and rewrites placeholder keys', () => {
+        const v1 = JSON.stringify({
+            usermeta: {
+                dataset: [
+                    { key: '__0__', name: 'Sales', type: 'numeric' },
+                    { key: '__1__', name: 'Region', type: 'text' }
+                ]
+            }
+        });
+        const result = getTemplateResolvedForLegacyDataset(v1);
+        const parsed = getJsoncStringAsObject(result);
+        expect(parsed.usermeta.dataset).toBeUndefined();
+        expect(parsed.usermeta.datasets.dataset).toEqual([
+            { key: '__dataset.0__', name: 'Sales', type: 'numeric' },
+            { key: '__dataset.1__', name: 'Region', type: 'text' }
+        ]);
+    });
+
+    it('migrates an empty v1 dataset array to datasets.dataset = []', () => {
+        const v1 = JSON.stringify({ usermeta: { dataset: [] } });
+        const result = getTemplateResolvedForLegacyDataset(v1);
+        const parsed = getJsoncStringAsObject(result);
+        expect(parsed.usermeta.dataset).toBeUndefined();
+        expect(parsed.usermeta.datasets).toEqual({ dataset: [] });
+    });
+
+    it('rewrites placeholder references in the spec body', () => {
+        const v1 = JSON.stringify({
+            usermeta: {
+                dataset: [{ key: '__0__', name: 'Sales', type: 'numeric' }]
+            },
+            mark: 'bar',
+            encoding: { x: { field: '__0__', type: 'quantitative' } }
+        });
+        const result = getTemplateResolvedForLegacyDataset(v1);
+        expect(result).toContain('"__dataset.0__"');
+        expect(result).not.toContain('"__0__"');
+    });
+
+    it('preserves compound placeholder suffixes like __1____highlight', () => {
+        const v1 = JSON.stringify({
+            usermeta: {
+                dataset: [
+                    { key: '__0__', name: 'A', type: 'text' },
+                    { key: '__1__', name: 'B', type: 'numeric' }
+                ]
+            },
+            mark: { type: 'bar' },
+            encoding: { color: { field: '__1____highlight' } }
+        });
+        const result = getTemplateResolvedForLegacyDataset(v1);
+        expect(result).toContain('__dataset.1____highlight');
+        expect(result).not.toContain('"__1____highlight"');
+    });
+
+    it('handles 11+ fields without partial matches between __1__ and __10__', () => {
+        const dataset = Array.from({ length: 11 }, (_, i) => ({
+            key: `__${i}__`,
+            name: `Field${i}`,
+            type: 'text'
+        }));
+        const v1 = JSON.stringify({
+            usermeta: { dataset },
+            spec: { x: '__1__', y: '__10__' }
+        });
+        const result = getTemplateResolvedForLegacyDataset(v1);
+        expect(result).toContain('"__dataset.1__"');
+        expect(result).toContain('"__dataset.10__"');
+        expect(result).not.toContain('"__1__"');
+        expect(result).not.toContain('"__10__"');
+        // Ensure __1__ was not partial-matched inside __10__ to produce __dataset.1__0__
+        expect(result).not.toContain('__dataset.1__0__');
+    });
+
+    it('rewrites placeholders inside Vega expression strings', () => {
+        const v1 = JSON.stringify({
+            usermeta: {
+                dataset: [{ key: '__0__', name: 'Sales', type: 'numeric' }]
+            },
+            signals: [{ name: 'tooltip', update: "{'value': datum['__0__']}" }]
+        });
+        const result = getTemplateResolvedForLegacyDataset(v1);
+        expect(result).toContain("datum['__dataset.0__']");
+        expect(result).not.toContain("datum['__0__']");
+    });
+
+    it('passes a v2 template through unchanged when datasets is already present', () => {
+        const v2 = JSON.stringify({
+            usermeta: {
+                datasets: {
+                    dataset: [
+                        {
+                            key: '__dataset.0__',
+                            name: 'Sales',
+                            type: 'numeric'
+                        }
+                    ]
+                }
+            }
+        });
+        const result = getTemplateResolvedForLegacyDataset(v2);
+        expect(result).toBe(v2);
+    });
+
+    it('passes through unchanged when both dataset and datasets are present (schema rejection deferred)', () => {
+        const both = JSON.stringify({
+            usermeta: {
+                dataset: [{ key: '__0__', name: 'A', type: 'text' }],
+                datasets: {
+                    dataset: [{ key: '__dataset.0__', name: 'A', type: 'text' }]
+                }
+            }
+        });
+        const result = getTemplateResolvedForLegacyDataset(both);
+        expect(result).toBe(both);
+    });
+
+    it('returns the template unchanged when usermeta is absent', () => {
+        const noUsermeta = JSON.stringify({ mark: 'bar' });
+        const result = getTemplateResolvedForLegacyDataset(noUsermeta);
+        expect(result).toBe(noUsermeta);
     });
 });
 
@@ -887,72 +1031,37 @@ describe('getValidatedTemplate', () => {
 
     it('should return valid template with import state "Success"', () => {
         const result = getValidatedTemplate(MOCK_CONTENT, MOCK_TAB_SIZE);
-        expect(result).toEqual({
-            candidates: {
-                spec: `{
-  "data": {
-    "values": []
-  },
-  "mark": {
-    "type": "bar"
-  },
-  "encoding": {
-    "x": {
-      "field": "__0__",
-      "type": "temporal"
-    },
-    "y": {
-      "field": "__1__",
-      "type": "quantitative"
-    }
-  }
-}`,
-                config: `{\n  "view": {\n    "stroke": "transparent"\n  }\n}`
-            },
-            importFile: MOCK_CONTENT,
-            importState: 'Success',
-            metadata: {
-                deneb: {
-                    build: '1.6.0.0',
-                    metaVersion: 1,
-                    provider: 'vegaLite',
-                    providerVersion: '5.15.0'
-                },
-                interactivity: {
-                    tooltip: true,
-                    contextMenu: true,
-                    selection: true,
-                    highlight: true,
-                    dataPointLimit: 50
-                },
-                information: {
-                    name: 'Compact Bar Chart',
-                    description:
-                        'A bar char, with the category labels at the base of the bar, rather than as a separate axis label. Data labels are also at the end of each bar.',
-                    author: 'DM-P',
-                    uuid: '42b0e8bb-8538-4510-bb95-1c5a0c5188ac',
-                    generated: '2023-09-22T01:15:02.162Z'
-                },
-                dataset: [
-                    {
-                        key: '__0__',
-                        name: 'Category',
-                        description: "Category for the bar chart's y-axis.",
-                        type: 'text',
-                        kind: 'column'
-                    },
-                    {
-                        key: '__1__',
-                        name: 'Measure',
-                        description:
-                            "Measure to display along the bar chart's x-axis.",
-                        type: 'numeric',
-                        kind: 'measure'
-                    }
-                ],
-                config: `{\n  "view": {\n    "stroke": "transparent"\n  }\n}`
-            }
+        expect(result.importState).toBe('Success');
+        expect(result.importFile).toBe(MOCK_CONTENT);
+        expect(result.metadata).toBeTruthy();
+        expect(result.metadata?.deneb).toEqual({
+            build: '1.6.0.0',
+            metaVersion: 1,
+            provider: 'vegaLite',
+            providerVersion: '5.15.0'
         });
+        // Structural assertions on the migrated dataset entries
+        expect(result.metadata?.datasets?.dataset).toEqual([
+            {
+                key: '__dataset.0__',
+                name: 'Category',
+                description: "Category for the bar chart's y-axis.",
+                type: 'text',
+                kind: 'column'
+            },
+            {
+                key: '__dataset.1__',
+                name: 'Measure',
+                description: "Measure to display along the bar chart's x-axis.",
+                type: 'numeric',
+                kind: 'measure'
+            }
+        ]);
+        // Spec body assertions: confirm placeholders rewritten in expected positions
+        // (use unquoted forms to also catch occurrences inside Vega expression strings)
+        expect(result.candidates?.spec).toMatch(/"field":\s*"__dataset\.0__"/);
+        expect(result.candidates?.spec).toMatch(/"field":\s*"__dataset\.1__"/);
+        expect(result.candidates?.spec).not.toMatch(/__\d+__/);
     });
     it('should return invalid template with import state "None" if not valid JSON', () => {
         const invalidContent = 'invalid-json';
@@ -1039,7 +1148,7 @@ describe('getValidatedTemplate', () => {
  */
 const TRACKED_FIELDS_BY_QUERYNAME: TrackedFields = {
     'Financials.$ Sales': {
-        placeholder: '__0__',
+        placeholder: '__dataset.0__',
         paths: [['encoding', 'x', 'field']],
         isInDataset: true,
         isInSpecification: true,
@@ -1062,7 +1171,7 @@ const TRACKED_FIELDS_BY_QUERYNAME: TrackedFields = {
         }
     },
     'Financials.$ Profit': {
-        placeholder: '__1__',
+        placeholder: '__dataset.1__',
         paths: [],
         isInDataset: true,
         isInSpecification: false,
@@ -1085,7 +1194,7 @@ const TRACKED_FIELDS_BY_QUERYNAME: TrackedFields = {
         }
     },
     'Category.Category Parameter': {
-        placeholder: '__2__',
+        placeholder: '__dataset.2__',
         paths: [['encoding', 'y', 'field']],
         isInDataset: true,
         isInSpecification: true,
@@ -1118,15 +1227,15 @@ const TRACKED_FIELDS_BY_QUERYNAME: TrackedFields = {
 const TRACKED_FIELDS_REORDERED: TrackedFields = {
     'Financials.$ Sales': {
         ...TRACKED_FIELDS_BY_QUERYNAME['Financials.$ Sales'],
-        placeholder: '__0__'
+        placeholder: '__dataset.0__'
     },
     'Category.Category Parameter': {
         ...TRACKED_FIELDS_BY_QUERYNAME['Category.Category Parameter'],
-        placeholder: '__1__'
+        placeholder: '__dataset.1__'
     },
     'Financials.$ Profit': {
         ...TRACKED_FIELDS_BY_QUERYNAME['Financials.$ Profit'],
-        placeholder: '__2__'
+        placeholder: '__dataset.2__'
     }
 };
 
@@ -1141,35 +1250,37 @@ describe('getPublishableUsermeta — dataset key remapping by name', () => {
 
     it('should remap dataset keys from placeholder to tracker placeholder via name lookup', () => {
         // In production, dataset entries arrive with positional placeholder keys
-        // (__0__, __1__, __2__) that may not match the tracker's assignments.
+        // (__dataset.0__, __dataset.1__, __dataset.2__) that may not match the tracker's assignments.
         const usermeta: UsermetaTemplate = {
             ...EXPECTED_METADATA_BASE,
-            dataset: [
-                {
-                    key: '__0__',
-                    name: '$ Sales',
-                    namePlaceholder: '$ Sales',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                },
-                {
-                    key: '__1__',
-                    name: '$ Profit',
-                    namePlaceholder: '$ Profit',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                },
-                {
-                    key: '__2__',
-                    name: 'Category Parameter',
-                    namePlaceholder: 'Category Parameter',
-                    description: '',
-                    kind: 'parameter',
-                    type: 'other'
-                }
-            ]
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: '$ Sales',
+                        namePlaceholder: '$ Sales',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    },
+                    {
+                        key: '__dataset.1__',
+                        name: '$ Profit',
+                        namePlaceholder: '$ Profit',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    },
+                    {
+                        key: '__dataset.2__',
+                        name: 'Category Parameter',
+                        namePlaceholder: 'Category Parameter',
+                        description: '',
+                        kind: 'parameter',
+                        type: 'other'
+                    }
+                ]
+            }
         };
 
         const result = getPublishableUsermeta(usermeta, {
@@ -1178,46 +1289,48 @@ describe('getPublishableUsermeta — dataset key remapping by name', () => {
         });
 
         // All three should map correctly via name lookup
-        expect(result.dataset[0].key).toBe('__0__');
-        expect(result.dataset[0].name).toBe('$ Sales');
-        expect(result.dataset[1].key).toBe('__1__');
-        expect(result.dataset[1].name).toBe('$ Profit');
-        expect(result.dataset[2].key).toBe('__2__');
-        expect(result.dataset[2].name).toBe('Category Parameter');
+        expect(result.datasets.dataset[0].key).toBe('__dataset.0__');
+        expect(result.datasets.dataset[0].name).toBe('$ Sales');
+        expect(result.datasets.dataset[1].key).toBe('__dataset.1__');
+        expect(result.datasets.dataset[1].name).toBe('$ Profit');
+        expect(result.datasets.dataset[2].key).toBe('__dataset.2__');
+        expect(result.datasets.dataset[2].name).toBe('Category Parameter');
     });
 
     it('should use tracker placeholders even when tracker order differs from dataset order', () => {
-        // Dataset array: $ Sales (__0__), $ Profit (__1__), Category Parameter (__2__)
-        // Tracker order: $ Sales (__0__), Category Parameter (__1__), $ Profit (__2__)
+        // Dataset array: $ Sales (__dataset.0__), $ Profit (__dataset.1__), Category Parameter (__dataset.2__)
+        // Tracker order: $ Sales (__dataset.0__), Category Parameter (__dataset.1__), $ Profit (__dataset.2__)
         // The dataset keys should be remapped to match the tracker's assignments.
         const usermeta: UsermetaTemplate = {
             ...EXPECTED_METADATA_BASE,
-            dataset: [
-                {
-                    key: '__0__',
-                    name: '$ Sales',
-                    namePlaceholder: '$ Sales',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                },
-                {
-                    key: '__1__',
-                    name: '$ Profit',
-                    namePlaceholder: '$ Profit',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                },
-                {
-                    key: '__2__',
-                    name: 'Category Parameter',
-                    namePlaceholder: 'Category Parameter',
-                    description: '',
-                    kind: 'parameter',
-                    type: 'other'
-                }
-            ]
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: '$ Sales',
+                        namePlaceholder: '$ Sales',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    },
+                    {
+                        key: '__dataset.1__',
+                        name: '$ Profit',
+                        namePlaceholder: '$ Profit',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    },
+                    {
+                        key: '__dataset.2__',
+                        name: 'Category Parameter',
+                        namePlaceholder: 'Category Parameter',
+                        description: '',
+                        kind: 'parameter',
+                        type: 'other'
+                    }
+                ]
+            }
         };
 
         const result = getPublishableUsermeta(usermeta, {
@@ -1226,24 +1339,26 @@ describe('getPublishableUsermeta — dataset key remapping by name', () => {
         });
 
         // Keys should be remapped to match the tracker (not the positional index)
-        expect(result.dataset[0].key).toBe('__0__'); // $ Sales: tracker says __0__
-        expect(result.dataset[1].key).toBe('__2__'); // $ Profit: tracker says __2__ (was __1__)
-        expect(result.dataset[2].key).toBe('__1__'); // Category Parameter: tracker says __1__ (was __2__)
+        expect(result.datasets.dataset[0].key).toBe('__dataset.0__'); // $ Sales: tracker says __dataset.0__
+        expect(result.datasets.dataset[1].key).toBe('__dataset.2__'); // $ Profit: tracker says __dataset.2__ (was __dataset.1__)
+        expect(result.datasets.dataset[2].key).toBe('__dataset.1__'); // Category Parameter: tracker says __dataset.1__ (was __dataset.2__)
     });
 
     it('should fall back to existing key when field is not in trackedFields', () => {
         const usermeta: UsermetaTemplate = {
             ...EXPECTED_METADATA_BASE,
-            dataset: [
-                {
-                    key: '__0__',
-                    name: 'Unknown Field',
-                    namePlaceholder: 'Unknown Field',
-                    description: '',
-                    kind: 'column',
-                    type: 'text'
-                }
-            ]
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: 'Unknown Field',
+                        namePlaceholder: 'Unknown Field',
+                        description: '',
+                        kind: 'column',
+                        type: 'text'
+                    }
+                ]
+            }
         };
 
         const result = getPublishableUsermeta(usermeta, {
@@ -1252,22 +1367,24 @@ describe('getPublishableUsermeta — dataset key remapping by name', () => {
         });
 
         // No match in tracker → key stays as-is
-        expect(result.dataset[0].key).toBe('__0__');
+        expect(result.datasets.dataset[0].key).toBe('__dataset.0__');
     });
 
     it('should strip namePlaceholder from output', () => {
         const usermeta: UsermetaTemplate = {
             ...EXPECTED_METADATA_BASE,
-            dataset: [
-                {
-                    key: '__0__',
-                    name: '$ Sales',
-                    namePlaceholder: '$ Sales',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                }
-            ]
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: '$ Sales',
+                        namePlaceholder: '$ Sales',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    }
+                ]
+            }
         };
 
         const result = getPublishableUsermeta(usermeta, {
@@ -1275,7 +1392,9 @@ describe('getPublishableUsermeta — dataset key remapping by name', () => {
             trackedFields: TRACKED_FIELDS_BY_QUERYNAME
         });
 
-        expect(result.dataset[0]).not.toHaveProperty('namePlaceholder');
+        expect(result.datasets.dataset[0]).not.toHaveProperty(
+            'namePlaceholder'
+        );
     });
 });
 
@@ -1307,24 +1426,26 @@ describe('getPublishableUsermeta — supportFieldConfiguration inline in dataset
         };
         const usermeta: UsermetaTemplate = {
             ...EXPECTED_METADATA_BASE,
-            dataset: [
-                {
-                    key: '__0__',
-                    name: '$ Sales',
-                    namePlaceholder: '$ Sales',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                },
-                {
-                    key: '__1__',
-                    name: '$ Profit',
-                    namePlaceholder: '$ Profit',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                }
-            ]
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: '$ Sales',
+                        namePlaceholder: '$ Sales',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    },
+                    {
+                        key: '__dataset.1__',
+                        name: '$ Profit',
+                        namePlaceholder: '$ Profit',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    }
+                ]
+            }
         };
 
         const result = getPublishableUsermeta(usermeta, {
@@ -1334,14 +1455,14 @@ describe('getPublishableUsermeta — supportFieldConfiguration inline in dataset
         });
 
         // Config should be embedded inline in each dataset entry
-        expect(result.dataset[0].supportFieldConfiguration).toEqual({
+        expect(result.datasets.dataset[0].supportFieldConfiguration).toEqual({
             highlight: true,
             highlightStatus: false,
             highlightComparator: false,
             format: false,
             formatted: false
         });
-        expect(result.dataset[1].supportFieldConfiguration).toEqual({
+        expect(result.datasets.dataset[1].supportFieldConfiguration).toEqual({
             highlight: true,
             highlightStatus: true,
             highlightComparator: false,
@@ -1353,16 +1474,18 @@ describe('getPublishableUsermeta — supportFieldConfiguration inline in dataset
     it('should not embed config for fields with no matching config entry', () => {
         const usermeta: UsermetaTemplate = {
             ...EXPECTED_METADATA_BASE,
-            dataset: [
-                {
-                    key: '__0__',
-                    name: '$ Sales',
-                    namePlaceholder: '$ Sales',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                }
-            ]
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: '$ Sales',
+                        namePlaceholder: '$ Sales',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    }
+                ]
+            }
         };
 
         const result = getPublishableUsermeta(usermeta, {
@@ -1371,7 +1494,7 @@ describe('getPublishableUsermeta — supportFieldConfiguration inline in dataset
             trackedFields: TRACKED_FIELDS_BY_QUERYNAME
         });
 
-        expect(result.dataset[0]).not.toHaveProperty(
+        expect(result.datasets.dataset[0]).not.toHaveProperty(
             'supportFieldConfiguration'
         );
     });
@@ -1379,16 +1502,18 @@ describe('getPublishableUsermeta — supportFieldConfiguration inline in dataset
     it('should not embed config when supportFieldConfiguration option is undefined', () => {
         const usermeta: UsermetaTemplate = {
             ...EXPECTED_METADATA_BASE,
-            dataset: [
-                {
-                    key: '__0__',
-                    name: '$ Sales',
-                    namePlaceholder: '$ Sales',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                }
-            ]
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: '$ Sales',
+                        namePlaceholder: '$ Sales',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    }
+                ]
+            }
         };
 
         const result = getPublishableUsermeta(usermeta, {
@@ -1396,7 +1521,7 @@ describe('getPublishableUsermeta — supportFieldConfiguration inline in dataset
             trackedFields: TRACKED_FIELDS_BY_QUERYNAME
         });
 
-        expect(result.dataset[0]).not.toHaveProperty(
+        expect(result.datasets.dataset[0]).not.toHaveProperty(
             'supportFieldConfiguration'
         );
     });
@@ -1415,32 +1540,34 @@ describe('getPublishableUsermeta — supportFieldConfiguration inline in dataset
         };
         const usermeta: UsermetaTemplate = {
             ...EXPECTED_METADATA_BASE,
-            dataset: [
-                {
-                    key: '__0__',
-                    name: '$ Sales',
-                    namePlaceholder: '$ Sales',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                },
-                {
-                    key: '__1__',
-                    name: '$ Profit',
-                    namePlaceholder: '$ Profit',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                },
-                {
-                    key: '__2__',
-                    name: 'Category Parameter',
-                    namePlaceholder: 'Category Parameter',
-                    description: '',
-                    kind: 'parameter',
-                    type: 'other'
-                }
-            ]
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: '$ Sales',
+                        namePlaceholder: '$ Sales',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    },
+                    {
+                        key: '__dataset.1__',
+                        name: '$ Profit',
+                        namePlaceholder: '$ Profit',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    },
+                    {
+                        key: '__dataset.2__',
+                        name: 'Category Parameter',
+                        namePlaceholder: 'Category Parameter',
+                        description: '',
+                        kind: 'parameter',
+                        type: 'other'
+                    }
+                ]
+            }
         };
 
         const result = getPublishableUsermeta(usermeta, {
@@ -1450,13 +1577,13 @@ describe('getPublishableUsermeta — supportFieldConfiguration inline in dataset
         });
 
         // Only Category Parameter should have config embedded
-        expect(result.dataset[0]).not.toHaveProperty(
+        expect(result.datasets.dataset[0]).not.toHaveProperty(
             'supportFieldConfiguration'
         );
-        expect(result.dataset[1]).not.toHaveProperty(
+        expect(result.datasets.dataset[1]).not.toHaveProperty(
             'supportFieldConfiguration'
         );
-        expect(result.dataset[2].supportFieldConfiguration).toEqual({
+        expect(result.datasets.dataset[2].supportFieldConfiguration).toEqual({
             highlight: false,
             highlightStatus: false,
             highlightComparator: false,
@@ -1472,7 +1599,7 @@ describe('remapSupportFieldConfigurationForImport', () => {
     it('should extract inline config from dataset entries keyed by suppliedObjectName', () => {
         const dataset: UsermetaDatasetField[] = [
             {
-                key: '__0__',
+                key: '__dataset.0__',
                 name: 'Date',
                 suppliedObjectName: 'Order Date',
                 kind: 'column',
@@ -1486,7 +1613,7 @@ describe('remapSupportFieldConfigurationForImport', () => {
                 }
             },
             {
-                key: '__1__',
+                key: '__dataset.1__',
                 name: '$ Sales',
                 suppliedObjectName: 'Revenue',
                 kind: 'measure',
@@ -1529,7 +1656,7 @@ describe('remapSupportFieldConfigurationForImport', () => {
     it('should skip fields without supportFieldConfiguration', () => {
         const dataset: UsermetaDatasetField[] = [
             {
-                key: '__0__',
+                key: '__dataset.0__',
                 name: 'Date',
                 suppliedObjectName: 'Order Date',
                 kind: 'column',
@@ -1544,7 +1671,7 @@ describe('remapSupportFieldConfigurationForImport', () => {
     it('should skip fields without suppliedObjectName', () => {
         const dataset: UsermetaDatasetField[] = [
             {
-                key: '__0__',
+                key: '__dataset.0__',
                 name: 'Date',
                 kind: 'column',
                 type: 'dateTime',
@@ -1578,32 +1705,34 @@ describe('remapSupportFieldConfigurationForImport', () => {
         };
         const exportUsermeta: UsermetaTemplate = {
             ...EXPECTED_METADATA_BASE,
-            dataset: [
-                {
-                    key: '__0__',
-                    name: '$ Sales',
-                    namePlaceholder: '$ Sales',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                },
-                {
-                    key: '__1__',
-                    name: '$ Profit',
-                    namePlaceholder: '$ Profit',
-                    description: '',
-                    kind: 'measure',
-                    type: 'numeric'
-                },
-                {
-                    key: '__2__',
-                    name: 'Category Parameter',
-                    namePlaceholder: 'Category Parameter',
-                    description: '',
-                    kind: 'parameter',
-                    type: 'other'
-                }
-            ]
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: '$ Sales',
+                        namePlaceholder: '$ Sales',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    },
+                    {
+                        key: '__dataset.1__',
+                        name: '$ Profit',
+                        namePlaceholder: '$ Profit',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    },
+                    {
+                        key: '__dataset.2__',
+                        name: 'Category Parameter',
+                        namePlaceholder: 'Category Parameter',
+                        description: '',
+                        kind: 'parameter',
+                        type: 'other'
+                    }
+                ]
+            }
         };
 
         const exportResult = getPublishableUsermeta(exportUsermeta, {
@@ -1617,7 +1746,9 @@ describe('remapSupportFieldConfigurationForImport', () => {
         });
 
         // Export should embed config on Category Parameter (index 2)
-        expect(exportResult.dataset[2].supportFieldConfiguration).toEqual({
+        expect(
+            exportResult.datasets.dataset[2].supportFieldConfiguration
+        ).toEqual({
             highlight: false,
             highlightStatus: false,
             highlightComparator: false,
@@ -1630,27 +1761,27 @@ describe('remapSupportFieldConfigurationForImport', () => {
         // Now import it back with a user-supplied field name
         const importDataset: UsermetaDatasetField[] = [
             {
-                key: '__0__',
+                key: '__dataset.0__',
                 name: '$ Sales',
                 suppliedObjectName: 'Revenue',
                 kind: 'measure',
                 type: 'numeric'
             },
             {
-                key: '__1__',
+                key: '__dataset.1__',
                 name: '$ Profit',
                 suppliedObjectName: 'Gross Profit',
                 kind: 'measure',
                 type: 'numeric'
             },
             {
-                key: '__2__',
+                key: '__dataset.2__',
                 name: 'Category Parameter',
                 suppliedObjectName: 'Region Parameter',
                 kind: 'parameter',
                 type: 'other',
                 supportFieldConfiguration:
-                    exportResult.dataset[2].supportFieldConfiguration
+                    exportResult.datasets.dataset[2].supportFieldConfiguration
             }
         ];
 

--- a/packages/json-processing/src/__test__/validation.test.ts
+++ b/packages/json-processing/src/__test__/validation.test.ts
@@ -22,7 +22,7 @@ describe('getProviderValidator', () => {
                 generated: '2024-01-01T00:00:00.000Z',
                 author: 'Test Author'
             },
-            dataset: []
+            datasets: { dataset: [] }
         };
         const result = validate(validTemplate);
         expect(result).toBe(true);
@@ -46,5 +46,115 @@ describe('getProviderValidator', () => {
         const validate1 = getProviderValidator();
         const validate2 = getProviderValidator();
         expect(validate1.schema).toEqual(validate2.schema);
+    });
+
+    it('should accept a template with multiple dataset keys (forward compatibility)', () => {
+        const validate = getProviderValidator();
+        const multiDatasetTemplate = {
+            deneb: {
+                build: '1.0.0',
+                metaVersion: 2,
+                provider: 'vegaLite',
+                providerVersion: '5.0.0'
+            },
+            information: {
+                name: 'Multi-dataset Template',
+                uuid: '12345678-1234-4234-a234-123456789012',
+                generated: '2024-01-01T00:00:00.000Z',
+                author: 'Test Author'
+            },
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: 'Sales',
+                        type: 'numeric'
+                    }
+                ],
+                mapLayer: [
+                    {
+                        key: '__mapLayer.0__',
+                        name: 'Region',
+                        type: 'text'
+                    }
+                ]
+            }
+        };
+        const result = validate(multiDatasetTemplate);
+        expect(result).toBe(true);
+        expect(validate.errors).toBeNull();
+    });
+
+    it('should reject a template using the legacy "dataset" property (additionalProperties: false)', () => {
+        const validate = getProviderValidator();
+        const legacyTemplate = {
+            deneb: {
+                build: '1.0.0',
+                metaVersion: 1,
+                provider: 'vegaLite',
+                providerVersion: '5.0.0'
+            },
+            information: {
+                name: 'Legacy Template',
+                uuid: '12345678-1234-4234-a234-123456789012',
+                generated: '2024-01-01T00:00:00.000Z',
+                author: 'Test Author'
+            },
+            dataset: [{ key: '__0__', name: 'Sales', type: 'numeric' }]
+        };
+        const result = validate(legacyTemplate);
+        expect(result).toBe(false);
+        expect(validate.errors).not.toBeNull();
+    });
+
+    it('should reject a template containing both legacy dataset and new datasets', () => {
+        const validate = getProviderValidator();
+        const dualTemplate = {
+            deneb: {
+                build: '1.0.0',
+                metaVersion: 2,
+                provider: 'vegaLite',
+                providerVersion: '5.0.0'
+            },
+            information: {
+                name: 'Both Template',
+                uuid: '12345678-1234-4234-a234-123456789012',
+                generated: '2024-01-01T00:00:00.000Z',
+                author: 'Test Author'
+            },
+            dataset: [{ key: '__0__', name: 'Sales', type: 'numeric' }],
+            datasets: {
+                dataset: [
+                    { key: '__dataset.0__', name: 'Sales', type: 'numeric' }
+                ]
+            }
+        };
+        const result = validate(dualTemplate);
+        expect(result).toBe(false);
+        expect(validate.errors).not.toBeNull();
+    });
+
+    it('should reject placeholder keys not matching the dataset-scoped pattern', () => {
+        const validate = getProviderValidator();
+        const oldKeyTemplate = {
+            deneb: {
+                build: '1.0.0',
+                metaVersion: 2,
+                provider: 'vegaLite',
+                providerVersion: '5.0.0'
+            },
+            information: {
+                name: 'Old Key Template',
+                uuid: '12345678-1234-4234-a234-123456789012',
+                generated: '2024-01-01T00:00:00.000Z',
+                author: 'Test Author'
+            },
+            datasets: {
+                dataset: [{ key: '__0__', name: 'Sales', type: 'numeric' }]
+            }
+        };
+        const result = validate(oldKeyTemplate);
+        expect(result).toBe(false);
+        expect(validate.errors).not.toBeNull();
     });
 });

--- a/packages/json-processing/src/index.ts
+++ b/packages/json-processing/src/index.ts
@@ -19,6 +19,7 @@ export {
     getNewTemplateMetadata,
     getTemplateMetadata,
     getTemplateReplacedForDataset,
+    getTemplateResolvedForLegacyDataset,
     getTemplateResolvedForPlaceholderAssignment,
     getUpdatedExportMetadata,
     getValidatedTemplate,

--- a/packages/json-processing/src/lib/spec-processing/workers/field-tracking.ts
+++ b/packages/json-processing/src/lib/spec-processing/workers/field-tracking.ts
@@ -23,6 +23,7 @@ import {
     getPlaceholderKey,
     type UsermetaDatasetField
 } from '@deneb-viz/data-core/field';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 /**
  * For a Vega expression AST node, check if it has an occurrence of a field from the visual dataset.
@@ -173,9 +174,10 @@ export const getTrackingDataFromSpecification = (
         reset,
         supplementaryPatterns
     } = options;
-    const datasetFields = getDatasetFieldsInclusive(
-        fields
-    ) as Record<string, DatasetFieldWithTemplateMetadata>;
+    const datasetFields = getDatasetFieldsInclusive(fields) as Record<
+        string,
+        DatasetFieldWithTemplateMetadata
+    >;
     const trackedFields: TrackedFields = {};
     const trackedDrilldown: TrackedDrilldownProperties = {
         isCurrent: hasDrilldown,
@@ -227,7 +229,10 @@ export const getTrackingDataFromSpecification = (
                 };
                 const { key } = templateMetadata;
                 const tracking: TrackedFieldProperties = trackedFields[key] || {
-                    placeholder: getPlaceholderKey(fieldIndex),
+                    placeholder: getPlaceholderKey(
+                        DATASET_DEFAULT_NAME,
+                        fieldIndex
+                    ),
                     paths: [],
                     isInDataset: f.isCurrent,
                     isInSpecification: false,

--- a/packages/json-processing/src/template-dataset.ts
+++ b/packages/json-processing/src/template-dataset.ts
@@ -5,6 +5,7 @@ import {
     type UsermetaDatasetField,
     type UsermetaDatasetFieldType
 } from '@deneb-viz/data-core/field';
+import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
 
 /**
  * Ensure that all requirements are tested and validated before we can create.
@@ -13,7 +14,7 @@ export const areAllCreateDataRequirementsMet = (
     metadata: Partial<UsermetaTemplate> | null | undefined
 ): Partial<DenebTemplateImportWorkingProperties> => {
     const metadataAllFieldsAssigned = areAllTemplateFieldsAssigned(
-        metadata?.dataset ?? []
+        metadata?.datasets?.[DATASET_DEFAULT_NAME] ?? []
     );
     const metadataDrilldownAssigned = true; // to be implemented when drilldown is implemented
     const metadataAllDependenciesAssigned =

--- a/packages/json-processing/src/template-usermeta.ts
+++ b/packages/json-processing/src/template-usermeta.ts
@@ -347,7 +347,7 @@ export const getTemplateResolvedForLegacyDataset = (
     });
     result = getModifiedJsoncByPath(result, ['usermeta', 'dataset'], undefined);
 
-    for (let i = legacyDataset.length - 1; i >= 0; i--) {
+    for (let i = 0; i < legacyDataset.length; i++) {
         const oldPattern = new RegExp(
             getEscapedReplacerPattern(`__${i}__`),
             'g'

--- a/packages/json-processing/src/template-usermeta.ts
+++ b/packages/json-processing/src/template-usermeta.ts
@@ -101,8 +101,8 @@ export const getExportTemplate = (options: {
     return getTextFormattedAsJsonC(withSchema, 2);
 };
 
-const getFieldPattern = (index: number) =>
-    new RegExp(getEscapedReplacerPattern(getPlaceholderKey(index)), 'g');
+const getFieldPatternByKey = (key: string) =>
+    new RegExp(getEscapedReplacerPattern(key), 'g');
 
 /**
  * When we initialize a new template for import (or when intializing the store), this provides the default values for
@@ -153,7 +153,7 @@ export const getNewTemplateMetadata = (options: {
         highlight: INTERACTIVITY_DEFAULTS.enableHighlight
     },
     config: '{}',
-    dataset: []
+    datasets: { [DATASET_DEFAULT_NAME]: [] }
 });
 
 /**
@@ -215,21 +215,20 @@ export const getPublishableUsermeta = (
                     usermeta.information.author ||
                     options.informationTranslationPlaceholders.author
             },
-            dataset: (() => {
+            datasets: (() => {
                 const nameMap = buildNameToTrackedFieldMap(
                     options.trackedFields
                 );
-                return (usermeta?.[DATASET_DEFAULT_NAME] ?? []).map((d) => {
+                const sourceDatasets = usermeta?.datasets ?? {
+                    [DATASET_DEFAULT_NAME]: []
+                };
+                const processField = (d: UsermetaDatasetField) => {
                     const item = { ...d };
                     const tracked = nameMap.get(
                         item.namePlaceholder ?? item.name
                     );
                     item.key = tracked?.placeholder ?? item.key;
                     item.name = getFieldNameForExport(item);
-                    // Embed per-field support field configuration if present.
-                    // Config is keyed by encoded field name, but namePlaceholder
-                    // holds the raw display name — encode before lookup so fields
-                    // with reserved characters (. [ ] \ ") are not silently dropped.
                     const sfcKey = getEncodedFieldName(
                         item.namePlaceholder ?? item.name ?? ''
                     );
@@ -241,7 +240,13 @@ export const getPublishableUsermeta = (
                     return omit(item as unknown as Record<string, unknown>, [
                         'namePlaceholder'
                     ]) as Omit<UsermetaDatasetField, 'namePlaceholder'>;
-                });
+                };
+                return Object.fromEntries(
+                    Object.entries(sourceDatasets).map(([name, fields]) => [
+                        name,
+                        (fields ?? []).map(processField)
+                    ])
+                );
             })()
         }
     };
@@ -254,20 +259,24 @@ export const getTemplateProvider = (template: string): SpecProvider =>
     getTemplateMetadata(template)?.deneb?.provider ?? DEFAULT_PROVIDER;
 
 /**
- * For all supplied template fields, perform a replace on all tokens and return the new spec.
+ * For all supplied template datasets, perform a key-based replace on all placeholder tokens
+ * and return the new spec. Each field's `key` property (e.g., `__dataset.0__`) is matched
+ * directly rather than deriving the pattern from the array index.
  * Also migrates any legacy signal references (pbiContainer → denebContainer).
  */
 export const getTemplateReplacedForDataset = (
     spec: string,
-    dataset: UsermetaDatasetField[]
+    datasets: Record<string, UsermetaDatasetField[]>
 ) => {
-    // First, migrate any legacy signal references
     const migratedSpec = replaceLegacySignalReferences(spec).spec;
-    // Then replace field placeholders
-    return dataset.reduce((result, value, index) => {
-        const pattern = getFieldPattern(index);
-        return result.replace(pattern, value.suppliedObjectName ?? '');
-    }, migratedSpec);
+    return Object.values(datasets).reduce(
+        (result, fields) =>
+            fields.reduce((r, field) => {
+                const pattern = getFieldPatternByKey(field.key);
+                return r.replace(pattern, field.suppliedObjectName ?? '');
+            }, result),
+        migratedSpec
+    );
 };
 
 /**
@@ -300,6 +309,54 @@ export const getTemplateResolvedForLegacyConfig = (
         return removedConfig;
     }
     return template;
+};
+
+/**
+ * V1 templates use `usermeta.dataset` (a flat array) with `__N__` placeholders. V2 uses `usermeta.datasets` (a keyed
+ * object) with `__datasetName.N__` placeholders. This migration converts the old structure to the new one, rewriting
+ * both the usermeta property and placeholder references in the spec body.
+ *
+ * If `usermeta.datasets` already exists, the template is assumed to be v2 and passed through unchanged.
+ * If both `usermeta.dataset` and `usermeta.datasets` exist, the template is passed through unchanged — schema
+ * validation will reject it via `additionalProperties: false`.
+ */
+export const getTemplateResolvedForLegacyDataset = (
+    template: string
+): string => {
+    const rawUsermeta = getJsoncStringAsObject(template)?.usermeta as
+        | Record<string, unknown>
+        | undefined;
+    if (!rawUsermeta) return template;
+
+    const hasLegacyDataset = Array.isArray(rawUsermeta['dataset']);
+    const hasNewDatasets = rawUsermeta['datasets'] !== undefined;
+
+    if (!hasLegacyDataset || hasNewDatasets) {
+        return template;
+    }
+
+    const legacyDataset = rawUsermeta['dataset'] as UsermetaDatasetField[];
+
+    const migratedFields = legacyDataset.map((field, i) => ({
+        ...field,
+        key: getPlaceholderKey(DATASET_DEFAULT_NAME, i)
+    }));
+
+    let result = getModifiedJsoncByPath(template, ['usermeta', 'datasets'], {
+        [DATASET_DEFAULT_NAME]: migratedFields
+    });
+    result = getModifiedJsoncByPath(result, ['usermeta', 'dataset'], undefined);
+
+    for (let i = legacyDataset.length - 1; i >= 0; i--) {
+        const oldPattern = new RegExp(
+            getEscapedReplacerPattern(`__${i}__`),
+            'g'
+        );
+        const newKey = getPlaceholderKey(DATASET_DEFAULT_NAME, i);
+        result = result.replace(oldPattern, newKey);
+    }
+
+    return result;
 };
 
 /**
@@ -358,13 +415,13 @@ export const getUpdatedExportMetadata = (
     metadata: UsermetaTemplate,
     options: {
         config?: string;
-        dataset?: UsermetaDatasetField[];
+        datasets?: Record<string, UsermetaDatasetField[]>;
         interactivity?: UsermetaInteractivity;
         provider?: SpecProvider;
         providerVersion?: string;
     }
 ) => {
-    const { config, dataset, interactivity, provider, providerVersion } =
+    const { config, datasets, interactivity, provider, providerVersion } =
         options;
     return {
         ...metadata,
@@ -374,7 +431,7 @@ export const getUpdatedExportMetadata = (
             providerVersion: providerVersion ?? metadata.deneb.providerVersion
         },
         interactivity: interactivity ?? metadata.interactivity,
-        dataset: dataset ?? metadata.dataset,
+        datasets: datasets ?? metadata.datasets,
         config: config ?? metadata.config
     };
 };
@@ -408,12 +465,14 @@ export const getValidatedTemplate = (
             templateResolvedLegacy,
             tabSize
         );
-        const metadata = getTemplateMetadata(templateResolvedLegacyConfig);
+        const templateResolvedLegacyDataset =
+            getTemplateResolvedForLegacyDataset(templateResolvedLegacyConfig);
+        const metadata = getTemplateMetadata(templateResolvedLegacyDataset);
         const validator = getProviderValidator();
         const valid = validator(metadata);
         if (valid) {
             const candidates = getTemplateResolvedForPlaceholderAssignment(
-                templateResolvedLegacyConfig,
+                templateResolvedLegacyDataset,
                 tabSize
             );
             return {

--- a/packages/template-usermeta/src/types.ts
+++ b/packages/template-usermeta/src/types.ts
@@ -4,6 +4,7 @@ import type { SelectionMode } from '@deneb-viz/powerbi-compat/interactivity';
 
 /**
  * Main template definition.
+ * @additionalProperties false
  */
 export interface UsermetaTemplate {
     /**
@@ -15,10 +16,10 @@ export interface UsermetaTemplate {
      */
     information: UsermetaInformation;
     /**
-     * Dataset columns or measures used by the template, that the end-user will need to supply for it to work.
-     * @uniqueItems true
+     * Named datasets used by the template. Each key is a dataset name (e.g., 'dataset') and each value is
+     * an array of field definitions the end-user will need to supply for it to work.
      */
-    dataset: UsermetaDatasetField[];
+    datasets: Record<string, UsermetaDatasetField[]>;
     /**
      * Any interactivity settings that we want to explicitly set.
      */


### PR DESCRIPTION
## Summary

Restructures the template serialization format from singular `usermeta.dataset` (flat array) to plural `usermeta.datasets` (Record keyed by dataset name), stabilizing the external template contract before v2 ships. Placeholders gain a dataset-scoped form with a dot separator (`__dataset.0__`).

**Scope is deliberately limited to the serialization format.** Internal Zustand state (`state.dataset`) is unchanged — the runtime continues to process a single dataset. This is architectural preparation, not a feature addition.

## Why now

If multi-dataset support is or can be eventually added (e.g., map layers via conditional formatting), restructuring the template format later would be a breaking v2 > v3 migration. Since v2 is unreleased, we can modify the schema in-place now with only v1 > v2 import migration needed.

## Changes

### Template schema

- `UsermetaTemplate.dataset: UsermetaDatasetField[]` > `UsermetaTemplate.datasets: Record<string, UsermetaDatasetField[]>`
- Default dataset uses key `'dataset'` (matching `DATASET_DEFAULT_NAME`)
- Placeholder pattern updated: `^__[a-zA-Z0-9]+__$` > `^__[a-zA-Z0-9_]+\.\d+__$`
- Explicit `@additionalProperties false` on `UsermetaTemplate` (tripwire against generator config changes)
- JSON schema regenerated from TypeScript types via `ts-json-schema-generator`

### Placeholder format

- `__0__` > `__dataset.0__` (dataset-scoped with dot separator)
- `getPlaceholderKey(i)` > `getPlaceholderKey(datasetName, i)`
- Dot chosen as separator because it cannot appear in dataset names - unambiguous parsing

### V1 import migration

New `getTemplateResolvedForLegacyDataset` runs before schema validation:

- Wraps `usermeta.dataset` > `usermeta.datasets.dataset`
- Rewrites spec body placeholders in reverse order (prevents `__1__` matching inside `__10__`)
- Preserves compound suffixes (`__1____highlight` > `__dataset.1____highlight`)
- Templates with both `dataset` and `datasets` fall through to schema validation, which rejects them via `additionalProperties: false`

### Replacement logic

`getTemplateReplacedForDataset` switched from index-based to **key-based matching** - each field's `key` property drives the regex directly. Reordering fields no longer changes behavior.

### State / export boundary

The `metadata.dataset` access path is updated to `metadata.datasets[DATASET_DEFAULT_NAME]` across the serialization boundary (state slices, components, string-based deep-path selectors that TypeScript can't catch).

State mutations spread existing datasets before overlaying the default key, so non-default dataset entries survive state transitions. `getPublishableUsermeta` iterates all dataset keys on export - multi-dataset templates round-trip correctly.

### Built-in catalog

All 8 catalog templates use the new `datasets` structure with template-literal placeholders (`` `__${DATASET_DEFAULT_NAME}.N__` ``) - decoupled from the constant value so everything stays coherent if the default ever changes.

## Test plan

- [x] `npm run test` - 591 tests passing across 6 packages
- [x] `tsc --noEmit` - clean across all packages
- [x] `npm run build:schema` - regenerated JSON schema verified to require `datasets`, reject `dataset`, and enforce the new placeholder pattern
- [x] New test coverage added:
  - 9 direct tests for `getTemplateResolvedForLegacyDataset` (empty array, compound placeholders, multi-digit indices, Vega expression strings, V2 pass-through, both-keys pass-through, absent usermeta)
  - 4 schema validation tests (forward compat with multiple dataset keys, legacy property rejection, dual-key rejection, old placeholder pattern rejection)
  - Strengthened `getValidatedTemplate` assertion with structural deep-equality
- [x] Manual verification: import a v1 template, confirm it migrates to the new structure and renders correctly
- [x] Manual verification: export a template from a clean project, confirm the output uses the new `datasets` structure and passes schema validation

## Scope boundaries (out of scope)

- No new dataset types (spatial etc.) - only structural foundation changes
- No multi-dataset UI (editor, export dialog, field assignment show single dataset)
- No internal Zustand state restructuring (`state.dataset` stays singular)
- No incremental update changes (`performIncrementalUpdate` targets single dataset)
- No Power BI data role changes (`DATASET_DEFAULT_NAME` stays `'dataset'`, capabilities.json unchanged)

## Documents

- Requirements: [`docs/brainstorms/2026-04-14-multi-dataset-template-structure-requirements.md`](docs/brainstorms/2026-04-14-multi-dataset-template-structure-requirements.md)
- Plan: [`docs/plans/2026-04-14-001-refactor-multi-dataset-template-schema-plan.md`](docs/plans/2026-04-14-001-refactor-multi-dataset-template-schema-plan.md)

## Review notes

Code review identified and addressed a critical consistency issue: the type signature committed to multi-dataset support but every state mutation destructively replaced the `datasets` object. All 10+ affected sites were updated to spread existing datasets, closing the gap between the type contract and the implementation. Additional test coverage was added for the migration function and forward-compatibility scenarios. See `.context/compound-engineering/ce-review/20260416-085326-13015cc0/synthesis.md` for the full review artifact.
