### PR TITLE
fix: validate datum.__row__ before trusting it in cross-filter (#650)

### DIFF
--- a/packages/data-core/src/lib/field/__tests__/row-index-validation.test.ts
+++ b/packages/data-core/src/lib/field/__tests__/row-index-validation.test.ts
@@ -1,0 +1,59 @@
+import { isValidRowIndex } from '../constants';
+import { describe, it, expect } from 'vitest';
+
+describe('isValidRowIndex', () => {
+    const DATASET_LENGTH = 10;
+
+    it('should accept a valid in-bounds integer', () => {
+        expect(isValidRowIndex(0, DATASET_LENGTH)).toBe(true);
+        expect(isValidRowIndex(5, DATASET_LENGTH)).toBe(true);
+        expect(isValidRowIndex(9, DATASET_LENGTH)).toBe(true);
+    });
+
+    it('should reject a negative integer', () => {
+        expect(isValidRowIndex(-1, DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex(-100, DATASET_LENGTH)).toBe(false);
+    });
+
+    it('should reject a value equal to or exceeding dataset length', () => {
+        expect(isValidRowIndex(10, DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex(100, DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex(11, DATASET_LENGTH)).toBe(false);
+    });
+
+    it('should reject a non-integer number (e.g. 3.7)', () => {
+        expect(isValidRowIndex(3.7, DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex(0.1, DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex(9.999, DATASET_LENGTH)).toBe(false);
+    });
+
+    it('should reject a string value', () => {
+        expect(isValidRowIndex('abc', DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex('3', DATASET_LENGTH)).toBe(false);
+    });
+
+    it('should reject null and undefined', () => {
+        expect(isValidRowIndex(null, DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex(undefined, DATASET_LENGTH)).toBe(false);
+    });
+
+    it('should reject NaN and Infinity', () => {
+        expect(isValidRowIndex(NaN, DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex(Infinity, DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex(-Infinity, DATASET_LENGTH)).toBe(false);
+    });
+
+    it('should reject boolean values', () => {
+        expect(isValidRowIndex(true, DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex(false, DATASET_LENGTH)).toBe(false);
+    });
+
+    it('should reject an object or array', () => {
+        expect(isValidRowIndex({}, DATASET_LENGTH)).toBe(false);
+        expect(isValidRowIndex([], DATASET_LENGTH)).toBe(false);
+    });
+
+    it('should handle a dataset length of 0', () => {
+        expect(isValidRowIndex(0, 0)).toBe(false);
+    });
+});

--- a/packages/data-core/src/lib/field/constants.ts
+++ b/packages/data-core/src/lib/field/constants.ts
@@ -54,6 +54,20 @@ export const HIGHLIGHT_COMPARATOR_SUFFIX = `${HIGHLIGHT_FIELD_SUFFIX}Comparator`
 export const ROW_INDEX_FIELD_NAME = '__row__';
 
 /**
+ * Validate that a `__row__` value is a non-negative integer within the
+ * bounds of the dataset. Returns `true` only when the value can be safely
+ * used as a row index into `dataset.values`.
+ */
+export const isValidRowIndex = (
+    value: unknown,
+    datasetLength: number
+): value is number =>
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value < datasetLength;
+
+/**
  * The name we use to denote a data point's selection status within the dataset.
  */
 export const SELECTED_ROW_FIELD_NAME = '__selected__';

--- a/src/lib/interactivity/data-point.ts
+++ b/src/lib/interactivity/data-point.ts
@@ -6,6 +6,7 @@ import { logDebug } from '@deneb-viz/utils/logging';
 import {
     type DatasetField,
     type DatasetFields,
+    isValidRowIndex,
     ROW_INDEX_FIELD_NAME
 } from '@deneb-viz/data-core/field';
 import { type VegaDatum } from '@deneb-viz/data-core/value';
@@ -41,17 +42,21 @@ export const getResolvedRowIdentities = (
         //logDebug(`${LOG_PREFIX} no data supplied, returning empty array`);
         return [];
     }
-    // Single, identifiable datum
+    // Single, identifiable datum — validate __row__ before trusting it
     if (data.length === 1 && data[0]?.[ROW_INDEX_FIELD_NAME] !== undefined) {
-        // logDebug(`${LOG_PREFIX} single datum with identity field found`, {
-        //     datum: data[0]
-        // });
-        return [data[0][ROW_INDEX_FIELD_NAME]];
+        const rawRow = data[0][ROW_INDEX_FIELD_NAME];
+        if (isValidRowIndex(rawRow, dataset.values.length)) {
+            return [rawRow];
+        }
+        // Invalid __row__: fall through to field-matching below
     }
     // Multiple values; all with identifiable row indices
     if (allValuesHaveIdentityField(data)) {
-        // logDebug(`${LOG_PREFIX} all datum have identity field`, { data });
-        return getRowNumbersFromData(data);
+        const validated = getRowNumbersFromData(data, dataset.values.length);
+        if (validated.length > 0) {
+            return validated;
+        }
+        // All __row__ values were invalid: fall through to field-matching
     }
     // Otherwise, panic mode: try to identify from the matched values
     // logDebug(`${LOG_PREFIX} attempting to resolve via field matching`, {
@@ -98,16 +103,23 @@ const getMatchedValues = (
 };
 
 /**
- * From an array of Vega datum, extract unique row numbers, provided that they exist.
+ * From an array of Vega datum, extract unique row numbers, provided that they exist and are valid indices.
  */
-export const getRowNumbersFromData = (data: VegaDatum[]) => {
+export const getRowNumbersFromData = (
+    data: VegaDatum[],
+    datasetLength?: number
+) => {
     const resolvedIndices: number[] = [];
     data.forEach((d) => {
         const rowIndex = d[ROW_INDEX_FIELD_NAME];
+        if (rowIndex === undefined) return;
         if (
-            rowIndex !== undefined &&
-            resolvedIndices.indexOf(rowIndex as number) === -1
+            datasetLength !== undefined &&
+            !isValidRowIndex(rowIndex, datasetLength)
         ) {
+            return;
+        }
+        if (resolvedIndices.indexOf(rowIndex as number) === -1) {
             resolvedIndices.push(rowIndex as number);
         }
     });


### PR DESCRIPTION
## Summary

Fixes #650 — `datum.__row__` trusted blindly enables spoofed cross-filter selection.

- Adds `isValidRowIndex` validator to `@deneb-viz/data-core` that checks `typeof === 'number'`, `Number.isInteger`, `>= 0`, and `< dataset.values.length`
- `getResolvedRowIdentities` now validates `__row__` before using it — invalid values fall through to the field-matching path instead of silently selecting the wrong row
- `getRowNumbersFromData` accepts an optional `datasetLength` parameter and skips invalid row indices when provided
- Backward-compatible: well-behaved specs that don't mutate `__row__` are unaffected

## What was tested

- 10 new unit tests covering: valid in-bounds integers, negative integers, out-of-bounds values, non-integer numbers (3.7), string values, null/undefined, NaN/Infinity, booleans, objects/arrays, and zero-length datasets
- All existing tests pass (`npm run test` — one pre-existing timezone-dependent failure in `type-conversion.test.ts` is unrelated)
- Lint passes with zero errors (`npm run eslint`)

## Changed files

| File | Change |
|------|--------|
| `packages/data-core/src/lib/field/constants.ts` | Added `isValidRowIndex` validator |
| `packages/data-core/src/lib/field/__tests__/row-index-validation.test.ts` | 10 test cases |
| `src/lib/interactivity/data-point.ts` | Validate `__row__` with fallback to field-matching |