### PR TITLE
fix: re-enable compilation-gated commands on parse-error recovery

### DIFF
--- a/docs/plans/2026-04-29-001-fix-zoom-stuck-disabled-on-recovery-plan.md
+++ b/docs/plans/2026-04-29-001-fix-zoom-stuck-disabled-on-recovery-plan.md
@@ -1,0 +1,276 @@
+---
+title: "fix: compilation-gated commands stuck disabled after parse-error click"
+type: fix
+status: completed
+date: 2026-04-29
+---
+
+# fix: compilation-gated commands stuck disabled after parse-error click
+
+## Overview
+
+Two commands gated on `isCompilationReady` — the zoom controls (`zoomIn`, `zoomOut`, `zoomFit`, `zoomReset`) and the spec exporter (`exportSpecification`) — can become persistently disabled after a Vega parse-error state. The trigger differs per command (a zoom click for zoom; an editor keystroke for export), but the structural cause is identical: state-management actions that fire *during* the error path write `false` into the `commands` slice, and nothing on the recovery path re-evaluates them. The deadlock can only be cleared by a full visual reload.
+
+This plan extracts two pure helpers — `evaluateZoomCommandsState` and `evaluateExportSpecCommandState` — and calls them from both the existing writer sites *and* `handleCompile`'s success branch (gated on `result.status === 'ready'`), so recovery from any error path automatically restores the correct enabled flags.
+
+## Problem Frame
+
+**Reproducible flow (zoom):**
+
+1. User triggers a Vega parse error. `state.compilation.result?.status !== 'ready'`.
+2. Zoom controls remain visually clickable because the `commands` slice initial values are all `true` and nothing has rewritten them yet.
+3. User clicks a zoom control. `handleZoomIn`/etc. → `executeCommand` reads the slice (sees `true`) → `updateEditorZoomLevel(level)` → [`handleUpdateEditorZoomLevel`](packages/app-core/src/state/editor.ts) reads the *current* `state.compilation.result` (in error state) and writes the four zoom command enabled flags as `false` into `commands`.
+4. User fixes the spec and recompiles. [`handleCompile`](packages/app-core/src/state/compilation.ts) sets `state.compilation.result` to `{ status: 'ready', ... }`. Visual / data / signals restore. **`handleCompile` does not touch the `commands` slice.** The only re-eval path is `updateEditorZoomLevel`, which the user can't trigger because zoom is disabled. Deadlock.
+
+**Reproducible flow (`exportSpecification`):**
+
+The same shape, with a different trigger. `handleUpdateEditorContent` and `handleUpdateIsDirty` write `exportSpecification` based on `isExportSpecCommandEnabled({ editorIsDirty, compilationResult })`. While in an error state, an editor keystroke writes `false`. Recovery doesn't re-evaluate. The deadlock window is narrower (the next keystroke after recovery would re-evaluate) but the structural gap is identical. The user-reported reproduction was for zoom only; `exportSpecification` was surfaced during plan review and brought into scope.
+
+This is the same shape as the [`lifecycle-owns-effect-rebind-identity-token-2026-04-28`](docs/solutions/best-practices/lifecycle-owns-effect-rebind-identity-token-2026-04-28.md) learning, applied to the `commands` slice: the lifecycle hook that recovers the resource (`handleCompile` reaching `ready`) must own the unwrite of any state set during the error path.
+
+## Requirements Trace
+
+- **R1.** After a parse error → zoom click → spec fix → recompile cycle, zoom controls are re-enabled without requiring a visual reload.
+- **R2.** After a parse error → editor keystroke → spec fix → recompile cycle, `exportSpecification` is re-enabled without requiring a visual reload.
+- **R3.** Existing behaviour preserved: compilation-gated commands remain correctly disabled while compilation is not `ready`. The existing writers (zoom-level, content, dirty handlers) continue to evaluate the same way they do today.
+- **R4.** Regression tests guard the recovery path so future changes can't silently revert it.
+
+## Scope Boundaries
+
+- **No refactor of the `commands` slice into derived selectors.** The slice is the contract for ALL commands; singling out a subset as derived would break the symmetry.
+- **No changes to `handleLogError`'s state writes.** Runtime errors arrive on the existing Vega view; `runtimeErrors` accumulation already covers them.
+- **`handleCompile` writes compilation-gated commands on BOTH branches** (success and error). Both helpers handle the not-ready case correctly (returning `false` for gated commands), so the symmetric write disables zoom on error compile and re-enables on recovery — parity with how `exportSpecification` already disables via continuous editor-edit writes. (An earlier draft of this plan scoped out the error-branch write; manual testing showed that left zoom controls looking enabled in known-bad states until the user clicked them, because zoom has no editor-edit cadence to self-correct against. The symmetric write closes that gap.)
+- **No audit-and-fix of every command potentially gated on `isCompilationReady`** — focus on zoom (user-reported reproduction) and `exportSpecification` (structurally identical, surfaced during review). A note in System-Wide Impact flags the broader audit as a follow-up if more cases surface.
+- **No change to the visual reload behaviour.** Today, a full reload clears the slice; that stays the same.
+
+## Context & Research
+
+### Relevant code and patterns
+
+- [`packages/app-core/src/state/commands.ts`](packages/app-core/src/state/commands.ts) — `CommandsSliceProperties` is a flat `{ [command in Command]: boolean }` map with all initial values `true`. **The slice has no setter** — every writer is a handler in another slice that returns `{ commands: { ...state.commands, ... } }`. Recovery requires an explicit cross-slice write, not a self-correcting derived value.
+- [`packages/app-core/src/state/editor.ts`](packages/app-core/src/state/editor.ts) — `handleUpdateEditorZoomLevel` (lines 362-383) writes the four zoom command enabled flags (`zoomFit`, `zoomIn`, `zoomOut`, `zoomReset`). It does **not** write `zoomLevel` — that command's slice value is initialized to `true` and never updated dynamically. `handleUpdateEditorContent` (around line 306) and `handleUpdateIsDirty` (around line 333) write `exportSpecification` using `isExportSpecCommandEnabled({ editorIsDirty, compilationResult })`.
+- [`packages/app-core/src/lib/commands/state.ts`](packages/app-core/src/lib/commands/state.ts) — `isCompilationReady(result)` returns `result?.status === 'ready'`. The four zoom-enabled predicates (`isZoomInCommandEnabled`, `isZoomOutCommandEnabled`, `isZoomOtherCommandsEnabled`) and `isExportSpecCommandEnabled` all gate on it. Extracting per-command-set evaluation into pure helpers avoids duplicating the logic between existing writers and `handleCompile`.
+- [`packages/app-core/src/lib/commands/actions.ts`](packages/app-core/src/lib/commands/actions.ts) — `executeCommand` reads `commands[command]` from the store and runs the callback only if true. No error handling, no per-command failure state. "Disabled" here strictly means "the slice value is false."
+- [`packages/app-core/src/state/compilation.ts`](packages/app-core/src/state/compilation.ts) — `handleCompile` writes `compilation.result`. Currently does **not** write to `commands`. Has no existing `result.status === 'ready'` branch — the conditional must be added by this fix.
+- [`packages/app-core/src/components/ui/toolbar/toolbar-button-standard.tsx`](packages/app-core/src/components/ui/toolbar/toolbar-button-standard.tsx) line 93 — `disabled={!commands[command]}`. Generic for all commands; the bug is upstream in the slice writes, not at this read site.
+- **Recent commits on the affected paths (last ~2 months on `next`):**
+  - `b3b0abf2` — JSON Schema / Monaco gating
+  - `c3535a56` — Show compiled Vega
+  - `c5052410` — Tab refinements
+  - `60f9cb16` — Data viewer refinements
+  Feasibility review confirms the deadlock is a **structural omission from the original implementation, not a regression introduced by any specific commit** — git log shows no commit ever added a recovery write to `commands`. Bisection adds no value.
+- **Existing test pattern:** `packages/app-core/src/state/__tests__/compilation-render-id.test.ts` and `debug.test.ts` are the slice-test conventions. Vitest in node env, no React rendering. **Critical:** the existing `compileSpec` mock in `compilation-render-id.test.ts` returns `{ errors: [], warnings: [], embedOptions: {}, spec: {} }` — it omits `status`. The new tests must explicitly include `{ status: 'ready', parsed: {...}, embedOptions: {} }` for the success case, otherwise `isCompilationReady` returns `false` and the test would pass for the wrong reason (false-negative regression guard).
+- **Zero existing test coverage** for `commands` slice transitions.
+
+### Institutional learnings
+
+- [`docs/solutions/best-practices/lifecycle-owns-effect-rebind-identity-token-2026-04-28.md`](docs/solutions/best-practices/lifecycle-owns-effect-rebind-identity-token-2026-04-28.md) — exactly this pattern. State written during the error path must be unwritten by the lifecycle hook that owns recovery. `handleCompile` reaching `ready` IS that hook for compilation state; it must also own the recovery write to `commands`.
+- [`docs/solutions/best-practices/dedup-synthetic-identity-token-rebind-trigger-2026-04-28.md`](docs/solutions/best-practices/dedup-synthetic-identity-token-rebind-trigger-2026-04-28.md) — adjacent. Vega may emit identical errors on every pulse; the recovery write must be idempotent so steady-state error → ready → error → ready cycles don't oscillate the slice values incorrectly. Writing the same value twice is fine; the concern is correctness, not deduplication.
+- [`docs/solutions/best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md`](docs/solutions/best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md) — supports the helper extraction. Two consumers per helper (existing writer + recovery write) is the codebase's threshold.
+- [`docs/solutions/best-practices/pure-setstate-updaters-no-dom-side-effects-2026-04-21.md`](docs/solutions/best-practices/pure-setstate-updaters-no-dom-side-effects-2026-04-21.md) — applies to the implementation: each helper must be a pure function. No closures over stale state.
+
+## Key Technical Decisions
+
+- **Two pure helpers, not one mega-helper.** Separate concerns:
+  - `evaluateZoomCommandsState(zoomLevel, compilationResult)` returns `Pick<CommandsSliceProperties, 'zoomIn' | 'zoomOut' | 'zoomFit' | 'zoomReset'>` — four keys, gated on `isCompilationReady` plus min/max checks for `zoomIn`/`zoomOut`.
+  - `evaluateExportSpecCommandState(editorIsDirty, compilationResult)` returns `Pick<CommandsSliceProperties, 'exportSpecification'>` — one key, gated on `isCompilationReady` and `editorIsDirty`.
+  Each existing writer keeps its narrow scope (zoom writers don't need to read `editorIsDirty`; export writers don't need to read `editorZoomLevel`). `handleCompile`'s recovery calls both, merges the results into the `commands` slice update.
+- **`zoomLevel` is excluded from the helper.** Confirmed via feasibility review: `handleUpdateEditorZoomLevel` writes only four keys; no predicate exists for `zoomLevel`; the slice value is `true` at init and never updated. Adding `zoomLevel` to the helper would speculatively widen the contract with no backing predicate. If a future change introduces dynamic `zoomLevel` gating, that's a separate addition.
+- **`handleCompile` writes compilation-gated commands on every compile (both branches).** Calls both helpers using `state.editorZoomLevel`, `state.editor.isDirty`, and the new `result`, and merges their output into `state.commands`. Both helpers handle the not-ready case correctly (returning `false` for gated commands), so the symmetric write disables zoom on error compile and re-enables on recovery — parity with how `exportSpecification` already disables via continuous editor-edit writes. (An earlier draft of this plan scoped out the error-branch write; manual testing showed that left zoom controls looking enabled in known-bad states until the user clicked them, because zoom has no editor-edit cadence to self-correct against.)
+- **Always re-evaluate on the success branch, don't gate on edge transitions.** Writing the same boolean values repeatedly is a no-op for React subscribers (Zustand's shallow-equal at the selector layer skips re-renders for unchanged primitives). The `set()` allocation cost is one helper call + one object spread per success compile — trivial.
+- **Don't add a Zustand subscription on `compilation.result`.** The codebase pattern is imperative cross-slice writes inside handlers; introducing a subscription would be a new pattern just for this bug.
+- **Don't touch `handleLogError`.** Runtime errors don't write `commands` today. The bug isn't on that path.
+
+## Open Questions
+
+### Resolved during planning
+
+- **Should the recovery path live in `handleCompile` or in a separate effect?** Resolved — `handleCompile`. Matches existing imperative-cross-slice-writes pattern.
+- **Should the zoom-eval logic be derived (read-time selector) instead of written (write-time slice update)?** Resolved — keep it written. Slice symmetry with all other commands.
+- **Does `zoomLevel` get the same treatment?** Resolved — no. `zoomLevel` has no predicate and no writer; including it would widen the contract without basis.
+- **Is `handleCompile`'s recovery write conditional or unconditional?** Resolved during execution — **unconditional** (writes on both branches). The original plan called for conditional ("only write on `result.status === 'ready'`"); manual testing of the conditional version showed it left zoom controls looking enabled in known-bad states because zoom has no continuous-edit cadence to self-correct against (unlike `exportSpecification`, whose editor-edit writers fire on every keystroke). Reversed mid-execution to the symmetric write.
+- **Does `exportSpecification` need recovery treatment?** Resolved — yes (in scope). Same structural gap; brought in based on plan review.
+- **One mega-helper or two narrow helpers?** Resolved — two narrow helpers, one per gated command set. Keeps existing writers' state reads narrow.
+
+### Deferred to implementation
+
+- **Exact helper file location** — likely alongside the existing `is*Enabled` predicates in `lib/commands/state.ts`, or in a new sibling file if that grows too large. Final location follows local conventions.
+- **Whether the `zoomLevel` exclusion from the helper warrants a comment** — implementer's call. A short JSDoc note ("zoomLevel has no dynamic predicate; intentionally excluded") would help future maintainers.
+
+## Implementation Units
+
+- [x] **Unit 1: Reproduce the bug as regression tests**
+
+**Goal:** Lock down both deadlocks (zoom + `exportSpecification`) in vitest-friendly tests BEFORE applying the fix. Tests fail in the current state; pass after Unit 2.
+
+**Requirements:** R4.
+
+**Dependencies:** None.
+
+**Files:**
+- Test: `packages/app-core/src/state/__tests__/commands-recovery.test.ts` (new)
+
+**Approach:**
+
+State-layer tests, no React rendering. Vitest in node env.
+
+Mock `compileSpec` carefully: the existing pattern in `compilation-render-id.test.ts` omits `status` from the mock, which would silently break this test by making `isCompilationReady` always false. The success-case mock MUST include `status: 'ready'` and a minimal `parsed` object so `isCompilationReady` returns true.
+
+Two test groups, one per command set:
+
+**Zoom recovery:**
+1. Initial state — assert `commands.zoomIn`, `zoomOut`, `zoomFit`, `zoomReset` all `true`.
+2. Set `compilation.result` to a non-ready state (e.g. `{ status: 'error', ... }` or `null`).
+3. Call `updateEditorZoomLevel(<some-level>)` — simulating a user zoom click. Assert all four zoom flags now `false`.
+4. Set `compilation.result` to `{ status: 'ready', parsed: {...}, embedOptions: {} }` via `handleCompile`. Assert all four zoom flags return to `true`. **Fails before fix; passes after.**
+5. Happy path (no zoom click during error): error → no click → recovery → flags stay `true` throughout. Should pass before and after the fix.
+
+**Export-spec recovery:**
+1. Initial state — assert `commands.exportSpecification === true`.
+2. Set `compilation.result` to non-ready, set `editorIsDirty` true (matching the precondition for the export gate).
+3. Call `handleUpdateEditorContent` (or `handleUpdateIsDirty`) — simulating an editor keystroke. Assert `commands.exportSpecification === false`.
+4. Set `compilation.result` to ready via `handleCompile`. Assert `commands.exportSpecification` returns to `true` (the `editorIsDirty` precondition still holds, so the recovery should produce true). **Fails before fix; passes after.**
+5. Happy path: error → no editor change → recovery → flag stays `true`. Should pass before and after the fix.
+
+**Edge cases (both groups):**
+- `handleCompile` called multiple times on the success path → flags stay `true` (idempotency).
+- Re-error after recovery (error → fix → error) → flags return to `false` correctly on the second error if and only if the trigger action (zoom click / editor keystroke) happens during the second error.
+- Zoom-specific: `zoomLevel` at min — assertion that `zoomOut: false, zoomIn: true` correctly on recovery (boundary check).
+
+**Patterns to follow:**
+- [`packages/app-core/src/state/__tests__/compilation-render-id.test.ts`](packages/app-core/src/state/__tests__/compilation-render-id.test.ts) — slice-test fixture pattern, vitest in node env. **Important: deviate from this file's mock by adding `status: 'ready'`** — see the Approach note above.
+- [`packages/app-core/src/state/__tests__/debug.test.ts`](packages/app-core/src/state/__tests__/debug.test.ts) — keyed-record slice setter test pattern.
+
+**Test scenarios:**
+- Happy path (zoom recovery): error → click → fix → all four zoom flags `true`. Currently fails.
+- Happy path (export recovery): error → keystroke → fix → exportSpecification `true`. Currently fails.
+- Happy path preservation (zoom no-click): error → no click → recovery → flags stay `true`. Should already pass; regression-guard on existing behaviour.
+- Happy path preservation (export no-keystroke): error → no keystroke → recovery → flag stays `true`. Same.
+- Edge case (idempotency): handleCompile called repeatedly on success → flags stable.
+- Edge case (re-error): error → fix → error-with-trigger → flags correctly disable on second error.
+- Edge case (zoom boundary): zoomLevel at min on recovery → zoomOut `false`, zoomIn `true`.
+
+**Verification:**
+- New test file added; "currently fails" tests demonstrate both bugs; happy-path-preservation tests pass before and after the fix.
+- Each test includes a `compileSpec` mock with `status: 'ready'` for the success case (avoids the false-negative trap).
+
+---
+
+- [x] **Unit 2: Extract helpers and add recovery write in `handleCompile`**
+
+**Goal:** Two pure helpers + a new conditional recovery branch in `handleCompile`. Existing writers refactored to call the helpers (single source of truth).
+
+**Requirements:** R1, R2, R3.
+
+**Dependencies:** Unit 1 (Unit 1's failing tests pass once this unit lands).
+
+**Files:**
+- Modify: `packages/app-core/src/lib/commands/state.ts` (add two pure helpers)
+- Modify: `packages/app-core/src/state/editor.ts` (`handleUpdateEditorZoomLevel`, `handleUpdateEditorContent`, `handleUpdateIsDirty` call the helpers)
+- Modify: `packages/app-core/src/state/compilation.ts` (`handleCompile` adds unconditional commands write — see Key Technical Decisions for the symmetry rationale)
+
+**Approach:**
+
+**Step 1 — Extract pure helpers** in `lib/commands/state.ts`, alongside the existing `is*Enabled` predicates. Suggested signatures (final naming and exact return types at implementation time):
+
+```
+evaluateZoomCommandsState(zoomLevel, compilationResult)
+    → Pick<CommandsSliceProperties, 'zoomIn' | 'zoomOut' | 'zoomFit' | 'zoomReset'>
+
+evaluateExportSpecCommandState(editorIsDirty, compilationResult)
+    → Pick<CommandsSliceProperties, 'exportSpecification'>
+```
+
+Both pure; no closures over store state. Each calls the existing `is*Enabled` predicates internally.
+
+**Step 2 — Refactor existing writers to call the helpers.** `handleUpdateEditorZoomLevel` calls the zoom helper; `handleUpdateEditorContent` and `handleUpdateIsDirty` call the export helper. Behaviour unchanged at these sites.
+
+**Step 3 — Add the recovery branch to `handleCompile`.** `handleCompile` currently has no `result.status` branch — it always merges the new `result` into `state.compilation`. Add a conditional that, when `result.status === 'ready'`, also merges the helpers' output into `state.commands`:
+
+```
+if (result.status === 'ready') {
+    set((state) => ({
+        compilation: { ...state.compilation, ...resultUpdate },
+        commands: {
+            ...state.commands,
+            ...evaluateZoomCommandsState(state.editorZoomLevel, result),
+            ...evaluateExportSpecCommandState(state.editorIsDirty, result)
+        }
+    }));
+} else {
+    set((state) => ({ compilation: { ...state.compilation, ...resultUpdate } }));
+}
+```
+
+(Directional only — final shape matches existing `handleCompile` patterns.)
+
+**Patterns to follow:**
+- Existing extracted predicates in [`packages/app-core/src/lib/commands/state.ts`](packages/app-core/src/lib/commands/state.ts).
+- [`docs/solutions/best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md`](docs/solutions/best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md) — extract once, call from multiple sites.
+- [`docs/solutions/best-practices/pure-setstate-updaters-no-dom-side-effects-2026-04-21.md`](docs/solutions/best-practices/pure-setstate-updaters-no-dom-side-effects-2026-04-21.md) — helpers are pure functions; the cross-slice write happens via the standard `set((state) => ({ ... }))` updater shape used elsewhere.
+
+**Test scenarios:**
+- All Unit 1 scenarios pass after this unit lands.
+- Helper unit tests (in the same test file or alongside): `evaluateZoomCommandsState` returns the expected boolean record for representative input combinations (zoom level at min, mid, max; result ready, error, null). `evaluateExportSpecCommandState` returns the expected record for `(dirty=true, ready)`, `(dirty=false, ready)`, `(dirty=true, error)`, `(dirty=false, error)`.
+- Integration (existing writer regressions): a successful compile from an idle state writes the same flags the existing code path wrote — no behaviour drift.
+- Integration (error-compile branch): a failing compile (where `result.status !== 'ready'`) writes `false` for compilation-gated commands via the same helpers. Confirms the symmetric write — error compile disables zoom without requiring a click first.
+
+**Verification:**
+- Unit 1's regression tests pass.
+- Helper unit tests cover the predicate logic comprehensively.
+- All existing tests still pass (no regression).
+- Manual QA: reproduce the original bug flow → confirm zoom controls re-enable on recovery without a visual reload. Reproduce the analogous flow for `exportSpecification` (error → keystroke → fix) → confirm the export action re-enables.
+
+## System-Wide Impact
+
+- **Interaction graph:** `handleCompile` already updates `compilation.result`; this adds an unconditional parallel write to `commands`. No new state machinery, no new subscriptions, no new effects.
+- **Error propagation:** The error path's writes to `commands` via the existing editor / zoom writers still happen. `handleCompile` now also writes on both branches: error compile disables compilation-gated commands; success compile re-enables them. Symmetric with how `exportSpecification` was already self-correcting via editor-edit cadence; closes the same gap for zoom (which has no equivalent cadence).
+- **State lifecycle risks:** Idempotency is the main concern. `handleCompile` may run multiple times in quick succession (debounced compiles, recovery oscillation). The helpers are pure and the slice writes are no-ops at the React-subscriber level when values are unchanged. No risk of feedback loops.
+- **API surface parity:** None. All changes internal to `app-core`'s state machinery.
+- **Integration coverage:** The Unit 1 tests exercise the cross-slice interaction (`compilation` → `commands`) which mocks alone wouldn't catch. Helper unit tests cover the predicate logic in isolation.
+- **Unchanged invariants:**
+  - `commands` slice initial values stay `true`.
+  - `handleUpdateEditorZoomLevel`, `handleUpdateEditorContent`, `handleUpdateIsDirty` observable behaviour is unchanged (the refactor extracts shared logic but doesn't alter what gets written or when).
+  - `executeCommand`'s contract — read the slice, run if true — is unchanged.
+  - The `disabled={!commands[command]}` pattern in `toolbar-button-standard.tsx` is unchanged.
+  - Other commands not gated on `isCompilationReady` are unaffected.
+  - `zoomLevel` slice value remains init-true-and-never-updated (out of scope for this fix).
+  - `handleLogError` writes (`runtimeErrors`) are untouched.
+
+**Audit follow-up:** if other commands are later found to gate on `isCompilationReady` and not be re-evaluated on recovery, extend the helper set the same way. Initial sweep during plan review found only zoom + `exportSpecification`; no others surfaced.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| The fix introduces drift between the two helpers if predicates change. | Both sites use the helpers after the refactor — single source of truth per command set. Adding a new gate to one of the predicates updates both call sites at once. |
+| `handleCompile` is invoked frequently (debounced compile per keystroke); always re-writing flags on success could thrash. | React subscribers skip re-renders for unchanged primitive values (Zustand's selector-side shallow-equal). The `set()` allocation cost is one helper call + one object spread per success compile — trivial. |
+| The test fixture mock pattern in this codebase omits `status` from `compileSpec` results, which would produce a false-negative regression guard. | Unit 1's approach explicitly requires `status: 'ready'` in the success-case mock. Documented in the test patterns section. |
+| Other compilation-gated commands may have the same deadlock pattern undetected. | Scope-confirmed during plan review: only zoom and `exportSpecification` matched the pattern in the current codebase. Future surfacing handled by extending the helper set. |
+| The unconditional commands write fires on every compile, including debounced edit-time compiles. | Both helpers are pure boolean evaluators; the slice merge is shallow-equal-friendly at the React-subscriber layer. No render thrash because subscribers see unchanged primitive values. |
+
+## Documentation / Operational Notes
+
+- No release notes needed beyond a one-line CHANGELOG entry: "Fix: zoom controls and the spec exporter no longer become permanently disabled if used during a parse-error state."
+- No bundle-size impact (two new helpers, ~30 lines combined).
+- No rollout / monitoring concerns — UI bug fix on the visual's internal state machinery.
+- A `/ce:compound` doc capturing the "recovery-path write must mirror error-path writes for cross-slice command-enabled state" pattern is worth writing after this lands. The base pattern (lifecycle owns identity token) is already documented; this is a specific application worth surfacing under a slightly different lens — "the slice that gets written during error must get rewritten during recovery, even when the writer and the slice live in different state slices."
+
+## Sources & References
+
+- Related code:
+  - [`packages/app-core/src/state/commands.ts`](packages/app-core/src/state/commands.ts)
+  - [`packages/app-core/src/state/editor.ts`](packages/app-core/src/state/editor.ts) — `handleUpdateEditorZoomLevel` (lines 362-383), `handleUpdateEditorContent` (~306), `handleUpdateIsDirty` (~333)
+  - [`packages/app-core/src/state/compilation.ts`](packages/app-core/src/state/compilation.ts) — `handleCompile`
+  - [`packages/app-core/src/lib/commands/state.ts`](packages/app-core/src/lib/commands/state.ts) — existing predicates, target for new helpers
+  - [`packages/app-core/src/lib/commands/actions.ts`](packages/app-core/src/lib/commands/actions.ts) — `executeCommand`
+  - [`packages/app-core/src/lib/commands/types.ts`](packages/app-core/src/lib/commands/types.ts) — `Command` union, `CommandsSliceProperties`
+  - [`packages/app-core/src/components/ui/toolbar/toolbar-button-standard.tsx`](packages/app-core/src/components/ui/toolbar/toolbar-button-standard.tsx) — read site
+- Institutional learnings:
+  - [`docs/solutions/best-practices/lifecycle-owns-effect-rebind-identity-token-2026-04-28.md`](docs/solutions/best-practices/lifecycle-owns-effect-rebind-identity-token-2026-04-28.md)
+  - [`docs/solutions/best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md`](docs/solutions/best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md)
+  - [`docs/solutions/best-practices/pure-setstate-updaters-no-dom-side-effects-2026-04-21.md`](docs/solutions/best-practices/pure-setstate-updaters-no-dom-side-effects-2026-04-21.md)
+  - [`docs/solutions/best-practices/dedup-synthetic-identity-token-rebind-trigger-2026-04-28.md`](docs/solutions/best-practices/dedup-synthetic-identity-token-rebind-trigger-2026-04-28.md)
+- Plan review context:
+  - Feasibility review confirmed: deadlock is a structural omission, not a regression introduced by any specific commit. Bisection skipped.
+  - Adversarial review surfaced: `exportSpecification` shares the deadlock pattern; `compileSpec` mock pattern needs `status: 'ready'` explicit; conditional vs unconditional `handleCompile` write needs commit. All resolved during planning.

--- a/docs/solutions/best-practices/keep-non-canonical-children-out-of-dom-positional-parents-2026-04-29.md
+++ b/docs/solutions/best-practices/keep-non-canonical-children-out-of-dom-positional-parents-2026-04-29.md
@@ -1,0 +1,100 @@
+---
+title: "Keep non-canonical children out of DOM-positional parent components"
+date: 2026-04-29
+category: best-practices
+module: app-core/debug-area, fluent-ui-9, react
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Placing structural / portal-mount nodes near a radio group, tab list, accordion, or focus trap
+  - Adding tooltip mount divs inside a composite ARIA widget
+  - Nesting foreign children inside react-window / react-virtualized lists
+  - Working with any component whose internal traversal relies on child role, type, or index
+  - A library upgrade is anticipated that could change internal child-iteration heuristics
+tags:
+  - fluent-ui
+  - accessibility
+  - keyboard-navigation
+  - roving-tabindex
+  - dom-structure
+  - composite-widget
+  - silent-dependency
+related_components:
+  - app-core/features/debug-area/components/debug-toolbar.tsx
+  - app-core/components/ui/tooltip-custom-mount.tsx
+---
+
+# Keep non-canonical children out of DOM-positional parent components
+
+## Context
+
+Fluent UI v9 composite widgets — `<ToolbarRadioGroup>`, `<TabList>`, `<AccordionItem>` — and their ARIA-spec equivalents (`menubar`, `listbox`, `grid`, `radiogroup`) manage keyboard navigation via internal traversal heuristics. Those heuristics walk the component's children to build a roving-tabindex map (or to compute layout, or to enforce focus order).
+
+During a polish pass on Deneb's debug-pane toolbar, four `<TooltipCustomMount>` elements (plain `<div>` portal-mount nodes) were placed *inside* `<ToolbarRadioGroup>` alongside the four `<ToolbarRadioButton>` children. Manual keyboard QA passed — Tab into the group focused the first radio, arrow keys cycled correctly, Tab exited cleanly. The four extra divs were invisible to navigation.
+
+A PR reviewer flagged the implementation detail behind the passing QA: Fluent UI v9's current implementation queries the radio group's children by `[role="radio"]`, filtering out the divs. That's an implementation detail, not a contract. A future Fluent minor bump could change the traversal to "all children," "first focusable child," or "by index" — silently breaking navigation with no code change on our side.
+
+## Guidance
+
+**Components with DOM-positional contracts should contain only their canonical child type.** When a foreign child is needed nearby (e.g. a portal mount div, a measurement shim, a hidden skip-link anchor), place it as a **sibling** of the constrained parent, not nested inside it.
+
+`mountNode`-style props on portal libraries (Fluent UI `<Tooltip>`, React's `createPortal`, etc.) accept any DOM node regardless of its tree position. The mount div's *physical placement* in the React tree is irrelevant to where the portal renders — the portal targets the DOM node by reference, not by tree position.
+
+```tsx
+// Before — non-radio divs interleaved inside the radio group:
+<ToolbarRadioGroup>
+    <Tooltip mountNode={sourceMount}><ToolbarRadioButton .../></Tooltip>
+    <TooltipCustomMount setRef={setSourceMount} />
+    <Tooltip mountNode={dataMount}><ToolbarRadioButton .../></Tooltip>
+    <TooltipCustomMount setRef={setDataMount} />
+    {/* ... */}
+</ToolbarRadioGroup>
+
+// After — mount divs as siblings of the radio group:
+<ToolbarRadioGroup>
+    <Tooltip mountNode={sourceMount}><ToolbarRadioButton .../></Tooltip>
+    <Tooltip mountNode={dataMount}><ToolbarRadioButton .../></Tooltip>
+    {/* ... */}
+</ToolbarRadioGroup>
+<TooltipCustomMount setRef={setSourceMount} />
+<TooltipCustomMount setRef={setDataMount} />
+{/* ... */}
+```
+
+Tooltip behavior is preserved completely. `mountNode` accepts the same DOM node regardless of where it lives in the tree.
+
+## Why This Matters
+
+"Passing QA today" is not the same as "correct." A library version bump can change traversal heuristics without warning:
+
+- Fluent UI v9's current `[role="radio"]` filter — could change to `Array.from(children)` indexing.
+- A `react-window` size-measurement walk — could change to count direct children for virtualization math.
+- An ARIA composite widget's `aria-owns` resolution — could be tightened to the spec's required child contract.
+
+When that happens, a structurally-correct codebase keeps working. A codebase that "got away with it" silently breaks. The failure surfaces as a confusing keyboard-navigation regression, layout glitch, or accessibility audit failure that's hard to trace back to the original placement decision — often discovered after deploy, in production, by a screen-reader user.
+
+The cost of getting placement right at write-time is zero (just hoist the foreign child outside the parent). The cost of getting it wrong is paid by future-you, on a deadline, after a library bump.
+
+## When to Apply
+
+- **Fluent UI `<ToolbarRadioGroup>`** — canonical children are `<ToolbarRadioButton>` only.
+- **Fluent UI `<TabList>`** — canonical children are `<Tab>` elements.
+- **`<AccordionItem>`** and similar disclosure widgets — canonical shape is header + panel body.
+- **`react-window` / `react-virtualized` lists** — item children must be measurable; structural wrappers break sizing math.
+- **ARIA composite widgets** (`menubar`, `listbox`, `grid`, `radiogroup`) — the WAI-ARIA spec defines the required owned-elements contract.
+- **Focus traps** (`<FocusTrapZone>`, `react-focus-lock`) — internal tabbable-element walks expect a stable child shape.
+- **Generally:** any parent whose internal logic makes assumptions about its child set to implement navigation, measurement, or accessibility semantics.
+
+## Examples
+
+Portal mount divs, drag-handle sentinels, hidden skip-link anchors, measurement shims, and "developer-only" debug nodes are all common "invisible" children that feel harmless but violate the parent's contract. In each case the fix is the same: hoist the foreign element to be a sibling of the constrained parent rather than a child inside it.
+
+If hoisting isn't possible (the foreign child *must* be a child for layout reasons), wrap the parent in a non-positional outer container that holds both — e.g. wrap `<ToolbarRadioGroup>` in a `<div>` that also contains the mount nodes as siblings.
+
+## Related
+
+- [`usestate-stable-setref-portal-mount-nodes-2026-04-29.md`](usestate-stable-setref-portal-mount-nodes-2026-04-29.md) — companion finding from the same PR; covers the React `useState`/`useRef` and stable-callback invariants for the same `<TooltipCustomMount>` integration. The two invariants stack: this doc covers DOM placement; the companion covers the React render-cycle contract. Both must hold for the pattern to be durable.
+- [`render-self-contained-components-bare-2026-04-29.md`](render-self-contained-components-bare-2026-04-29.md) — third companion from the same PR. Different angle on structural discipline: check the component's render output before wrapping it (analogue of "check the parent's traversal contract before nesting inside it" that this doc captures).
+- [`lifecycle-owns-effect-rebind-identity-token-2026-04-28.md`](lifecycle-owns-effect-rebind-identity-token-2026-04-28.md) — same family of "silent dependencies on library/runtime contracts that a version bump can expose."
+- [`../ui-bugs/modal-dialog-tab-trapped-by-keyboard-focus-handler-2026-04-10.md`](../ui-bugs/modal-dialog-tab-trapped-by-keyboard-focus-handler-2026-04-10.md) — keyboard-focus interaction with composite widgets in this codebase; concrete example of how a parent's traversal heuristic and a sibling handler can interact in unexpected ways.

--- a/docs/solutions/best-practices/render-self-contained-components-bare-2026-04-29.md
+++ b/docs/solutions/best-practices/render-self-contained-components-bare-2026-04-29.md
@@ -1,0 +1,93 @@
+---
+title: "Render self-contained components bare — avoid doubled layout chrome"
+date: 2026-04-29
+category: best-practices
+module: app-core/debug-area, react
+problem_type: best_practice
+component: tooling
+severity: low
+applies_when:
+  - You're about to wrap a component invocation in a styled `<div>` chain
+  - You find yourself copying the same wrapper structure across multiple call sites of one component
+  - The component's name signals completeness — `ProcessingDataMessage`, `EmptyState`, `LoadingPanel`, etc.
+  - During code review, an early-return contains layout chrome plus a single component invocation
+  - You're reviewing JSX that has more wrapper divs than meaningful elements
+tags:
+  - react
+  - layout
+  - composition
+  - dom-noise
+  - structural-duplication
+  - self-contained
+related_components:
+  - app-core/features/debug-area/components/data-table/processing-data-message.tsx
+  - app-core/features/debug-area/components/dataset-viewer/data-tab.tsx
+  - app-core/features/debug-area/components/dataset-viewer/source-tab.tsx
+---
+
+# Render self-contained components bare — avoid doubled layout chrome
+
+## Context
+
+In Deneb, two data-viewer tab components (`data-tab.tsx` and `source-tab.tsx`) each had early-return guards that wrapped a `<ProcessingDataMessage />` invocation in three nested `<div>` elements using `useDebugWrapperStyles`-derived classes. `ProcessingDataMessage` renders that same three-level wrapper internally via the same hook. The result was a doubled shell: `container > wrapper > details > container > wrapper > details > Spinner`. The pattern predated the polish-pass branch; a PR reviewer flagged it when an `aria-busy` addition drew fresh attention to the file.
+
+## Guidance
+
+Before adding layout chrome around a component invocation, inspect the component's render output. If it already returns a styled root element — particularly one using `makeStyles`, `useStyles`, or an equivalent hook — the outer wrapper is redundant. Drop it and render the component bare.
+
+```tsx
+// Before — doubled shell
+if (isLoading) {
+    return (
+        <div className={classes.container}>
+            <div className={classes.wrapper}>
+                <div className={classes.details}>
+                    <ProcessingDataMessage />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+// After — component is self-contained
+if (isLoading) {
+    return <ProcessingDataMessage />;
+}
+```
+
+The populated-data return path in the same file correctly keeps its wrapper because `<DataTableViewer />` does not render its own chrome — that wrapper earns its place. The distinction: does the child manage its own layout root? If yes, the outer wrapper is dead weight.
+
+## Why This Matters
+
+Doubled shells are visually silent — they don't throw errors, fail tests, or block ship. Their cost accumulates invisibly:
+
+- **DOM noise:** extra nodes React reconciles, extra CSS classes browsers compute, extra levels accessibility tools traverse.
+- **Debugging friction:** when overflow clipping, margin collapse, or focus trapping misbehaves, the doubled chrome doubles the surface area to inspect.
+- **Ownership ambiguity:** two `container > wrapper > details` stacks with no clear authority — tuning spacing tokens on one may silently leave the other adrift.
+- **Diff readability:** a 9-line early-return is harder to scan than a 1-line one; multiply across many call sites and the noise compounds.
+
+The fix takes 60 seconds. The principle is simply: "if a function does X, don't wrap it in another function that does X."
+
+## When to Apply
+
+- Before wrapping any component invocation in a styled `<div>` chain.
+- When you find yourself copying the same wrapper structure across multiple call sites of one component.
+- When a component's name signals completeness: `ProcessingDataMessage`, `EmptyState`, `LoadingPanel` — names that imply the component owns its own presentation.
+- During code review: an early-return containing layout chrome plus a single component invocation is the canonical smell.
+
+## Examples
+
+Canonical fix in this codebase: `data-tab.tsx` and `source-tab.tsx`, where three-level wrappers around `<ProcessingDataMessage />` were reduced to bare invocations. A quick grep surfaces similar patterns:
+
+```bash
+# Find call sites that wrap components in styled divs:
+rg -B 2 -A 2 'classes\.(container|wrapper)' --type tsx
+```
+
+When the wrapper around `<SomeCompleteComponent />` mirrors the chrome inside it, drop the outer wrapper. If you DO need additional positioning at the call site (e.g. a Flex parent with specific gap/padding), reach for a single semantic wrapper instead of duplicating the component's entire chrome.
+
+## Related
+
+- [`extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md`](extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md) — doubled layout chrome is a structural form of dual maintenance: two wrappers must be kept in sync if either's shape changes. Different fix (delete vs extract), same underlying smell of structural duplication caught only by reviewer.
+- [`usestate-stable-setref-portal-mount-nodes-2026-04-29.md`](usestate-stable-setref-portal-mount-nodes-2026-04-29.md) — companion finding from the same PR; pattern of "check the component's source before integrating it." That doc covers the React contract; this doc covers the DOM contract.
+- [`keep-non-canonical-children-out-of-dom-positional-parents-2026-04-29.md`](keep-non-canonical-children-out-of-dom-positional-parents-2026-04-29.md) — companion from the same PR; structural-placement discipline. That doc covers child placement inside DOM-positional parents; this doc covers wrapping discipline at call sites.

--- a/docs/solutions/best-practices/usestate-stable-setref-portal-mount-nodes-2026-04-29.md
+++ b/docs/solutions/best-practices/usestate-stable-setref-portal-mount-nodes-2026-04-29.md
@@ -1,0 +1,143 @@
+---
+title: "Portal-mount-ref slots use useState and identity-stable setters"
+date: 2026-04-29
+category: best-practices
+module: app-core/debug-area, react, fluent-ui-9
+problem_type: best_practice
+component: tooling
+severity: high
+applies_when:
+  - You are mounting a Fluent UI Tooltip (or any portal component) to a custom DOM node via `mountNode` / `portalRoot`
+  - You hold a DOM reference whose value is read by JSX expressions during render (not just by event handlers)
+  - You are consolidating multiple ref slots into a single useRef/useState record to "reduce boilerplate"
+  - A reviewer recommends replacing several useState pairs with one useRef
+  - You are writing a `setRef` callback inline as an arrow function rather than passing a setter directly
+tags:
+  - react
+  - fluent-ui
+  - tooltips
+  - portal
+  - useref-vs-usestate
+  - ref-callback
+  - render-loop
+  - canonical-pattern
+related_components:
+  - app-core/components/ui/toolbar/toolbar-button-standard.tsx
+  - app-core/features/debug-area/components/debug-toolbar.tsx
+  - app-core/components/ui/tooltip-custom-mount.tsx
+---
+
+# Portal-mount-ref slots use useState and identity-stable setters
+
+## Context
+
+Fluent UI v9 (and similar component libraries) support custom portal mount points via a pattern where a child component (`<TooltipCustomMount>`) populates a parent-held ref slot via a `setRef` callback prop, and the parent passes that slot to `<Tooltip mountNode={...}>`. The canonical reference implementation in [`packages/app-core/src/components/ui/toolbar/toolbar-button-standard.tsx`](packages/app-core/src/components/ui/toolbar/toolbar-button-standard.tsx#L80) uses ONE `useState<HTMLElement | null>` per button, passing the state setter directly as `setRef={setRef}`:
+
+```tsx
+const [ref, setRef] = useState<HTMLElement | null>();
+// ...
+<Tooltip mountNode={ref}>...</Tooltip>
+<TooltipCustomMount setRef={setRef} />
+```
+
+For a four-button toolbar, a doc-review reviewer recommended "consolidate four `useState` pairs into one `useRef<Record<DebugPaneRole, HTMLElement | null>>`" as a "premature-complexity simplification." Two consecutive attempts to follow that direction violated different React contracts and broke the pattern in different ways.
+
+## Guidance
+
+Two invariants must BOTH hold for any portal-mount-ref slot. Violating either produces a distinct bug.
+
+**Invariant 1: Use `useState`, not `useRef`, for the mount slot.**
+
+The mount-ref assignment must trigger a re-render so the parent's `<Tooltip mountNode={...}>` (or equivalent prop on a similar component) picks up the populated DOM node on the next render. `useRef` mutations are invisible to React's render cycle — the prop value freezes at whatever the initial render saw (`null`).
+
+**Invariant 2: The `setRef` callback identity must be stable across renders.**
+
+React's ref-callback contract: when the callback's identity changes between renders, the OLD callback is called with `null` (detach) and the NEW callback is called with the element (attach). Inline arrow functions (`setRef={(el) => doStuff(el)}`) are recreated each render — new identity each render → infinite detach/reattach + setState + re-render loop.
+
+The simplest way to satisfy both invariants: pass the React state setter directly as the ref callback. State setters are identity-stable by React's contract. Alternative: wrap the closure with `useCallback(fn, [])`.
+
+**For multiple slots in one component, prefer N separate `useState` pairs over one `useState<Record<...>>` with inline closures.** The single-record approach forces inline-callback violations of Invariant 2 without ergonomic benefit. Consolidation is the wrong simplification axis here.
+
+## Why This Matters
+
+The two failure modes have very different visibility:
+
+**Invariant 1 violation (`useRef`)** — silent breakage. The Tooltip mounts to Fluent's default portal target instead of the custom mount node. Visual symptoms only — wrong z-index, wrong stacking context, possible clipping at scroll boundaries. No error is thrown. No automated test in node-env vitest can catch it (the failure is in React's rendering output, not in the component's reasoning logic). This branch's review needed three independent reviewers (correctness, julik-frontend-races, reliability) at 0.88-0.97 confidence to surface it.
+
+**Invariant 2 violation (inline closures)** — loud breakage. React immediately throws on first hover or first commit:
+
+```text
+Error: Maximum update depth exceeded.
+    at dispatchSetState
+    at setRef (debug-toolbar.tsx)
+    at safelyDetachRef
+    at commitMutationEffectsOnFiber
+```
+
+The crash is fast and obvious, but only surfaces during manual testing — pure-helper unit tests don't render React, so they pass while production crashes.
+
+**Meta-lesson on reviewer feedback (auto memory [claude]):** a reviewer's high-confidence "premature complexity" or "simplification" suggestion deserves a verification step against the canonical pattern in the codebase, not blind compliance. The canonical pattern in this codebase exists *for a reason* — it was deliberately written to satisfy both invariants. Consolidating multiple slots into one record looked like reduced boilerplate but broke the underlying contract twice in a row. The codebase's functional-programming preference and behavior-not-implementation test philosophy don't help here either: both bugs are in the *rendering shape* of the component, which the test suite (vitest in node env, no jsdom) can't observe. Human eyes on the canonical pattern were the only catch.
+
+## When to Apply
+
+- Any pattern where a child component populates a parent-held slot via a ref callback prop.
+- Fluent UI `<TooltipCustomMount setRef={...}>` paired with `<Tooltip mountNode={...}>`.
+- Any library's "custom portal mount" API that hands back a DOM node via a callback.
+- Anytime you reach for `useRef` to hold a DOM node whose value is read by another prop on the same render.
+- When a reviewer suggests consolidating several `useState<HTMLElement | null>` pairs into one record — pause and verify the canonical pattern's intent before complying.
+
+## Examples
+
+**Before #1 — `useRef<Record<...>>` (silent breakage):**
+
+```tsx
+const mountRefs = useRef<Record<DebugPaneRole, HTMLElement | null>>({
+    source: null, data: null, signal: null, log: null,
+});
+<Tooltip mountNode={mountRefs.current.source}>...</Tooltip>
+<TooltipCustomMount setRef={(el) => { mountRefs.current.source = el; }} />
+// First render: mountNode={null}. setRef fires in commit phase, mutates ref,
+// but no re-render. Tooltip already mounted to default portal — for the
+// component's lifetime. TooltipCustomMount is structurally pointless.
+```
+
+**Before #2 — `useState<Record<...>>` with inline closures (infinite loop):**
+
+```tsx
+const [mountNodes, setMountNodes] = useState<Record<DebugPaneRole, HTMLElement | null>>({
+    source: null, data: null, signal: null, log: null,
+});
+<Tooltip mountNode={mountNodes.source}>...</Tooltip>
+<TooltipCustomMount
+    setRef={(el) => { setMountNodes((prev) => ({ ...prev, source: el })); }}
+/>
+// Each render creates a new arrow → new ref-callback identity →
+// React calls old(null) + new(el) → setState → re-render → repeat.
+// Crashes immediately with "Maximum update depth exceeded".
+```
+
+**Final — four `useState` pairs, setter passed directly:**
+
+```tsx
+const [sourceMount, setSourceMount] = useState<HTMLElement | null>(null);
+const [dataMount, setDataMount] = useState<HTMLElement | null>(null);
+const [signalMount, setSignalMount] = useState<HTMLElement | null>(null);
+const [logMount, setLogMount] = useState<HTMLElement | null>(null);
+
+<Tooltip mountNode={sourceMount}>...</Tooltip>
+<TooltipCustomMount setRef={setSourceMount} />
+// (× 4)
+// State setters are identity-stable. Each assignment triggers exactly
+// one re-render that picks up the populated mountNode. No detach/reattach
+// loop. Matches the canonical toolbar-button-standard.tsx pattern.
+```
+
+## Related
+
+- [`keep-non-canonical-children-out-of-dom-positional-parents-2026-04-29.md`](keep-non-canonical-children-out-of-dom-positional-parents-2026-04-29.md) — companion finding from the same PR. This doc covers the React render-cycle invariants (`useState` over `useRef`, stable callback identity); the companion covers the DOM placement invariant (mount divs go *outside* the radio group, not inside). Both must hold for the pattern to be durable.
+- [`render-self-contained-components-bare-2026-04-29.md`](render-self-contained-components-bare-2026-04-29.md) — third companion from the same PR. The "check the canonical pattern before consolidating" discipline behind this doc generalises to the "check the component's render output before wrapping it" discipline that one captures.
+- [`pure-setstate-updaters-no-dom-side-effects-2026-04-21.md`](pure-setstate-updaters-no-dom-side-effects-2026-04-21.md) — sibling "React contract violation caught by reviewer" pattern; same debug-pane toolbar context. Renders-synced refs + pure updaters address a different invariant; the canonical-pattern verification discipline is the same.
+- [`lifecycle-owns-effect-rebind-identity-token-2026-04-28.md`](lifecycle-owns-effect-rebind-identity-token-2026-04-28.md) — companion: identity tokens for effect rebinding share the same "React contract about identity" family as ref-callback identity stability.
+- [`singleton-worker-addEventListener-ownership-filter-2026-04-28.md`](singleton-worker-addEventListener-ownership-filter-2026-04-28.md) — "one owner per channel" applied to Worker `onmessage`; callback-identity invariants matter here too.
+- [`extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md`](extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md) — reviewer-recommended consolidation that introduced drift; same pattern of "simplification suggestion that violated an invariant."
+- [`../logic-errors/stale-echo-triple-render-on-apply-2026-04-10.md`](../logic-errors/stale-echo-triple-render-on-apply-2026-04-10.md) — render-thrash bug; same family of "state setter churn produces unexpected render cycles."

--- a/packages/app-core/src/lib/commands/__tests__/state.test.ts
+++ b/packages/app-core/src/lib/commands/__tests__/state.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import type { CompilationResult } from '@deneb-viz/vega-runtime/compilation';
+import { VISUAL_PREVIEW_ZOOM_CONFIGURATION } from '@deneb-viz/configuration';
+
+import {
+    evaluateExportSpecCommandState,
+    evaluateZoomCommandsState
+} from '../state';
+
+/**
+ * Pure-helper unit tests for the two `commands` slice evaluators added in
+ * Unit 2 of the recovery-on-compile plan. The helpers are the single
+ * source of truth shared between the user-action writers
+ * (`handleUpdateEditorZoomLevel`, `handleUpdateChanges`,
+ * `handleUpdateIsDirty`) and `handleCompile`'s success-branch recovery
+ * write. These tests pin the predicate logic in isolation; integration
+ * coverage lives in `state/__tests__/commands-recovery.test.ts`.
+ */
+
+const READY_RESULT: CompilationResult = {
+    status: 'ready',
+    parsed: {} as never,
+    embedOptions: {}
+};
+const ERROR_RESULT: CompilationResult = {
+    status: 'error',
+    parsed: {} as never,
+    embedOptions: {},
+    errors: ['boom']
+};
+
+const ZOOM_MIN = VISUAL_PREVIEW_ZOOM_CONFIGURATION.min;
+const ZOOM_MAX = VISUAL_PREVIEW_ZOOM_CONFIGURATION.max;
+const ZOOM_MID = VISUAL_PREVIEW_ZOOM_CONFIGURATION.default;
+
+describe('evaluateZoomCommandsState', () => {
+    it('returns all four flags true when at a mid zoom level and compilation is ready', () => {
+        expect(evaluateZoomCommandsState(ZOOM_MID, READY_RESULT)).toEqual({
+            zoomFit: true,
+            zoomIn: true,
+            zoomOut: true,
+            zoomReset: true
+        });
+    });
+
+    it('returns zoomOut false at the min zoom boundary even when ready', () => {
+        const result = evaluateZoomCommandsState(ZOOM_MIN, READY_RESULT);
+        expect(result.zoomOut).toBe(false);
+        expect(result.zoomIn).toBe(true);
+        expect(result.zoomFit).toBe(true);
+        expect(result.zoomReset).toBe(true);
+    });
+
+    it('returns zoomIn false at the max zoom boundary even when ready', () => {
+        const result = evaluateZoomCommandsState(ZOOM_MAX, READY_RESULT);
+        expect(result.zoomIn).toBe(false);
+        expect(result.zoomOut).toBe(true);
+        expect(result.zoomFit).toBe(true);
+        expect(result.zoomReset).toBe(true);
+    });
+
+    it('returns all four flags false when compilation is in error, regardless of zoom level', () => {
+        expect(evaluateZoomCommandsState(ZOOM_MID, ERROR_RESULT)).toEqual({
+            zoomFit: false,
+            zoomIn: false,
+            zoomOut: false,
+            zoomReset: false
+        });
+    });
+
+    it('returns all four flags false when compilation result is null, regardless of zoom level', () => {
+        expect(evaluateZoomCommandsState(ZOOM_MID, null)).toEqual({
+            zoomFit: false,
+            zoomIn: false,
+            zoomOut: false,
+            zoomReset: false
+        });
+    });
+
+    it('returns all four flags false at the min boundary when compilation is in error', () => {
+        expect(evaluateZoomCommandsState(ZOOM_MIN, ERROR_RESULT)).toEqual({
+            zoomFit: false,
+            zoomIn: false,
+            zoomOut: false,
+            zoomReset: false
+        });
+    });
+
+    it('returns all four flags false at the max boundary when compilation is null', () => {
+        expect(evaluateZoomCommandsState(ZOOM_MAX, null)).toEqual({
+            zoomFit: false,
+            zoomIn: false,
+            zoomOut: false,
+            zoomReset: false
+        });
+    });
+});
+
+describe('evaluateExportSpecCommandState', () => {
+    it('returns exportSpecification true when editor is clean and compilation is ready', () => {
+        expect(evaluateExportSpecCommandState(false, READY_RESULT)).toEqual({
+            exportSpecification: true
+        });
+    });
+
+    it('returns exportSpecification false when editor is dirty even if compilation is ready', () => {
+        expect(evaluateExportSpecCommandState(true, READY_RESULT)).toEqual({
+            exportSpecification: false
+        });
+    });
+
+    it('returns exportSpecification false when compilation is in error even if editor is clean', () => {
+        expect(evaluateExportSpecCommandState(false, ERROR_RESULT)).toEqual({
+            exportSpecification: false
+        });
+    });
+
+    it('returns exportSpecification false when both editor is dirty and compilation is in error', () => {
+        expect(evaluateExportSpecCommandState(true, ERROR_RESULT)).toEqual({
+            exportSpecification: false
+        });
+    });
+
+    it('returns exportSpecification false when compilation result is null and editor is clean', () => {
+        expect(evaluateExportSpecCommandState(false, null)).toEqual({
+            exportSpecification: false
+        });
+    });
+
+    it('returns exportSpecification false when compilation result is null and editor is dirty', () => {
+        expect(evaluateExportSpecCommandState(true, null)).toEqual({
+            exportSpecification: false
+        });
+    });
+});

--- a/packages/app-core/src/lib/commands/index.ts
+++ b/packages/app-core/src/lib/commands/index.ts
@@ -1,10 +1,14 @@
 export * from './actions';
 export { HOTKEY_OPTIONS } from './constants';
 export {
+    evaluateExportSpecCommandState,
+    evaluateZoomCommandsState,
     getNextApplyMode,
+    isCompilationReady,
     isExportSpecCommandEnabled,
     isZoomInCommandEnabled,
     isZoomOtherCommandsEnabled,
     isZoomOutCommandEnabled
 } from './state';
+export type { ExportSpecCommandState, ZoomCommandsState } from './state';
 export type * from './types';

--- a/packages/app-core/src/lib/commands/state.ts
+++ b/packages/app-core/src/lib/commands/state.ts
@@ -17,9 +17,8 @@ export const getNextApplyMode = (
 /**
  * Check if compilation result indicates a valid/ready specification.
  */
-export const isCompilationReady = (
-    result: CompilationResult | null
-): boolean => result?.status === 'ready';
+export const isCompilationReady = (result: CompilationResult | null): boolean =>
+    result?.status === 'ready';
 
 /**
  * Tests whether the export specification command is enabled.
@@ -48,3 +47,79 @@ export const isZoomOtherCommandsEnabled = (
 export const isZoomOutCommandEnabled = (options: ZoomLevelCommandTestOptions) =>
     options.value !== VISUAL_PREVIEW_ZOOM_CONFIGURATION.min &&
     isCompilationReady(options.compilationResult);
+
+/**
+ * Result shape produced by {@link evaluateZoomCommandsState}. Mirrors the
+ * subset of the `commands` slice (defined in
+ * `packages/app-core/src/state/commands.ts` as
+ * `CommandsSliceProperties`) that the zoom controls write. Inlined as a
+ * literal type rather than `Pick<CommandsSliceProperties, ...>` to avoid
+ * the `lib → state → lib` import cycle that the latter would introduce.
+ *
+ * Note: `zoomLevel` is intentionally excluded — it has no dynamic
+ * predicate and its slice value is initialised to `true` and never
+ * updated. Adding it here would speculatively widen the contract.
+ */
+export type ZoomCommandsState = {
+    zoomFit: boolean;
+    zoomIn: boolean;
+    zoomOut: boolean;
+    zoomReset: boolean;
+};
+
+/**
+ * Result shape produced by {@link evaluateExportSpecCommandState}.
+ * Inlined for the same reason as {@link ZoomCommandsState}.
+ */
+export type ExportSpecCommandState = {
+    exportSpecification: boolean;
+};
+
+/**
+ * Pure helper that evaluates the four zoom command enabled flags from the
+ * current zoom level and compilation result. Single source of truth for
+ * the zoom-gate predicates: called from `handleUpdateEditorZoomLevel`
+ * (the user-action writer) and from `handleCompile`'s success branch
+ * (the recovery write that re-enables zoom after a parse-error click).
+ *
+ * Pure: no closures over store state, no side effects.
+ */
+export const evaluateZoomCommandsState = (
+    zoomLevel: number,
+    compilationResult: CompilationResult | null
+): ZoomCommandsState => {
+    const zoomLevelOptions: ZoomLevelCommandTestOptions = {
+        value: zoomLevel,
+        compilationResult
+    };
+    const zoomOtherOptions: ZoomOtherCommandTestOptions = {
+        compilationResult
+    };
+    const otherEnabled = isZoomOtherCommandsEnabled(zoomOtherOptions);
+    return {
+        zoomFit: otherEnabled,
+        zoomIn: isZoomInCommandEnabled(zoomLevelOptions),
+        zoomOut: isZoomOutCommandEnabled(zoomLevelOptions),
+        zoomReset: otherEnabled
+    };
+};
+
+/**
+ * Pure helper that evaluates the `exportSpecification` command enabled
+ * flag from the editor dirty state and compilation result. Single source
+ * of truth for the export-gate predicate: called from
+ * `handleUpdateChanges` and `handleUpdateIsDirty` (the user-action
+ * writers) and from `handleCompile`'s success branch (the recovery write
+ * that re-enables export after a keystroke during a parse-error state).
+ *
+ * Pure: no closures over store state, no side effects.
+ */
+export const evaluateExportSpecCommandState = (
+    editorIsDirty: boolean,
+    compilationResult: CompilationResult | null
+): ExportSpecCommandState => ({
+    exportSpecification: isExportSpecCommandEnabled({
+        editorIsDirty,
+        compilationResult
+    })
+});

--- a/packages/app-core/src/state/__tests__/commands-recovery.test.ts
+++ b/packages/app-core/src/state/__tests__/commands-recovery.test.ts
@@ -1,0 +1,347 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CompilationResult } from '@deneb-viz/vega-runtime/compilation';
+
+/**
+ * Regression tests for the "compilation-gated commands stuck disabled
+ * after parse-error click" bug. See
+ * docs/plans/2026-04-29-001-fix-zoom-stuck-disabled-on-recovery-plan.md.
+ *
+ * Two command sets gate on `isCompilationReady`:
+ *  - The four zoom controls (`zoomIn`, `zoomOut`, `zoomFit`, `zoomReset`),
+ *    written by `handleUpdateEditorZoomLevel`.
+ *  - `exportSpecification`, written by `handleUpdateChanges` and
+ *    `handleUpdateIsDirty`.
+ *
+ * If the user takes a triggering action (zoom click / editor keystroke)
+ * while compilation is in an error state, the writer evaluates the gate
+ * with `isCompilationReady === false` and writes `false` into the
+ * `commands` slice. `handleCompile` reaching `ready` does NOT currently
+ * re-evaluate the gates, so the slice stays `false` until the user takes
+ * the same triggering action again — at which point zoom buttons are
+ * disabled, so the user can't trigger them. Deadlock.
+ *
+ * Unit 2 of the plan adds a conditional recovery write to `handleCompile`
+ * that re-evaluates both gates on `result.status === 'ready'`. The
+ * "REGRESSION GUARD" tests below FAIL before Unit 2 and PASS after.
+ *
+ * Critical fixture detail: the `compileSpec` mock in
+ * `compilation-render-id.test.ts` deliberately omits `status` because that
+ * file is asserting `renderId` does not change regardless of result shape.
+ * For the recovery-write tests below, the success-case mock MUST include
+ * `status: 'ready'` and a minimal `parsed` object so `isCompilationReady`
+ * actually returns `true`. Without that, every test would pass for the
+ * wrong reason (the recovery write would no-op even after the fix).
+ */
+
+const READY_RESULT: CompilationResult = {
+    status: 'ready',
+    parsed: {} as never,
+    embedOptions: {}
+};
+const ERROR_RESULT: CompilationResult = {
+    status: 'error',
+    parsed: {} as never,
+    embedOptions: {},
+    errors: ['boom']
+};
+
+vi.mock('@deneb-viz/vega-runtime/compilation', async () => {
+    const actual = await vi.importActual<
+        typeof import('@deneb-viz/vega-runtime/compilation')
+    >('@deneb-viz/vega-runtime/compilation');
+    return {
+        ...actual,
+        compileSpec: vi.fn(() => READY_RESULT)
+    };
+});
+
+import { compileSpec } from '@deneb-viz/vega-runtime/compilation';
+import { createDenebState } from '../state';
+
+// Mirror the `VISUAL_PREVIEW_ZOOM_CONFIGURATION` constants used by the
+// predicates so test intent is unambiguous. If these change in
+// configuration, update them here too.
+const ZOOM_MIN = 10;
+const ZOOM_MAX = 400;
+const ZOOM_MID = 100;
+
+/**
+ * Build a fresh, fully-wired Deneb state store per test. Using the real
+ * store factory rather than hand-rolling slice composition avoids the
+ * circular-import problem (`editor.ts` imports `StoreState` from
+ * `./state`) and ensures cross-slice writes work the same way they do at
+ * runtime.
+ */
+const makeStore = () => createDenebState({ applicationVersion: 'test' });
+
+/**
+ * Force the compilation result into a non-ready state without going
+ * through the `compile()` action. Used to set up the error precondition
+ * that the triggering writer reads.
+ */
+const setCompilationResult = (
+    store: ReturnType<typeof makeStore>,
+    result: CompilationResult | null
+) => {
+    store.setState((s) => ({
+        compilation: { ...s.compilation, result }
+    }));
+};
+
+describe('commands recovery — zoom controls', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(compileSpec).mockReturnValue(READY_RESULT);
+    });
+
+    it('initialises zoom command flags to true', () => {
+        const store = makeStore();
+        const { commands } = store.getState();
+        expect(commands.zoomIn).toBe(true);
+        expect(commands.zoomOut).toBe(true);
+        expect(commands.zoomFit).toBe(true);
+        expect(commands.zoomReset).toBe(true);
+    });
+
+    it('writes false for all zoom flags when a zoom click happens during a parse-error state', () => {
+        const store = makeStore();
+        setCompilationResult(store, ERROR_RESULT);
+
+        // Simulating the user clicking a zoom control while compilation
+        // is in error: `handleZoomIn` -> `executeCommand` -> the slice
+        // ultimately calls `updateEditorZoomLevel(level)`.
+        store.getState().updateEditorZoomLevel(ZOOM_MID);
+
+        const { commands } = store.getState();
+        expect(commands.zoomIn).toBe(false);
+        expect(commands.zoomOut).toBe(false);
+        expect(commands.zoomFit).toBe(false);
+        expect(commands.zoomReset).toBe(false);
+    });
+
+    it('REGRESSION GUARD: re-enables all zoom flags when handleCompile reaches a ready state after a parse-error click. FAILS BEFORE UNIT 2; PASSES AFTER.', () => {
+        const store = makeStore();
+
+        // Step 1: enter error state and trigger the zoom write that
+        // disables the flags.
+        setCompilationResult(store, ERROR_RESULT);
+        store.getState().updateEditorZoomLevel(ZOOM_MID);
+        expect(store.getState().commands.zoomIn).toBe(false);
+
+        // Step 2: a successful recompile. After Unit 2, `handleCompile`
+        // re-evaluates the zoom gate and writes the four flags back.
+        vi.mocked(compileSpec).mockReturnValueOnce(READY_RESULT);
+        store.getState().compilation.compile({} as never);
+
+        const { commands } = store.getState();
+        // zoom level is mid-range, so all four should recover to true.
+        expect(commands.zoomIn).toBe(true);
+        expect(commands.zoomOut).toBe(true);
+        expect(commands.zoomFit).toBe(true);
+        expect(commands.zoomReset).toBe(true);
+    });
+
+    it('preserves zoom flags as true on recovery when no zoom click occurred during the error window', () => {
+        const store = makeStore();
+
+        // Error state but the user never clicked a zoom control.
+        setCompilationResult(store, ERROR_RESULT);
+        // Recovery.
+        vi.mocked(compileSpec).mockReturnValueOnce(READY_RESULT);
+        store.getState().compilation.compile({} as never);
+
+        const { commands } = store.getState();
+        expect(commands.zoomIn).toBe(true);
+        expect(commands.zoomOut).toBe(true);
+        expect(commands.zoomFit).toBe(true);
+        expect(commands.zoomReset).toBe(true);
+    });
+
+    it('disables zoom flags when handleCompile produces an error result, even with no prior zoom click', () => {
+        // Symmetry with exportSpecification: editor-edit writers fire
+        // continuously and self-correct exportSpec on every keystroke during
+        // an error state, so its disable feels "automatic." Zoom has only
+        // one writer (`handleUpdateEditorZoomLevel`) which fires only on
+        // user zoom interaction, so without this symmetric write in
+        // handleCompile, zoom controls would look enabled in a known-bad
+        // state until the user clicks them. This test guards the
+        // handleCompile error-branch write that closes that gap.
+        const store = makeStore();
+
+        // Sanity: flags are true before any compile.
+        expect(store.getState().commands.zoomIn).toBe(true);
+
+        // Compile with an error result; no prior zoom click.
+        vi.mocked(compileSpec).mockReturnValueOnce(ERROR_RESULT);
+        store.getState().compilation.compile({} as never);
+
+        const { commands } = store.getState();
+        expect(commands.zoomIn).toBe(false);
+        expect(commands.zoomOut).toBe(false);
+        expect(commands.zoomFit).toBe(false);
+        expect(commands.zoomReset).toBe(false);
+    });
+
+    it('REGRESSION GUARD: zoom recovery is idempotent across repeated successful compiles. FAILS BEFORE UNIT 2; PASSES AFTER.', () => {
+        const store = makeStore();
+        setCompilationResult(store, ERROR_RESULT);
+        store.getState().updateEditorZoomLevel(ZOOM_MID);
+
+        vi.mocked(compileSpec).mockReturnValue(READY_RESULT);
+        store.getState().compilation.compile({} as never);
+        store.getState().compilation.compile({} as never);
+
+        const { commands } = store.getState();
+        expect(commands.zoomIn).toBe(true);
+        expect(commands.zoomOut).toBe(true);
+        expect(commands.zoomFit).toBe(true);
+        expect(commands.zoomReset).toBe(true);
+    });
+
+    it('REGRESSION GUARD: re-disables zoom flags when a second error follows recovery and the user clicks again. FAILS BEFORE UNIT 2; PASSES AFTER.', () => {
+        const store = makeStore();
+
+        // First error -> click -> recovery cycle.
+        setCompilationResult(store, ERROR_RESULT);
+        store.getState().updateEditorZoomLevel(ZOOM_MID);
+        vi.mocked(compileSpec).mockReturnValueOnce(READY_RESULT);
+        store.getState().compilation.compile({} as never);
+        expect(store.getState().commands.zoomIn).toBe(true);
+
+        // Second error -> click. Should disable again.
+        setCompilationResult(store, ERROR_RESULT);
+        store.getState().updateEditorZoomLevel(ZOOM_MID);
+
+        const { commands } = store.getState();
+        expect(commands.zoomIn).toBe(false);
+        expect(commands.zoomOut).toBe(false);
+        expect(commands.zoomFit).toBe(false);
+        expect(commands.zoomReset).toBe(false);
+    });
+
+    it('REGRESSION GUARD: respects the zoom min boundary on recovery (zoomOut stays false at min, zoomIn re-enables). FAILS BEFORE UNIT 2; PASSES AFTER.', () => {
+        const store = makeStore();
+
+        // Trigger the disable at the min zoom level — `isZoomOutCommandEnabled`
+        // returns false at min regardless of compilation state.
+        setCompilationResult(store, ERROR_RESULT);
+        store.getState().updateEditorZoomLevel(ZOOM_MIN);
+
+        // Recovery — the helper must apply the boundary check, not just
+        // restore everything to true.
+        vi.mocked(compileSpec).mockReturnValueOnce(READY_RESULT);
+        store.getState().compilation.compile({} as never);
+
+        const { commands } = store.getState();
+        expect(commands.zoomOut).toBe(false); // at min, can't zoom out
+        expect(commands.zoomIn).toBe(true); // not at max, can zoom in
+        expect(commands.zoomFit).toBe(true);
+        expect(commands.zoomReset).toBe(true);
+    });
+
+    it('REGRESSION GUARD: respects the zoom max boundary on recovery (zoomIn stays false at max, zoomOut re-enables). FAILS BEFORE UNIT 2; PASSES AFTER.', () => {
+        const store = makeStore();
+
+        setCompilationResult(store, ERROR_RESULT);
+        store.getState().updateEditorZoomLevel(ZOOM_MAX);
+
+        vi.mocked(compileSpec).mockReturnValueOnce(READY_RESULT);
+        store.getState().compilation.compile({} as never);
+
+        const { commands } = store.getState();
+        expect(commands.zoomIn).toBe(false); // at max, can't zoom in
+        expect(commands.zoomOut).toBe(true); // not at min, can zoom out
+        expect(commands.zoomFit).toBe(true);
+        expect(commands.zoomReset).toBe(true);
+    });
+});
+
+describe('commands recovery — exportSpecification', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(compileSpec).mockReturnValue(READY_RESULT);
+    });
+
+    it('initialises exportSpecification to true', () => {
+        const store = makeStore();
+        expect(store.getState().commands.exportSpecification).toBe(true);
+    });
+
+    it('writes false for exportSpecification when an editor isDirty change happens during a parse-error state', () => {
+        const store = makeStore();
+        setCompilationResult(store, ERROR_RESULT);
+
+        // Simulating a keystroke that toggles dirty during error. The
+        // gate is `!editorIsDirty && isCompilationReady` — both conditions
+        // fail here, so the writer must produce false.
+        store.getState().editor.updateIsDirty(true);
+
+        expect(store.getState().commands.exportSpecification).toBe(false);
+    });
+
+    it('REGRESSION GUARD: re-enables exportSpecification when handleCompile reaches ready and editor is no longer dirty. FAILS BEFORE UNIT 2; PASSES AFTER.', () => {
+        const store = makeStore();
+
+        // Step 1: error + dirty=true -> writer disables.
+        setCompilationResult(store, ERROR_RESULT);
+        store.getState().editor.updateIsDirty(true);
+        expect(store.getState().commands.exportSpecification).toBe(false);
+
+        // Step 2: editor reverts to clean (e.g. apply succeeded). The
+        // writer fires again but compilation is still in error, so
+        // exportSpec stays false. This is the deadlock window the
+        // recovery write must close.
+        store.getState().editor.updateIsDirty(false);
+        expect(store.getState().commands.exportSpecification).toBe(false);
+
+        // Step 3: successful recompile. With dirty=false and ready=true,
+        // the recovery write must produce exportSpecification=true.
+        vi.mocked(compileSpec).mockReturnValueOnce(READY_RESULT);
+        store.getState().compilation.compile({} as never);
+
+        expect(store.getState().commands.exportSpecification).toBe(true);
+    });
+
+    it('preserves exportSpecification as true on recovery when no editor change occurred during the error window', () => {
+        const store = makeStore();
+
+        // No keystroke during the error -> the writer never fires ->
+        // exportSpec stays at its initial true.
+        setCompilationResult(store, ERROR_RESULT);
+        vi.mocked(compileSpec).mockReturnValueOnce(READY_RESULT);
+        store.getState().compilation.compile({} as never);
+
+        expect(store.getState().commands.exportSpecification).toBe(true);
+    });
+
+    it('REGRESSION GUARD: exportSpecification recovery is idempotent across repeated successful compiles. FAILS BEFORE UNIT 2; PASSES AFTER.', () => {
+        const store = makeStore();
+        setCompilationResult(store, ERROR_RESULT);
+        store.getState().editor.updateIsDirty(true);
+        store.getState().editor.updateIsDirty(false);
+
+        vi.mocked(compileSpec).mockReturnValue(READY_RESULT);
+        store.getState().compilation.compile({} as never);
+        store.getState().compilation.compile({} as never);
+
+        expect(store.getState().commands.exportSpecification).toBe(true);
+    });
+
+    it('REGRESSION GUARD: re-disables exportSpecification when a second error follows recovery and the editor goes dirty again. FAILS BEFORE UNIT 2; PASSES AFTER.', () => {
+        const store = makeStore();
+
+        // First error -> dirty -> apply -> recovery cycle.
+        setCompilationResult(store, ERROR_RESULT);
+        store.getState().editor.updateIsDirty(true);
+        store.getState().editor.updateIsDirty(false);
+        vi.mocked(compileSpec).mockReturnValueOnce(READY_RESULT);
+        store.getState().compilation.compile({} as never);
+        expect(store.getState().commands.exportSpecification).toBe(true);
+
+        // Second error -> dirty. Should disable again.
+        setCompilationResult(store, ERROR_RESULT);
+        store.getState().editor.updateIsDirty(true);
+
+        expect(store.getState().commands.exportSpecification).toBe(false);
+    });
+});

--- a/packages/app-core/src/state/__tests__/commands-recovery.test.ts
+++ b/packages/app-core/src/state/__tests__/commands-recovery.test.ts
@@ -56,14 +56,16 @@ vi.mock('@deneb-viz/vega-runtime/compilation', async () => {
 });
 
 import { compileSpec } from '@deneb-viz/vega-runtime/compilation';
+import { VISUAL_PREVIEW_ZOOM_CONFIGURATION } from '@deneb-viz/configuration';
 import { createDenebState } from '../state';
 
-// Mirror the `VISUAL_PREVIEW_ZOOM_CONFIGURATION` constants used by the
-// predicates so test intent is unambiguous. If these change in
-// configuration, update them here too.
-const ZOOM_MIN = 10;
-const ZOOM_MAX = 400;
-const ZOOM_MID = 100;
+// Source the boundaries from the same configuration constant the
+// predicates use. Mirrors the sibling helper-unit test in
+// `lib/commands/__tests__/state.test.ts` and keeps boundary assertions
+// in sync with config changes automatically.
+const ZOOM_MIN = VISUAL_PREVIEW_ZOOM_CONFIGURATION.min;
+const ZOOM_MAX = VISUAL_PREVIEW_ZOOM_CONFIGURATION.max;
+const ZOOM_MID = VISUAL_PREVIEW_ZOOM_CONFIGURATION.default;
 
 /**
  * Build a fresh, fully-wired Deneb state store per test. Using the real

--- a/packages/app-core/src/state/__tests__/compilation-render-id.test.ts
+++ b/packages/app-core/src/state/__tests__/compilation-render-id.test.ts
@@ -65,6 +65,13 @@ const makeStateFixture = (overrides: Partial<Record<string, unknown>> = {}) =>
         interface: {
             renderId: 'initial-render-id'
         },
+        // `handleCompile` re-evaluates compilation-gated commands on every
+        // compile via the helpers in `lib/commands/state.ts`, reading these
+        // three fields. Fixture provides safe defaults; tests in this file
+        // don't assert on commands but the code path needs the inputs.
+        editorZoomLevel: 100,
+        editor: { isDirty: false },
+        commands: {},
         ...overrides
     }) as never;
 

--- a/packages/app-core/src/state/compilation.ts
+++ b/packages/app-core/src/state/compilation.ts
@@ -6,6 +6,11 @@ import type {
 } from '@deneb-viz/vega-runtime/compilation';
 import { type StoreState, type SyncableSlice } from './state';
 import { INCREMENTAL_UPDATE_CONFIGURATION } from '../lib/vega/incremental-update-configuration';
+import {
+    evaluateExportSpecCommandState,
+    evaluateZoomCommandsState,
+    isCompilationReady
+} from '../lib/commands/state';
 
 /**
  * Performance settings that control compilation and rendering behavior.
@@ -320,7 +325,7 @@ const handleCompile = (
     const runtimeErrors = [...state.compilation.durableErrors];
     const runtimeWarnings = [...state.compilation.durableWarnings];
 
-    return {
+    const compilationUpdate: Partial<StoreState> = {
         compilation: {
             ...state.compilation,
             result,
@@ -332,6 +337,27 @@ const handleCompile = (
             // Clear durable errors/warnings - they've been merged into runtime errors/warnings
             durableErrors: [],
             durableWarnings: []
+        }
+    };
+
+    // Always re-evaluate compilation-gated commands on compile. Both
+    // helpers handle the not-ready case correctly (returning `false` for
+    // gated commands), so writing unconditionally:
+    //   - re-enables flags on success (recovery from error states)
+    //   - disables flags on error (parity with how exportSpecification
+    //     already disables via continuous editor writes; without this,
+    //     zoom would only disable after the user clicks a zoom control,
+    //     because handleUpdateEditorZoomLevel is its sole writer).
+    // The asymmetry the error-branch-skip preserved was actually the bug
+    // for zoom: editor-edit writers fire continuously and self-correct
+    // exportSpec; zoom has no parallel cadence, so the recovery-only
+    // write left zoom enabled-looking until clicked.
+    return {
+        ...compilationUpdate,
+        commands: {
+            ...state.commands,
+            ...evaluateZoomCommandsState(state.editorZoomLevel, result),
+            ...evaluateExportSpecCommandState(state.editor.isDirty, result)
         }
     };
 };

--- a/packages/app-core/src/state/editor.ts
+++ b/packages/app-core/src/state/editor.ts
@@ -1,14 +1,10 @@
 import { getUpdatedExportMetadata } from '@deneb-viz/json-processing';
 import type { monaco } from '../components/code-editor/monaco-integration';
 import {
-    getNextApplyMode,
-    isExportSpecCommandEnabled,
-    isZoomInCommandEnabled,
-    isZoomOtherCommandsEnabled,
-    isZoomOutCommandEnabled,
-    type ZoomLevelCommandTestOptions,
-    type ZoomOtherCommandTestOptions
-} from '../lib';
+    evaluateExportSpecCommandState,
+    evaluateZoomCommandsState,
+    getNextApplyMode
+} from '../lib/commands/state';
 import {
     type ContainerViewport,
     type DebugPaneRole,
@@ -305,10 +301,7 @@ const handleUpdateChanges = (
     return {
         commands: {
             ...state.commands,
-            exportSpecification: isExportSpecCommandEnabled({
-                editorIsDirty: isDirty,
-                compilationResult: state.compilation.result
-            })
+            ...evaluateExportSpecCommandState(isDirty, state.compilation.result)
         },
         editor: {
             ...state.editor,
@@ -332,10 +325,7 @@ const handleUpdateIsDirty = (
 ): Partial<StoreState> => ({
     commands: {
         ...state.commands,
-        exportSpecification: isExportSpecCommandEnabled({
-            editorIsDirty: isDirty,
-            compilationResult: state.compilation.result
-        })
+        ...evaluateExportSpecCommandState(isDirty, state.compilation.result)
     },
     editor: {
         ...state.editor,
@@ -362,22 +352,10 @@ const handleUpdateEditorSelectedPreviewRole = (
 const handleUpdateEditorZoomLevel = (
     state: StoreState,
     zoomLevel: number
-): Partial<StoreState> => {
-    const zoomOtherCommandTest: ZoomOtherCommandTestOptions = {
-        compilationResult: state.compilation.result
-    };
-    const zoomLevelCommandTest: ZoomLevelCommandTestOptions = {
-        value: zoomLevel,
-        compilationResult: state.compilation.result
-    };
-    return {
-        commands: {
-            ...state.commands,
-            zoomFit: isZoomOtherCommandsEnabled(zoomOtherCommandTest),
-            zoomIn: isZoomInCommandEnabled(zoomLevelCommandTest),
-            zoomOut: isZoomOutCommandEnabled(zoomLevelCommandTest),
-            zoomReset: isZoomOtherCommandsEnabled(zoomOtherCommandTest)
-        },
-        editorZoomLevel: zoomLevel
-    };
-};
+): Partial<StoreState> => ({
+    commands: {
+        ...state.commands,
+        ...evaluateZoomCommandsState(zoomLevel, state.compilation.result)
+    },
+    editorZoomLevel: zoomLevel
+});


### PR DESCRIPTION
Two commands gated on isCompilationReady (zoom controls and the spec exporter) could become persistently disabled after a parse-error state. The trigger differs per command — a zoom click for zoom; an editor keystroke for exportSpecification — but the structural cause is identical: state-management actions fire during the error path and write false into the commands slice; nothing on the recovery path re-evaluates them. Only a full visual reload cleared the lock.

Includes compound engineering docs for previous session
