### PR TITLE
fix: inspector testing remediations (#450)

### DIFF
--- a/docs/solutions/best-practices/pure-setstate-updaters-no-dom-side-effects-2026-04-21.md
+++ b/docs/solutions/best-practices/pure-setstate-updaters-no-dom-side-effects-2026-04-21.md
@@ -1,6 +1,7 @@
 ---
 title: "React setState updaters must be pure: use render-synced refs for DOM side effects"
 date: 2026-04-21
+last_updated: 2026-04-22
 category: best-practices
 module: react-state-management
 problem_type: best_practice
@@ -11,16 +12,16 @@ applies_when:
   - Focus management must run after a state dispatch but relies on a value that was in state at dispatch time
   - Components run under React StrictMode, where updater double-invocation is intentional and will expose impure updaters
   - Keyboard navigation handlers dispatch state updates and must also move DOM focus in the same logical operation
-  - Any callback that would otherwise capture stale state via closure and is also responsible for a DOM mutation or imperative API call
+  - A context provider exposes both a dismiss action and a refresh/reopen action that can fire in the same event-loop tick from different sources (a user event and a subscription tick)
 tags:
   - react
   - setstate
   - pure-functions
-  - focus-management
   - useref
   - strict-mode
   - concurrent-rendering
-  - keyboard-navigation
+  - race-condition
+  - context-actions
 ---
 
 # React setState updaters must be pure: use render-synced refs for DOM side effects
@@ -77,6 +78,8 @@ The render-body line `stateRef.current = state` is the key idiom. It runs on eve
 **Concurrent rendering.** In concurrent mode React may interrupt, replay, or re-order work. A pending updater can be re-invoked between scheduling and commit. DOM mutations inside an updater can therefore fire at arbitrary points relative to the DOM's actual committed state, meaning the element being focused may no longer be in the position the updater expects.
 
 **Same-tick duplicate calls.** When two separate event handlers both call the same closing/resetting action in a single event-loop tick (a common pattern with Fluent UI popover `onOpenChange` and a manual outside-click listener), an impure updater has no safe way to detect it has already run. The `prev` snapshot passed to the second invocation may still show `isOpen: true` if the first `setState` has not yet been processed. See Example 2 for the idempotence pattern that solves this.
+
+**Same-tick cross-action races.** The same problem extends to different actions on the same state. When a context provider exposes both a close action and a refresh (or reopen) action, and the refresh is callable from a `useEffect` reacting to external-source updates (a Vega signal tick, a `setInterval`, a WebSocket message — anything not originating inside a React event handler), the two updates are not batched into a single render. They commit in the same tick but carry independent render-closure snapshots. A `useEffect` that reads `isOpen` from `useContext` to decide whether to refresh sees the snapshot from its render, which may predate the close. The refresh dispatches, and the popover reopens after the user dismissed it. See Example 3 for the `refreshInspector` pattern that solves this with the same `stateRef` primitive plus a narrow action signature.
 
 ## Examples
 
@@ -146,7 +149,77 @@ const closeInspector = useCallback(() => {
 
 The critical line is `stateRef.current = INSPECTOR_POPOVER_CLOSED_STATE` placed before `setState`. Because `setState` is asynchronous and `stateRef.current` is a mutable object, the synchronous assignment makes the closed state immediately visible to any code that reads the ref within the same synchronous execution context. A second call to `closeInspector` in the same tick reads `stateRef.current.isOpen === false` and returns early, preventing the focus side effect from firing twice.
 
+### Example 3 — Cross-action race: `refreshInspector` vs `closeInspector` (second follow-up round)
+
+A later PR added a live-refresh path: cells whose underlying values change beneath an already-open inspector (a signal-viewer cell whose Vega signal ticks every second) dispatch a refresh from a `useEffect`. The first attempt reused `openInspector` with a React-context-sourced `isOpenForCellId` guard at the effect boundary — and hit the same stale-closure problem as Example 2, just across two different actions instead of two invocations of the same action.
+
+```tsx
+// BROKEN: the guard reads React context — one render stale relative to stateRef.
+useEffect(() => {
+    if (!cellId || !inspector) return;
+    if (!isOpenForCellId(inspector, cellId)) return;   // ← stale snapshot
+    inspector.openInspector(cellRef, rawValue, valueType, cellId);
+}, [rawValue, valueType, cellId, inspector]);
+```
+
+If `closeInspector` commits in the same tick as a signal update, the effect from the pre-close render runs with `inspector.isOpen === true` in its closure. The guard passes. `openInspector` is dispatched. The popover reopens after dismissal.
+
+The fix pairs the `stateRef` primitive from Example 2 with a narrow, purpose-built action:
+
+```tsx
+// In the provider — `refreshInspector` is the authoritative gate.
+const refreshInspector = useCallback(
+    (rawValue: unknown, valueType: WorkerDatasetViewerValueType) => {
+        // Read isOpen from the synchronously-maintained ref, not from
+        // closure or React state. `closeInspector` has already flipped
+        // this to false before scheduling its setState, so any
+        // concurrent refresh in the same tick bails.
+        if (!stateRef.current.isOpen) return;
+        const next = { ...stateRef.current, rawValue, valueType };
+        stateRef.current = next;   // mirror before dispatch, as in Example 2
+        setState(next);
+    },
+    []
+);
+```
+
+```tsx
+// In the cell — the cross-cell scoping check still runs at the effect
+// boundary, but the authoritative isOpen check happens inside the dispatch.
+useEffect(() => {
+    if (!cellId || !inspector) return;
+    if (valueType === undefined) return;
+    if (!shouldRefreshInspector(inspector, cellId, rawValue, valueType)) return;
+    inspector.refreshInspector(rawValue, valueType);
+}, [rawValue, valueType, cellId, inspector]);
+```
+
+Two design points beyond the `stateRef` read:
+
+**Narrow signature as compile-time invariant.** `refreshInspector(rawValue, valueType)` has no `anchorRef` parameter and no `cellId` parameter. It spreads `stateRef.current` for the other fields, so identity fields are structurally immutable across any refresh. A future caller cannot accidentally route a retarget through this path with a different `cellId`, because the TypeScript signature does not permit it. The runtime invariant ("refresh never changes which cell is open") becomes a compile-time guarantee.
+
+**Extracted predicate for unit testing.** The three-branch cross-cell scoping logic is extracted as a pure function alongside `isOpenForCellId`:
+
+```tsx
+export const shouldRefreshInspector = (
+    state: Pick<InspectorPopoverState, 'isOpen' | 'cellId' | 'rawValue' | 'valueType'>,
+    cellId: string,
+    rawValue: unknown,
+    valueType: WorkerDatasetViewerValueType
+): boolean => {
+    if (!isOpenForCellId(state, cellId)) return false;
+    if (
+        Object.is(state.rawValue, rawValue) &&
+        state.valueType === valueType
+    ) return false;
+    return true;
+};
+```
+
+`Object.is` is used rather than `===` because it handles `NaN` correctly (a tick from `NaN` to `NaN` is a no-op, where `===` would treat them as different and dispatch a redundant refresh). The predicate is fully testable without mounting React. The authoritative `isOpen` check remains inside `refreshInspector` itself — the effect-boundary predicate suppresses spurious dispatch work, but the race guard is at the dispatch layer where `stateRef` is accessible.
+
 ## Related
 
 - [`docs/solutions/ui-bugs/modal-dialog-tab-trapped-by-keyboard-focus-handler-2026-04-10.md`](../ui-bugs/modal-dialog-tab-trapped-by-keyboard-focus-handler-2026-04-10.md) — covers the document-level keyboard handler side of the same focus feature this learning addresses (the React callback side). Together they form a complete picture of the focus feature's two problem zones.
 - Commits in `feat/additional-complex-object-debugging`: `689c7d77` (Wave 1 — initial fix across both contexts), `fd6f9237` (self-idempotent `closeInspector`).
+- Commits in `fix/inspector-testing-remediations`: `0c578f06` (Example 3 — `refreshInspector` action with synchronous close guard and extracted `shouldRefreshInspector` predicate).

--- a/packages/app-core/src/features/debug-area/components/data-table/__tests__/inspector-popover-context.test.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/__tests__/inspector-popover-context.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
     INSPECTOR_POPOVER_CLOSED_STATE,
-    isOpenForCellId
+    isOpenForCellId,
+    shouldRefreshInspector
 } from '../inspector-popover-context';
 
 describe('INSPECTOR_POPOVER_CLOSED_STATE', () => {
@@ -40,5 +41,70 @@ describe('isOpenForCellId', () => {
         expect(isOpenForCellId({ isOpen: true, cellId: null }, 'any')).toBe(
             false
         );
+    });
+});
+
+describe('shouldRefreshInspector', () => {
+    const openState = {
+        isOpen: true as const,
+        cellId: 'row-1:value',
+        rawValue: 42 as unknown,
+        valueType: 'number' as const
+    };
+
+    it('returns true when the cell matches and values differ', () => {
+        expect(
+            shouldRefreshInspector(openState, 'row-1:value', 43, 'number')
+        ).toBe(true);
+    });
+
+    it('returns false when the inspector is closed', () => {
+        expect(
+            shouldRefreshInspector(
+                { ...openState, isOpen: false },
+                'row-1:value',
+                43,
+                'number'
+            )
+        ).toBe(false);
+    });
+
+    it('returns false when the inspector targets a different cell', () => {
+        expect(
+            shouldRefreshInspector(openState, 'row-2:value', 43, 'number')
+        ).toBe(false);
+    });
+
+    it('returns false when both rawValue and valueType are unchanged', () => {
+        expect(
+            shouldRefreshInspector(openState, 'row-1:value', 42, 'number')
+        ).toBe(false);
+    });
+
+    it('returns true when only valueType changes', () => {
+        expect(
+            shouldRefreshInspector(openState, 'row-1:value', 42, 'string')
+        ).toBe(true);
+    });
+
+    it('treats NaN as equal to NaN (no refresh for a NaN-valued tick)', () => {
+        const nanState = { ...openState, rawValue: NaN };
+        expect(
+            shouldRefreshInspector(nanState, 'row-1:value', NaN, 'number')
+        ).toBe(false);
+    });
+
+    it('distinguishes +0 from -0 (Object.is semantics, not ===)', () => {
+        const zeroState = { ...openState, rawValue: +0 };
+        expect(
+            shouldRefreshInspector(zeroState, 'row-1:value', -0, 'number')
+        ).toBe(true);
+    });
+
+    it('treats a fresh object reference with identical content as a refresh (caller memoises upstream)', () => {
+        const objState = { ...openState, rawValue: { a: 1 } };
+        expect(
+            shouldRefreshInspector(objState, 'row-1:value', { a: 1 }, 'object')
+        ).toBe(true);
     });
 });

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
@@ -135,6 +135,13 @@ export const DataTableCell = ({
     // state is already current).
     useEffect(() => {
         if (!cellId || !inspector) return;
+        // `cellId` non-null implies `canInspect` was true at memo time,
+        // which implies `valueType !== undefined` — but React can't follow
+        // that inference across render boundaries, so if a parent flips
+        // valueType to undefined in the same render that commits the
+        // effect, cellId may still be non-null. Guard explicitly rather
+        // than leaning on a non-null assertion.
+        if (valueType === undefined) return;
         if (!isOpenForCellId(inspector, cellId)) return;
         if (
             Object.is(inspector.rawValue, rawValue) &&
@@ -142,7 +149,7 @@ export const DataTableCell = ({
         ) {
             return;
         }
-        inspector.openInspector(cellRef, rawValue, valueType!, cellId);
+        inspector.openInspector(cellRef, rawValue, valueType, cellId);
     }, [rawValue, valueType, cellId, inspector]);
 
     // Both render branches wrap in the same Fluent Tooltip when there IS

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, type KeyboardEvent } from 'react';
-import { makeStyles, Tooltip } from '@fluentui/react-components';
+import { makeStyles } from '@fluentui/react-components';
 
 import {
     isCrossHighlightComparatorField,
@@ -23,7 +23,7 @@ import {
     useIsDataTableCellActive
 } from './data-table-keyboard-context';
 import { resolveCellKeyAction } from './data-table-keyboard-utils';
-import { useDataTableTooltip } from './data-table-tooltip-context';
+import { DataTableTooltip } from './data-table-tooltip';
 
 const useDataTableCellStyles = makeStyles({
     cell: {
@@ -86,7 +86,6 @@ export const DataTableCell = ({
 }: DataTableCellProps) => {
     const effectiveColumnId = columnId ?? field;
     const classes = useDataTableCellStyles();
-    const tooltipMountNode = useDataTableTooltip();
     const tooltipContent = getCellTooltip(
         field,
         rawValue,
@@ -152,27 +151,11 @@ export const DataTableCell = ({
         inspector.refreshInspector(rawValue, valueType);
     }, [rawValue, valueType, cellId, inspector]);
 
-    // Both render branches wrap in the same Fluent Tooltip when there IS
-    // tooltip content; collect the props once so the two call sites can't
-    // drift apart. A null tooltipContent means the cell has nothing to
-    // surface (non-inspectable cell without a support-field explanation) —
-    // skip the Tooltip wrapper entirely so hover and focus don't produce an
-    // empty tooltip.
-    const tooltipProps = tooltipContent
-        ? {
-              content: tooltipContent,
-              relationship: 'description' as const,
-              withArrow: true,
-              mountNode: tooltipMountNode
-          }
-        : null;
-
     if (!canInspect || !cellId || !inspector) {
-        const cellBody = <div>{displayValue}</div>;
-        return tooltipProps ? (
-            <Tooltip {...tooltipProps}>{cellBody}</Tooltip>
-        ) : (
-            cellBody
+        return (
+            <DataTableTooltip content={tooltipContent}>
+                <div>{displayValue}</div>
+            </DataTableTooltip>
         );
     }
 
@@ -212,30 +195,27 @@ export const DataTableCell = ({
         keyboard?.setActiveCell(cellId);
     };
 
-    const cellBody = (
-        <div
-            ref={cellRef}
-            role='button'
-            tabIndex={isActive ? 0 : -1}
-            aria-haspopup='dialog'
-            aria-expanded={isOpen}
-            aria-label={getDenebState().i18n.translate(
-                'Table_Aria_InspectCell',
-                [field]
-            )}
-            data-inspector-cell=''
-            className={classes.cell}
-            onClick={handleClick}
-            onKeyDown={handleKeyDown}
-            onFocus={handleFocus}
-        >
-            {displayValue}
-        </div>
-    );
-    return tooltipProps ? (
-        <Tooltip {...tooltipProps}>{cellBody}</Tooltip>
-    ) : (
-        cellBody
+    return (
+        <DataTableTooltip content={tooltipContent}>
+            <div
+                ref={cellRef}
+                role='button'
+                tabIndex={isActive ? 0 : -1}
+                aria-haspopup='dialog'
+                aria-expanded={isOpen}
+                aria-label={getDenebState().i18n.translate(
+                    'Table_Aria_InspectCell',
+                    [field]
+                )}
+                data-inspector-cell=''
+                className={classes.cell}
+                onClick={handleClick}
+                onKeyDown={handleKeyDown}
+                onFocus={handleFocus}
+            >
+                {displayValue}
+            </div>
+        </DataTableTooltip>
     );
 };
 

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
@@ -14,6 +14,7 @@ import type { WorkerDatasetViewerValueType } from '../../workers/types';
 import { getDenebState } from '../../../../state';
 import {
     isOpenForCellId,
+    shouldRefreshInspector,
     useDataTableInspector
 } from './inspector-popover-context';
 import {
@@ -125,14 +126,17 @@ export const DataTableCell = ({
     }, [cellId, keyboard]);
 
     // Keep the inspector's snapshot in sync with live cell updates. The
-    // inspector captures rawValue/valueType at click time via openInspector;
-    // without this effect, a cell whose value changes beneath it (e.g. the
-    // signal-viewer's currentDate signal ticking every second) would show
-    // stale content until the user re-clicks. Only the currently-targeted
-    // cell dispatches a refresh, so ticks from unrelated cells don't stomp
-    // the inspector. The Object.is guard suppresses the redundant
-    // re-dispatch that would otherwise fire immediately after click (when
-    // state is already current).
+    // inspector captures rawValue/valueType at click time; without this
+    // effect, a cell whose value changes beneath it (e.g. the signal-
+    // viewer's currentDate signal ticking every second) would show stale
+    // content until the user re-clicks. Only the currently-targeted cell
+    // dispatches a refresh, so ticks from unrelated cells don't stomp the
+    // inspector. The Object.is guard suppresses the redundant re-dispatch
+    // that would otherwise fire immediately after click (when state is
+    // already current). `refreshInspector` internally checks
+    // `stateRef.current.isOpen` so a close fired earlier in the same tick
+    // cannot be undone — the cell's React-context snapshot is one render
+    // stale relative to the ref, and the dispatch has to be authoritative.
     useEffect(() => {
         if (!cellId || !inspector) return;
         // `cellId` non-null implies `canInspect` was true at memo time,
@@ -142,14 +146,10 @@ export const DataTableCell = ({
         // effect, cellId may still be non-null. Guard explicitly rather
         // than leaning on a non-null assertion.
         if (valueType === undefined) return;
-        if (!isOpenForCellId(inspector, cellId)) return;
-        if (
-            Object.is(inspector.rawValue, rawValue) &&
-            inspector.valueType === valueType
-        ) {
+        if (!shouldRefreshInspector(inspector, cellId, rawValue, valueType)) {
             return;
         }
-        inspector.openInspector(cellRef, rawValue, valueType, cellId);
+        inspector.refreshInspector(rawValue, valueType);
     }, [rawValue, valueType, cellId, inspector]);
 
     // Both render branches wrap in the same Fluent Tooltip when there IS

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
@@ -166,7 +166,13 @@ export const DataTableCell = ({
     const isOpen = isOpenForCellId(inspector, cellId);
 
     const openForThisCell = () => {
-        inspector.openInspector(cellRef, rawValue, valueType!, cellId);
+        // Same pattern as the live-refresh effect's guard: `canInspect`
+        // (and therefore the cellId memo) implies `valueType !== undefined`,
+        // but TypeScript can't follow that inference across closure
+        // boundaries. Narrow via control flow rather than a non-null
+        // assertion so the invariant is visible at the call site.
+        if (valueType === undefined) return;
+        inspector.openInspector(cellRef, rawValue, valueType, cellId);
     };
 
     const handleClick = () => {

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
@@ -124,6 +124,27 @@ export const DataTableCell = ({
         return keyboard.registerCell(cellId, cellRef);
     }, [cellId, keyboard]);
 
+    // Keep the inspector's snapshot in sync with live cell updates. The
+    // inspector captures rawValue/valueType at click time via openInspector;
+    // without this effect, a cell whose value changes beneath it (e.g. the
+    // signal-viewer's currentDate signal ticking every second) would show
+    // stale content until the user re-clicks. Only the currently-targeted
+    // cell dispatches a refresh, so ticks from unrelated cells don't stomp
+    // the inspector. The Object.is guard suppresses the redundant
+    // re-dispatch that would otherwise fire immediately after click (when
+    // state is already current).
+    useEffect(() => {
+        if (!cellId || !inspector) return;
+        if (!isOpenForCellId(inspector, cellId)) return;
+        if (
+            Object.is(inspector.rawValue, rawValue) &&
+            inspector.valueType === valueType
+        ) {
+            return;
+        }
+        inspector.openInspector(cellRef, rawValue, valueType!, cellId);
+    }, [rawValue, valueType, cellId, inspector]);
+
     // Both render branches wrap in the same Fluent Tooltip when there IS
     // tooltip content; collect the props once so the two call sites can't
     // drift apart. A null tooltipContent means the cell has nothing to

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-header-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-header-cell.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
-import { makeStyles, Tooltip } from '@fluentui/react-components';
 
-import { useDataTableTooltip } from './data-table-tooltip-context';
+import { DataTableTooltip } from './data-table-tooltip';
 
 type DataTableHeaderCellProps = {
     label: ReactNode;
@@ -13,40 +12,17 @@ type DataTableHeaderCellProps = {
     tooltip?: string | null;
 };
 
-const useStyles = makeStyles({
-    // Fluent's default tooltip content collapses `\n` to whitespace because
-    // the container inherits `white-space: normal`. `pre-line` preserves
-    // explicit line breaks from the i18n string while still allowing soft
-    // wrapping when the line exceeds the tooltip width.
-    tooltipContent: {
-        whiteSpace: 'pre-line'
-    }
-});
-
 /**
- * Renders a column header with an optional help tooltip. Uses the same
- * Fluent `<Tooltip>` + shared mount-node pattern as `DataTableCell`, so
- * header tooltips portal alongside cell tooltips instead of falling back to
- * the browser-native `title` attribute (which can't be dismissed
- * programmatically and conflicts with the inspector popover).
+ * Renders a column header with an optional help tooltip. Delegates to
+ * `DataTableTooltip` so header tooltips portal alongside cell tooltips
+ * (via the shared `DataTableTooltipProvider` mount node) and honour `\n`
+ * line breaks uniformly with the rest of the debug-area table.
  */
 export const DataTableHeaderCell = ({
     label,
     tooltip
-}: DataTableHeaderCellProps) => {
-    const mountNode = useDataTableTooltip();
-    const classes = useStyles();
-    if (!tooltip) {
-        return <span>{label}</span>;
-    }
-    return (
-        <Tooltip
-            content={<span className={classes.tooltipContent}>{tooltip}</span>}
-            relationship='description'
-            withArrow
-            mountNode={mountNode}
-        >
-            <span>{label}</span>
-        </Tooltip>
-    );
-};
+}: DataTableHeaderCellProps) => (
+    <DataTableTooltip content={tooltip}>
+        <span>{label}</span>
+    </DataTableTooltip>
+);

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-header-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-header-cell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Tooltip } from '@fluentui/react-components';
+import { makeStyles, Tooltip } from '@fluentui/react-components';
 
 import { useDataTableTooltip } from './data-table-tooltip-context';
 
@@ -7,10 +7,21 @@ type DataTableHeaderCellProps = {
     label: ReactNode;
     /**
      * Optional help text shown on hover. When absent or empty, the header
-     * renders plainly with no tooltip wrapper.
+     * renders plainly with no tooltip wrapper. May contain `\n` to force
+     * line breaks in the rendered tooltip.
      */
     tooltip?: string | null;
 };
+
+const useStyles = makeStyles({
+    // Fluent's default tooltip content collapses `\n` to whitespace because
+    // the container inherits `white-space: normal`. `pre-line` preserves
+    // explicit line breaks from the i18n string while still allowing soft
+    // wrapping when the line exceeds the tooltip width.
+    tooltipContent: {
+        whiteSpace: 'pre-line'
+    }
+});
 
 /**
  * Renders a column header with an optional help tooltip. Uses the same
@@ -24,12 +35,13 @@ export const DataTableHeaderCell = ({
     tooltip
 }: DataTableHeaderCellProps) => {
     const mountNode = useDataTableTooltip();
+    const classes = useStyles();
     if (!tooltip) {
         return <span>{label}</span>;
     }
     return (
         <Tooltip
-            content={tooltip}
+            content={<span className={classes.tooltipContent}>{tooltip}</span>}
             relationship='description'
             withArrow
             mountNode={mountNode}

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-tooltip.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-tooltip.tsx
@@ -1,0 +1,61 @@
+import type { ReactElement } from 'react';
+import { makeStyles, Tooltip } from '@fluentui/react-components';
+
+import { useDataTableTooltip } from './data-table-tooltip-context';
+
+type DataTableTooltipProps = {
+    /**
+     * Text shown on hover/focus. When absent or empty, renders `children`
+     * without a Fluent Tooltip wrapper — hover and focus don't produce an
+     * empty tooltip, and the wrapping span's implicit description is
+     * suppressed.
+     *
+     * May contain `\n` to force line breaks in the rendered tooltip.
+     */
+    content: string | null | undefined;
+    /**
+     * Must be a single React element — Fluent `<Tooltip>` clones the child
+     * to inject ARIA description attributes, which requires an element
+     * rather than a bare text node or fragment.
+     */
+    children: ReactElement;
+};
+
+const useStyles = makeStyles({
+    // Fluent's default tooltip content inherits `white-space: normal` and
+    // collapses `\n` to whitespace. `pre-line` preserves explicit line
+    // breaks from i18n strings while still allowing soft wrap when the
+    // line exceeds the tooltip width. Applied centrally here so every
+    // consumer gets the same newline behaviour by construction rather than
+    // by discipline.
+    content: {
+        whiteSpace: 'pre-line'
+    }
+});
+
+/**
+ * Shared Fluent `<Tooltip>` wrapper for debug-area table cells (header and
+ * body). Centralises the `mountNode` wiring, the `relationship` /
+ * `withArrow` configuration, and the `white-space: pre-line` content
+ * styling so both call sites can't drift apart on any of those.
+ */
+export const DataTableTooltip = ({
+    content,
+    children
+}: DataTableTooltipProps) => {
+    const classes = useStyles();
+    const mountNode = useDataTableTooltip();
+    if (!content) {
+        return <>{children}</>;
+    }
+    return (
+        <Tooltip
+            content={<span className={classes.content}>{content}</span>}
+            relationship='description'
+            withArrow
+            mountNode={mountNode}
+        >
+            {children}
+        </Tooltip>
+    );
+};

--- a/packages/app-core/src/features/debug-area/components/data-table/inspector-popover-context.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/inspector-popover-context.tsx
@@ -40,6 +40,19 @@ export interface InspectorPopoverContextValue extends InspectorPopoverState {
      * the anchor element is still connected to the DOM.
      */
     closeInspector: () => void;
+    /**
+     * Update the currently-open inspector's `rawValue` / `valueType` without
+     * touching `anchorRef` or `cellId`. Used when the cell behind an open
+     * inspector has its value change beneath it (e.g. a signal-viewer cell
+     * whose signal ticks while inspected). No-ops when the inspector is
+     * already closed, reading from a synchronous internal ref so a dismiss
+     * fired earlier in the same event-loop tick cannot be undone by a
+     * refresh dispatched against the pre-dismiss context snapshot.
+     */
+    refreshInspector: (
+        rawValue: unknown,
+        valueType: WorkerDatasetViewerValueType
+    ) => void;
 }
 
 export const INSPECTOR_POPOVER_CLOSED_STATE: InspectorPopoverState = {
@@ -58,6 +71,35 @@ export const isOpenForCellId = (
     state: Pick<InspectorPopoverState, 'isOpen' | 'cellId'>,
     cellId: string
 ): boolean => state.isOpen && state.cellId === cellId;
+
+/**
+ * Pure predicate: should a cell that is the currently-targeted inspector
+ * cell dispatch `refreshInspector` with the given next `rawValue`/
+ * `valueType`? Returns false when the inspector isn't targeting this cell
+ * (nothing to refresh) and when the incoming values are referentially
+ * identical to the state already held (redundant dispatch would be a
+ * no-op). `Object.is` is deliberate — primitives compare by value (so a
+ * numeric tick from `n` to `n` is correctly a no-op) and objects by
+ * reference (so a freshly-pruned object is treated as changed content).
+ */
+export const shouldRefreshInspector = (
+    state: Pick<
+        InspectorPopoverState,
+        'isOpen' | 'cellId' | 'rawValue' | 'valueType'
+    >,
+    cellId: string,
+    nextRawValue: unknown,
+    nextValueType: WorkerDatasetViewerValueType
+): boolean => {
+    if (!isOpenForCellId(state, cellId)) return false;
+    if (
+        Object.is(state.rawValue, nextRawValue) &&
+        state.valueType === nextValueType
+    ) {
+        return false;
+    }
+    return true;
+};
 
 const InspectorPopoverContext =
     createContext<InspectorPopoverContextValue | null>(null);
@@ -127,13 +169,34 @@ export const DataTableInspectorProvider = ({
         }
     }, []);
 
+    const refreshInspector = useCallback<
+        InspectorPopoverContextValue['refreshInspector']
+    >((rawValue, valueType) => {
+        // Read from `stateRef` rather than closing over `state` so a
+        // `closeInspector` call earlier in the same event-loop tick
+        // (which synchronously flips `stateRef.current.isOpen` to false)
+        // prevents a refresh dispatched against a pre-close context
+        // snapshot from reopening the popover. Cells see the open state
+        // via React context — which is one render stale relative to the
+        // ref — so the dispatch has to be the authoritative check.
+        if (!stateRef.current.isOpen) return;
+        const next: InspectorPopoverState = {
+            ...stateRef.current,
+            rawValue,
+            valueType
+        };
+        stateRef.current = next;
+        setState(next);
+    }, []);
+
     const value = useMemo<InspectorPopoverContextValue>(
         () => ({
             ...state,
             openInspector,
-            closeInspector
+            closeInspector,
+            refreshInspector
         }),
-        [state, openInspector, closeInspector]
+        [state, openInspector, closeInspector, refreshInspector]
     );
 
     return (

--- a/packages/app-core/src/features/debug-area/components/data-table/inspector-popover.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/inspector-popover.tsx
@@ -231,7 +231,15 @@ export const InspectorPopover = ({
             open={isOpen}
             onOpenChange={handleOpenChange}
             withArrow
-            positioning={{ target: anchorRef?.current ?? null }}
+            // `above-start` anchors the popover to the cell's top-left.
+            // Cells are left-aligned, so the popover's left edge stays put
+            // even when the rendered value width changes (e.g. a ticking
+            // numeric signal whose decimal-place count fluctuates).
+            positioning={{
+                target: anchorRef?.current ?? null,
+                position: 'above',
+                align: 'start'
+            }}
         >
             <PopoverSurface
                 className={classes.popoverSurface}

--- a/packages/app-core/src/features/debug-area/components/data-table/inspector-popover.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/inspector-popover.tsx
@@ -139,11 +139,13 @@ export const InspectorPopover = ({
     // editor instance before Monaco finishes constructing.
     //
     // Invariant this guard depends on: live-refresh (DataTableCell's effect
-    // that re-dispatches `openInspector` on rawValue/valueType changes) MUST
-    // always dispatch with the same `cellId` as the currently-open inspector.
-    // If a future change ever routes a retarget through that path with a
-    // different cellId, `wasOpenRef.current` will already be true and the
-    // focus call here would be wrongly suppressed on the retarget.
+    // that re-dispatches `refreshInspector` on rawValue/valueType changes)
+    // never changes `cellId` — `refreshInspector` takes only (rawValue,
+    // valueType) and spreads the existing stateRef, so `cellId` is
+    // structurally stable across refreshes. If a future change ever
+    // bypassed `refreshInspector` and called `openInspector` directly with
+    // a different cellId, `wasOpenRef.current` would already be true and
+    // the focus call here would be wrongly suppressed on the retarget.
     const wasOpenRef = useRef(false);
     useEffect(() => {
         if (!isOpen) {

--- a/packages/app-core/src/features/debug-area/components/data-table/inspector-popover.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/inspector-popover.tsx
@@ -137,6 +137,13 @@ export const InspectorPopover = ({
     // true — on initial open `handleEditorMount` already focuses Monaco once
     // mounted, and firing here would either double-focus or focus a stale
     // editor instance before Monaco finishes constructing.
+    //
+    // Invariant this guard depends on: live-refresh (DataTableCell's effect
+    // that re-dispatches `openInspector` on rawValue/valueType changes) MUST
+    // always dispatch with the same `cellId` as the currently-open inspector.
+    // If a future change ever routes a retarget through that path with a
+    // different cellId, `wasOpenRef.current` will already be true and the
+    // focus call here would be wrongly suppressed on the retarget.
     const wasOpenRef = useRef(false);
     useEffect(() => {
         if (!isOpen) {


### PR DESCRIPTION
## Summary

Follow-up to #625. Three issues surfaced during manual testing of the merged universal cell inspector — inspector popover not refreshing when the underlying cell value changed, header tooltips collapsing `\n` to spaces, and popover jitter on live-updating numeric signals — plus a `/ce:review` pass that prompted a small set of correctness/maintainability refactors. Each fix is its own commit so a revert is tightly scoped.

## What changed

**Inspector stays in sync with live cell updates**
- `InspectorPopoverContextValue` gains a `refreshInspector(rawValue, valueType)` action that writes only those two state fields and reads `isOpen` from the provider's synchronously-maintained `stateRef` — not from React context. A `closeInspector` fired earlier in the same event-loop tick flips the ref immediately, so a refresh dispatched against the pre-close React-context snapshot cannot reopen the popover.
- `DataTableCell` now carries a `useEffect` that routes through `refreshInspector` when it's the currently-targeted cell and its `rawValue` / `valueType` change beneath it (signal-viewer cells whose signals tick, etc.). Gated by a pure `shouldRefreshInspector(state, cellId, nextRawValue, nextValueType)` predicate that scopes to "same cell" and suppresses the immediate-after-click redundant re-dispatch via `Object.is`.
- `shouldRefreshInspector` lives alongside `isOpenForCellId` in `inspector-popover-context.ts` and has 8 new parameterised tests: open/close state, cross-cell scoping, value-unchanged no-op, NaN identity, ±0 distinction, reference-vs-content for objects.

**Header tooltips honour `\n`**
- Fluent `<Tooltip content={string}>` inherits `white-space: normal`, which collapses `\n` to spaces (unlike the native `title` it replaced). Wrap tooltip content in a `<span>` styled `white-space: pre-line` so i18n strings with explicit breaks render correctly while still allowing soft-wrap at the container edge.

**Popover positioning**
- Live-updating numeric signals whose rendered width changes between ticks (e.g. `now()` decimal-place fluctuation) caused the popover's above-centre anchor to move with the cell's centre and jump horizontally on every refresh. Switch to `position: 'above' + align: 'start'` so the popover's left edge stays aligned with the (stable) left edge of the cell.

**Shared tooltip wrapper**
- Both `DataTableCell` and `DataTableHeaderCell` previously mounted identical Fluent Tooltip configs (same `relationship`, `withArrow`, `mountNode`) with only the header carrying the pre-line style. Extracted `DataTableTooltip` — owns the mountNode wiring, the description/arrow config, the pre-line content span, and the "no wrapper when content is absent" branch. Both call sites now share the same behaviour by construction; future cell tooltips with `\n` will work without rediscovery.

**Code review fixes from `/ce:review`**
- `data-table-cell.tsx`: replaced a `valueType!` non-null assertion in the live-refresh effect with an explicit `if (valueType === undefined) return;` guard matching the style of the other guards in the same block. The safety argument (`cellId` non-null → `canInspect` true → `valueType !== undefined`) is correct at memo time but crosses render-cycle boundaries TypeScript can't follow. Four reviewers (correctness, project-standards, maintainability, kieran-typescript) converged on this.
- `inspector-popover.tsx`: pinned the invariant that `wasOpenRef`'s retarget guard depends on live-refresh always re-dispatching with the same `cellId` as the currently-open inspector (comment only; no code change).

## Scope boundaries

- **Not included:** `@testing-library/react` infrastructure. Full-component behavioural tests for `DataTableCell` and `DataTableHeaderCell` remain deferred — extracted pure predicates (`shouldRefreshInspector`) are tested with the existing vitest pattern, which closes the behavioural gap that was extractable without a React renderer.
- Julik-frontend-races flagged an `Object.is`-bypass concern for object-typed signal `rawValue`. Verified as pre-existing mitigated — `SignalValue` already memoises its `currentValues` on `[getSignalValues, signalValue]`, so `raw` is reference-stable between true signal changes.

## Test plan

- [ ] Open inspector on a signal cell for a `now()`-ticked signal — popover content updates each tick, popover anchor stays put
- [ ] Press Escape / click outside exactly as a signal tick fires — popover closes and stays closed (no reopen race)
- [ ] Retarget: click cell A (open), click cell B while open — popover re-anchors to B without flashing closed
- [ ] Header with a `\n`-containing i18n tooltip string — line breaks render as real breaks in the popover
- [ ] Tab into the grid, arrow-nav across cells, Tab out — roving-tabindex behaviour unchanged
- [ ] Numeric signal whose decimal-place count fluctuates — popover's left edge does not jitter
- [ ] Signal cell whose value does not change between renders (non-tick re-render) — popover does not re-dispatch (verified via the Object.is guard)
- [ ] `valueType` transitions to `undefined` mid-inspection (edge case) — no runtime error, inspector falls back to non-inspectable render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
