### PR TITLE
fix: escape placeholder values in cross-filter expressions

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -53,6 +53,10 @@
             "types": "./dist/lib/versioning.d.ts",
             "default": "./dist/lib/versioning.js"
         },
+        "./escaping": {
+            "types": "./dist/lib/escaping.d.ts",
+            "default": "./dist/lib/escaping.js"
+        },
         "./worker": {
             "types": "./dist/lib/worker.d.ts",
             "default": "./dist/lib/worker.js"

--- a/packages/utils/src/lib/__tests__/escaping.test.ts
+++ b/packages/utils/src/lib/__tests__/escaping.test.ts
@@ -1,0 +1,60 @@
+import { escapeVegaExpressionString } from '../escaping';
+import { describe, it, expect } from 'vitest';
+
+describe('escapeVegaExpressionString', () => {
+    it('should return the same string when no special characters are present', () => {
+        expect(escapeVegaExpressionString('hello')).toBe('hello');
+    });
+
+    it('should escape single quotes', () => {
+        expect(escapeVegaExpressionString("O'Brien")).toBe("O\\'Brien");
+    });
+
+    it('should escape backslashes', () => {
+        expect(escapeVegaExpressionString('path\\to\\file')).toBe(
+            'path\\\\to\\\\file'
+        );
+    });
+
+    it('should escape backslashes before single quotes to prevent double-escape bypass', () => {
+        expect(escapeVegaExpressionString("a\\'b")).toBe("a\\\\\\'b");
+    });
+
+    it('should neutralize the injection payload from the issue PoC', () => {
+        const malicious = "O'Brien' || true || '";
+        const escaped = escapeVegaExpressionString(malicious);
+        // When wrapped in single quotes the result must be a single
+        // string literal, not a valid compound expression.
+        expect(escaped).toBe("O\\'Brien\\' || true || \\'");
+        // The full expression that would be produced:
+        const expr = `'${escaped}'`;
+        expect(expr).toBe("'O\\'Brien\\' || true || \\''");
+    });
+
+    it('should handle backslash sequences in datum values', () => {
+        const value = "x\\' || datum.__row__ == 42 || \\'y";
+        const escaped = escapeVegaExpressionString(value);
+        expect(escaped).toBe(
+            "x\\\\\\' || datum.__row__ == 42 || \\\\\\'y"
+        );
+    });
+
+    it('should handle empty string', () => {
+        expect(escapeVegaExpressionString('')).toBe('');
+    });
+
+    it('should handle string with only a single quote', () => {
+        expect(escapeVegaExpressionString("'")).toBe("\\'");
+    });
+
+    it('should handle string with only a backslash', () => {
+        expect(escapeVegaExpressionString('\\')).toBe('\\\\');
+    });
+
+    it('should handle null coerced to string via String()', () => {
+        // The caller uses String(value) before passing to this function,
+        // so we verify the "null" and "undefined" literal strings pass through.
+        expect(escapeVegaExpressionString('null')).toBe('null');
+        expect(escapeVegaExpressionString('undefined')).toBe('undefined');
+    });
+});

--- a/packages/utils/src/lib/escaping.ts
+++ b/packages/utils/src/lib/escaping.ts
@@ -1,0 +1,10 @@
+/**
+ * Escape a string value for safe interpolation into a Vega expression
+ * string literal (single-quoted). Backslashes are escaped first, then
+ * single quotes, so that the resulting value is inert inside `'…'`.
+ *
+ * @param value - The raw string value to escape.
+ * @returns The escaped string (without surrounding quotes).
+ */
+export const escapeVegaExpressionString = (value: string): string =>
+    value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");

--- a/src/lib/vega-embed/cross-filter-expressions.ts
+++ b/src/lib/vega-embed/cross-filter-expressions.ts
@@ -7,6 +7,7 @@ import {
     type CrossFilterOptions,
     type InteractivityLookupDataset
 } from '../interactivity';
+import { escapeVegaExpressionString } from '@deneb-viz/utils/escaping';
 import { logDebug, logWarning } from '@deneb-viz/utils/logging';
 import { getDenebState } from '@deneb-viz/app-core';
 import { useDenebVisualState } from '../../state';
@@ -174,9 +175,9 @@ const getResolvedFilterExpressionForPlaceholder = (
             return `${value}`;
         }
         if (value instanceof Date) {
-            return `toDate('${value}')`;
+            return `toDate('${escapeVegaExpressionString(String(value))}')`;
         }
-        return `'${datum?.[m1]}'`;
+        return `'${escapeVegaExpressionString(String(datum?.[m1]))}'`;
     });
 
 /**


### PR DESCRIPTION
## Summary

Fixes #649 — Vega expression injection via unescaped placeholder substitution in `pbiCrossFilterApply`.

- Adds `escapeVegaExpressionString` utility to `@deneb-viz/utils` that escapes `\` → `\\` and `'` → `\'` before interpolation into single-quoted Vega expression literals
- Applies escaping to both the string and Date branches in `getResolvedFilterExpressionForPlaceholder`
- Handles `null`/`undefined` datum values gracefully via `String()` coercion

## What was tested

- 10 new unit tests covering: plain strings, single quote escaping, backslash escaping, backslash-before-quote bypass, the exact PoC payload from the issue (`O'Brien' || true || '`), calculated-field injection payload, and edge cases (empty string, lone quote, lone backslash, null/undefined literals)
- All existing tests pass (`npm run test` — one pre-existing timezone-dependent failure in `type-conversion.test.ts` is unrelated)
- Lint passes with zero errors (`npm run eslint`)

## Changed files

| File | Change |
|------|--------|
| `packages/utils/src/lib/escaping.ts` | New escaping utility |
| `packages/utils/src/lib/__tests__/escaping.test.ts` | 10 test cases |
| `packages/utils/package.json` | Added `./escaping` export |
| `src/lib/vega-embed/cross-filter-expressions.ts` | Applied escaping to placeholder substitution |