### PR TITLE
fix: sync editor pane sizes to container resize post-hydration

### DIFF
--- a/docs/solutions/logic-errors/zoom-to-fit-negative-scale-on-unhydrated-viewport-2026-05-20.md
+++ b/docs/solutions/logic-errors/zoom-to-fit-negative-scale-on-unhydrated-viewport-2026-05-20.md
@@ -1,0 +1,107 @@
+---
+title: Zoom-to-Fit produces tiny scale when computed against unhydrated preview viewport
+date: 2026-05-20
+category: logic-errors
+module: app-core/lib/interface
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Editor `Fit` zoom (popover radio and `ctrl+alt+*` shortcut) snaps to 10% instead of fitting the visual"
+  - "Bug reproduces when `Fit` is clicked before `useLayoutEffect` in `use-editor-pane-layout.ts` hydrates `previewAreaViewport` from its initial `{0, 0}` state"
+  - "Expanding the debug pane (small preview height) makes the bug more reliable to reproduce"
+  - "Keyboard shortcut path writes a raw negative zoom value to `editorZoomLevel` state; popover path silently clamps to the min (10%)"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components:
+  - app-core/lib/commands/actions
+  - app-core/app/editor/hooks/use-editor-pane-layout
+  - app-core/state/editor
+tags:
+  - zoom
+  - fit
+  - viewport
+  - editor
+  - unhydrated-state
+  - clamp
+  - pure-helper
+  - silent-clamp
+---
+
+# Zoom-to-Fit produces tiny scale when computed against unhydrated preview viewport
+
+## Problem
+
+In Deneb's advanced editor, invoking "Fit" zoom (popover Fit radio or `ctrl+alt+*` hotkey) before the editor pane layout had measured itself produced absurdly small zoom values — typically snapping the visual to 10% — instead of fitting the preview area. The same failure occurred with a fully-hydrated layout when the debug pane was expanded to consume most of the editor height.
+
+> **Scope note.** This doc covers the `<= 0` / negative-scale failure mode in the pure math. A sibling failure mode — non-zero-but-stale `previewAreaViewport` inputs slipping past the guard because hydration captured a mid-iframe-expansion size — is covered separately in [`zoom-to-fit-stale-preview-area-after-iframe-expansion-2026-05-21.md`](zoom-to-fit-stale-preview-area-after-iframe-expansion-2026-05-21.md). Both fixes are needed to fully close the user-visible umbrella ("Fit shrinks the visual"); this one alone is necessary but not sufficient.
+
+## Symptoms
+
+- Open the advanced editor, immediately click the zoom popover and select "Fit": the visual collapses to ~10% instead of fitting.
+- Expand the debug pane to dominate the editor height, then click Fit: same ~10% collapse.
+- Trigger Fit via the `ctrl+alt+*` hotkey under the same conditions: zoom can land on a *negative* value because the hotkey path writes directly to state without the popover's downstream clamp.
+- No console error, no diagnostic — the math silently produces nonsense and the UI accepts it.
+
+## What Didn't Work
+
+The original [`getZoomToFitScale()`](../../../packages/app-core/src/lib/interface/layout.ts) clamped only the upper bound at each return point (`Math.min(scaleFactorX, max)`) and had no input guard. The author had implicitly relied on the popover's downstream clamp (`Math.max(Math.min(value, max), min)` in `handleCustomZoomLevelChange`) to catch bad outputs. Two things broke that assumption:
+
+1. **The downstream clamp masked the root cause.** When `previewAreaViewport` was the seed default `{width: 0, height: 0}`, `getAdjustedPreviewAreaWidthForPadding(0)` returned `-20`, `previewWidth - ZOOM_FIT_BUFFER` was `-35`, and the scale factor came out negative. The downstream `Math.max(value, min)` then silently transformed "fit couldn't compute" into "valid zoom of 10%". The bug felt mysterious rather than diagnostic.
+2. **The hotkey path bypassed the clamp entirely.** [`handleZoomFit`](../../../packages/app-core/src/lib/commands/actions.ts) calls `updateEditorZoomLevel(rawValue)` directly, so a negative scale factor could land in persisted visual state.
+
+A prior fix in this neighborhood ([`docs/solutions/logic-errors/focus-mode-viewport-overwrites-persisted-dimensions-2026-04-16.md`](focus-mode-viewport-overwrites-persisted-dimensions-2026-04-16.md)) had already established the `> 0` dimension-guard pattern for viewport-consuming code. That pattern simply was not applied here — the fit calculation was an outlier.
+
+## Solution
+
+Three changes to [`packages/app-core/src/lib/interface/layout.ts`](../../../packages/app-core/src/lib/interface/layout.ts):
+
+1. **Input guard** that returns `VISUAL_PREVIEW_ZOOM_CONFIGURATION.default` when any of `previewAreaWidth`, `previewAreaHeight`, `width`, or `height` is `<= 0`.
+2. **Symmetric clamp** at each return point: `Math.max(min, Math.min(value, max))` instead of `Math.min(value, max)`.
+3. **Pure-helper extraction**: split `getZoomToFitScale()` (which reads from `getDenebState()`) from `computeZoomToFitScale({ previewAreaViewport, embedViewport })` (pure math). The Zustand-bound wrapper stays trivial; the math becomes unit-testable without store-mocking infrastructure.
+
+Before:
+
+```typescript
+scaleFactorWidth = Math.floor(100 / (width / (previewWidth - ZOOM_FIT_BUFFER))),
+scaleFactorHeight = Math.floor(100 / (height / (previewHeight - ZOOM_FIT_BUFFER))),
+// ...
+return Math.min(scaleFactorWidth, max);  // clamps max only
+```
+
+After:
+
+```typescript
+if (
+    previewAreaWidth <= 0 ||
+    previewAreaHeight <= 0 ||
+    width <= 0 ||
+    height <= 0
+) {
+    return zDefault;
+}
+// ...
+const clamp = (value: number) => Math.max(min, Math.min(value, max));
+return clamp(scaleFactorWidth);
+```
+
+A 12-case unit suite in [`packages/app-core/src/lib/interface/__tests__/layout.test.ts`](../../../packages/app-core/src/lib/interface/__tests__/layout.test.ts) pins the behaviour: six input-guard cases (zero/null/negative dimensions return `DEFAULT_ZOOM`), three output-clamp cases (clamp to MIN below, MAX above, and the tiny-pane case pins to MIN), two happy paths (height-binding → 75, width-binding → 58), and one regression guard explicitly locking the `<= 0` check against future narrowing to `=== 0`.
+
+## Why This Works
+
+**Input guards beat output clamps for measurement-driven math.** An output clamp can only ask "is the result in range?" — it cannot distinguish "the inputs were valid and the math produced 10%" from "the inputs were garbage and the math produced -47, which we then clamped to 10%". Both look identical downstream. The user sees an in-range value and the system has no way to surface that the computation was meaningless. An input guard asks the *correct* question: "do I have enough information to do this math at all?" When the answer is no, returning `zDefault` (the current visual's zoom, falling through to 100%) makes the failure mode visible — the user sees Fit as a no-op rather than a destructive snap to 10% — without leaving broken state behind.
+
+**Extracting a pure helper is the right shape here** because the math has no business knowing about Zustand. `getZoomToFitScale()` stays as the integration seam (one line: read state, delegate); `computeZoomToFitScale()` takes plain inputs and is trivial to test. Without this split, every test case would need a Zustand store mock just to exercise arithmetic. The split also documents intent: the wrapper exists only to bridge state to math. This is the same pattern the prior best-practice doc [`extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md`](../best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md) prescribes for cases where multiple entry paths must agree.
+
+## Prevention
+
+- **The 12-test unit suite** locks every failure mode (zero/null/negative inputs, MIN/MAX clamp boundaries, both binding axes) and includes an explicit regression guard against narrowing the `<= 0` check to `=== 0`.
+- **Rule:** any zoom or viewport calculation that consumes a measurement-driven dimension must check `> 0` on every input before running math on it. Negative or zero values are an "I don't know yet" signal, not a number.
+- **Rule:** clamp at the source, not at the call site. Every entry path (popover, hotkey, future surfaces) should be able to consume the returned value verbatim. Defensive re-clamping at call sites is a smell — it means the producer is shipping out-of-contract values, and the silent transformation hides the real failure from anyone trying to diagnose it.
+
+## Related Issues
+
+- [`docs/solutions/logic-errors/zoom-to-fit-stale-preview-area-after-iframe-expansion-2026-05-21.md`](zoom-to-fit-stale-preview-area-after-iframe-expansion-2026-05-21.md) — sibling failure mode for the same user-visible umbrella. That fix handles the case where `previewAreaViewport` is non-zero but stuck at a partial-iframe-expansion size; this fix handles the case where it's `{0, 0}` or otherwise non-positive. Together they cover the full surface.
+- [`docs/solutions/logic-errors/focus-mode-viewport-overwrites-persisted-dimensions-2026-04-16.md`](focus-mode-viewport-overwrites-persisted-dimensions-2026-04-16.md) — establishes the `> 0` dimension-guard pattern that this fix re-applies. Both involve the `{0, 0}` unhydrated viewport shape; that doc is the write-time guard, this one is the read-time guard.
+- [`docs/solutions/best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md`](../best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md) — backs the pure-helper extraction pattern for cases where parallel entry paths (here: popover, hotkey, command bar) must agree on output semantics.
+- [`docs/solutions/ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md`](../ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md) — documents the host-paced iframe expansion that creates the unhydrated `previewAreaViewport` window in the first place. Upstream cause.

--- a/docs/solutions/logic-errors/zoom-to-fit-stale-preview-area-after-iframe-expansion-2026-05-21.md
+++ b/docs/solutions/logic-errors/zoom-to-fit-stale-preview-area-after-iframe-expansion-2026-05-21.md
@@ -1,0 +1,83 @@
+---
+title: Zoom-to-Fit reads stale preview area when hydration captures mid-iframe-expansion size
+date: 2026-05-21
+category: logic-errors
+module: app-core/app/editor/hooks
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Editor `Fit` zoom returns a result in the 40-50% range against a preview area that visibly has room for ~120%+"
+  - "Debug-logging confirms `previewAreaViewport` in the store is roughly half of the live `useResizeObserver` measurement at Fit time"
+  - "Reproduces consistently on first editor open; clears if the user manually drags either pane after the iframe finishes expanding"
+  - "Math in `computeZoomToFitScale` is correct against the supplied inputs; the inputs themselves are wrong"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components:
+  - app-core/app/editor/hooks/use-editor-pane-layout
+  - app-core/lib/interface
+  - app-core/state/editor
+  - app-core/app/editor/components/editor-pane-layout
+tags:
+  - zoom
+  - fit
+  - viewport
+  - editor
+  - hydration
+  - iframe-expansion
+  - allotment
+  - one-shot-effect
+  - stale-store
+---
+
+# Zoom-to-Fit reads stale preview area when hydration captures mid-iframe-expansion size
+
+## Problem
+
+In Deneb's advanced editor, invoking "Fit" zoom (popover Fit radio or `ctrl+alt+*` hotkey) consistently returned a value in the 40-50% range when the user perceived the preview area as having ample room for 120%+. Unlike the sibling failure mode covered in [`zoom-to-fit-negative-scale-on-unhydrated-viewport-2026-05-20.md`](zoom-to-fit-negative-scale-on-unhydrated-viewport-2026-05-20.md) — which produced negative scale factors from `{0, 0}` viewports — this case produced a mathematically valid, in-range scale factor. The inputs were non-zero, the math was correct, but the inputs were stale.
+
+## Symptoms
+
+- Open the advanced editor with a typical spec; click Fit: result lands on ~44% rather than the ~120% the math should produce against the visible preview area.
+- Add a `logDebug` inside `computeZoomToFitScale` and click Fit. The log shows `previewAreaViewport = {width: 415, height: 179}` even though the rendered preview area is visibly ~881×674.
+- Drag either pane after the iframe settles; click Fit again. Result now lands on the expected ~120% — the drag committed the live sizes to the store.
+- Both the popover Fit radio and the hotkey path exhibit the same number — the bug is in the input to the math, not in either entry path.
+
+## What Didn't Work
+
+The input guard and symmetric clamp added in [`zoom-to-fit-negative-scale-on-unhydrated-viewport-2026-05-20.md`](zoom-to-fit-negative-scale-on-unhydrated-viewport-2026-05-20.md) protect against `<= 0` dimensions. They are necessary but not sufficient: `{415, 179}` is non-zero and produces a valid (if perceptually wrong) result. The guard is at the read-time pure-math layer; this failure mode lives one stage earlier, in the *write* path that feeds the store.
+
+Speculating that `embedViewport` was stale was also a dead end. Logging confirmed `embedViewport` matched the live Power BI host viewport. The wrong-input was specifically `previewAreaViewport` — the editor's own internal pane size.
+
+## Solution
+
+A new post-hydration synchronisation effect in [`packages/app-core/src/app/editor/hooks/use-editor-pane-layout.ts`](../../../packages/app-core/src/app/editor/hooks/use-editor-pane-layout.ts):
+
+1. **Track container size at last sync.** A `prevContainerSizeRef` ref captures the container width/height every time the store is touched (initial hydration and subsequent rescales).
+2. **Detect post-hydration container changes.** A second `useLayoutEffect` runs after hydration whenever `containerWidth` / `containerHeight` change. When the live size diverges from the ref, it computes new pane sizes proportionally and dispatches a single `setViewports` update.
+3. **Pure-helper extraction.** The scaling math is exported as `scalePaneSizesForContainerResize` so it can be unit-tested without React or Zustand. The hook stays the integration seam.
+4. **Respect Allotment's minSize.** The right pane width is clamped to `DEBUG_PANE_CONFIGURATION.minWidth` so the store agrees with what Allotment renders. Without this clamp, a narrow container reintroduces the same store-vs-render desync at a smaller scale.
+5. **Route latch through existing semantics.** The debug-pane latch is computed via `getDebugPaneLatchHeight` so its "freeze while minimized" and "areaMinSize fallback" behaviours apply uniformly across hydrate, drag, and rescale paths.
+
+13 unit tests in [`packages/app-core/src/app/editor/hooks/__tests__/use-editor-pane-layout-scaling.test.ts`](../../../packages/app-core/src/app/editor/hooks/__tests__/use-editor-pane-layout-scaling.test.ts) pin the math: sum-conservation on each axis, ratio preservation across resize, asymmetric width-only / height-only changes, rounding-error absorption by the right and bottom panes, the user's reproduced repro values (`{692, 300}` hydration → `{1480, 1124}` settled), the `minWidth` clamp, and both latch semantics (minimized preservation; areaMinSize fallback).
+
+## Why This Works
+
+**The bug was a category error about effect lifecycle.** The hook's hydration effect was gated by `!hasHydratedViewports` to run exactly once. But Power BI's iframe expands the editor's container in stages after open (the same host-paced sequence documented in [`freeze-on-viewer-editor-transition-2026-05-01.md`](../ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md)). `useResizeObserver` fires for every stage; the one-shot gate captures only the *first* non-zero stage, which is typically a partial-expansion size. Subsequent stages update `containerWidth`/`containerHeight` but the hook ignores them. Drag handlers (`commitVerticalSizes`, `commitHorizontalSizes`) only fire on user input. Without user drag, the store stays stuck at the first stage's measurement for the rest of the session.
+
+**Allotment hides the symptom from the user but not from the store.** Allotment internally rescales its rendered children when its container resizes, so the on-screen preview area *does* track the live container size. But Allotment doesn't fire `onChange` / `onDragEnd` for container resizes, only for user-driven changes. The store has no other writer that would notice the divergence. The visible UI and the store drift apart, silently, until a consumer (Fit) reads the store and produces a result that doesn't match what the user sees.
+
+**Proportional rescale is the right shape because pane sizes are derivable from container ratios.** The hydration effect already computed initial sizes as percentages of the container (`SPLIT_PANE_CONFIGURATION.defaultSizePercent` for editor width; `DEBUG_PANE_CONFIGURATION.preferredHeightPercentage` for debug height). The rescale extends the same logic: when the container changes, preserve current ratios. User-dragged ratios survive resize automatically — there's no special case for "did the user drag," because dragging just changes which ratio gets preserved.
+
+## Prevention
+
+- **The 13-test unit suite** locks every shape of the rescale math, plus the `minWidth` clamp and both latch semantics, plus the user's actual repro values as a regression guard.
+- **Rule:** treat any one-shot `useLayoutEffect` that captures measurement-driven dimensions as a smell. If the measured thing can change after the first commit (host resize, iframe expansion, theme-driven layout shifts), the one-shot capture will go stale. Either re-run the effect on every change, or pair the hydration with a continuous sync that observes the same source.
+- **Rule:** when integrating with a layout library that auto-handles container resize (Allotment, react-resizable-panels, react-split, similar), audit which events propagate back to the store. Container-resize-driven changes are typically silent at the library API level; the store needs an independent observer if downstream consumers read pane sizes from it.
+- **Rule:** when scaling stored layout values, route them through the same helpers that the drag / commit paths use (in this case `getDebugPaneLatchHeight`). Bypassing the helpers creates two divergent expressions of the same invariant, which inevitably drift.
+
+## Related Issues
+
+- [`docs/solutions/logic-errors/zoom-to-fit-negative-scale-on-unhydrated-viewport-2026-05-20.md`](zoom-to-fit-negative-scale-on-unhydrated-viewport-2026-05-20.md) — sibling failure mode. That doc covers the `{0, 0}` / negative-scale path closed by the input guard in `computeZoomToFitScale`. This doc covers the partial-hydration path that produces non-zero-but-stale inputs slipping past that guard. The umbrella user-visible symptom ("Fit shrinks the visual") has two root causes; both fixes are needed for full coverage.
+- [`docs/solutions/logic-errors/focus-mode-viewport-overwrites-persisted-dimensions-2026-04-16.md`](focus-mode-viewport-overwrites-persisted-dimensions-2026-04-16.md) — established the `> 0` viewport-guard pattern for write-time paths. This fix is the read-time complement at the *next* layer up: not just guarding against zero, but actively resyncing when the upstream measurement changes.
+- [`docs/solutions/ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md`](../ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md) — documents the host-paced iframe expansion sequence that creates the partial-hydration window. Upstream cause.

--- a/packages/app-core/src/app/editor/hooks/__tests__/use-editor-pane-layout-scaling.test.ts
+++ b/packages/app-core/src/app/editor/hooks/__tests__/use-editor-pane-layout-scaling.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEBUG_PANE_CONFIGURATION } from '@deneb-viz/configuration';
+import { scalePaneSizesForContainerResize } from '../use-editor-pane-layout';
+
+/**
+ * Pure-helper tests for the proportional pane-rescaling math that
+ * `useEditorPaneLayout` runs whenever the container resizes after its
+ * one-shot hydration.
+ *
+ * Bug being guarded against: the host iframe in Power BI expands in stages
+ * after the editor opens. The hook's hydration `useLayoutEffect` is gated by
+ * `!hasHydratedViewports` and fires on the first `(containerWidth > 0 &&
+ * containerHeight > 0)` measurement - which can be a mid-expansion partial
+ * size. Without this rescale, the store keeps the partial-size pane values
+ * for the rest of the session, and downstream consumers that read pane sizes
+ * from the store (notably `getZoomToFitScale`) compute Fit against stale,
+ * tiny preview area dimensions. The user-visible symptom was Fit landing on
+ * ~44% with a fully-expanded ~881x674 preview area visible on screen - the
+ * math was correct, the inputs were wrong.
+ *
+ * These tests pin the math: width and height scale independently and
+ * proportionally; editor + preview widths sum to the new container width
+ * (modulo rounding); preview + debug heights sum to the new container height
+ * (modulo rounding); user-dragged ratios survive a resize; the right pane is
+ * clamped to `DEBUG_PANE_CONFIGURATION.minWidth` so the store stays in sync
+ * with the same minSize Allotment enforces on render; and the latch height
+ * goes through `getDebugPaneLatchHeight` so its semantics (freeze while
+ * minimized, areaMinSize fallback) apply uniformly across hydrate, drag, and
+ * rescale paths.
+ */
+
+const MIN_RIGHT_WIDTH = DEBUG_PANE_CONFIGURATION.minWidth; // 525
+
+describe('scalePaneSizesForContainerResize', () => {
+    it('returns sizes that sum to the new container dimensions (width axis)', () => {
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 800 },
+            current: { width: 2000, height: 800 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 480,
+            debugPaneLatchHeight: 320,
+            isDebugPaneMinimized: false
+        });
+        expect(
+            result.editorPaneViewport.width +
+                result.previewAreaViewport.width
+        ).toBe(2000);
+    });
+
+    it('returns sizes that sum to the new container dimensions (height axis)', () => {
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 800 },
+            current: { width: 1500, height: 1200 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 480,
+            debugPaneLatchHeight: 320,
+            isDebugPaneMinimized: false
+        });
+        expect(
+            result.previewAreaViewport.height +
+                result.debugPaneViewport.height
+        ).toBe(1200);
+    });
+
+    it('doubling both container dimensions doubles all pane dimensions', () => {
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 800 },
+            current: { width: 3000, height: 1600 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 480,
+            debugPaneLatchHeight: 320,
+            isDebugPaneMinimized: false
+        });
+        expect(result.editorPaneViewport).toEqual({
+            width: 1200,
+            height: 1600
+        });
+        expect(result.previewAreaViewport).toEqual({
+            width: 1800,
+            height: 960
+        });
+        expect(result.debugPaneViewport).toEqual({
+            width: 1800,
+            height: 640
+        });
+        // Not minimized + debug height >= areaMinSize ⇒ latch follows debug height
+        expect(result.debugPaneLatchHeight).toBe(640);
+    });
+
+    it('preserves the editor-pane-width-to-container-width ratio after resize', () => {
+        // Editor takes 40% of container width pre-resize; verify the same
+        // ratio holds post-resize so user-dragged splits survive.
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 800 },
+            current: { width: 2500, height: 800 },
+            editorPaneWidth: 600, // 40% of 1500
+            previewAreaHeight: 480,
+            debugPaneLatchHeight: 320,
+            isDebugPaneMinimized: false
+        });
+        expect(result.editorPaneViewport.width / 2500).toBeCloseTo(0.4, 2);
+    });
+
+    it('preserves the preview-height-to-container-height ratio after resize', () => {
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 800 },
+            current: { width: 1500, height: 1100 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 480, // 60% of 800
+            debugPaneLatchHeight: 320,
+            isDebugPaneMinimized: false
+        });
+        expect(result.previewAreaViewport.height / 1100).toBeCloseTo(0.6, 2);
+    });
+
+    it('rescales asymmetrically - width-only change leaves heights untouched', () => {
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 800 },
+            current: { width: 2000, height: 800 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 480,
+            debugPaneLatchHeight: 320,
+            isDebugPaneMinimized: false
+        });
+        expect(result.previewAreaViewport.height).toBe(480);
+        expect(result.debugPaneViewport.height).toBe(320);
+        expect(result.debugPaneLatchHeight).toBe(320);
+    });
+
+    it('rescales asymmetrically - height-only change leaves widths untouched', () => {
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 800 },
+            current: { width: 1500, height: 1200 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 480,
+            debugPaneLatchHeight: 320,
+            isDebugPaneMinimized: false
+        });
+        expect(result.editorPaneViewport.width).toBe(600);
+        expect(result.previewAreaViewport.width).toBe(900);
+        expect(result.debugPaneViewport.width).toBe(900);
+    });
+
+    it('produces sizes that match the user-reported repro after settling', () => {
+        // Captured state from the bug report:
+        //   - At Fit click: previewAreaViewport={415,179},
+        //     editorPaneViewport=(rest of container width), container settles
+        //     to ~1480x900 from a partial ~692x300 hydration.
+        //   - After this rescale, previewAreaViewport should be close to the
+        //     post-settle ~881x674 that the user observed in state once the
+        //     iframe stopped expanding.
+        // This characterises that the rescale recovers a usable Fit input
+        // even when hydration captured a tiny partial size.
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 692, height: 300 },
+            current: { width: 1480, height: 1124 },
+            // editor=277 (40% of 692), preview=415 (60% of 692)
+            // previewH=179 (~60% of 300), debugH=121 (~40% of 300)
+            editorPaneWidth: 277,
+            previewAreaHeight: 179,
+            debugPaneLatchHeight: 121,
+            isDebugPaneMinimized: false
+        });
+        // 277/692 ≈ 0.4; preserved against 1480 ⇒ ~592 editor, ~888 preview
+        expect(result.editorPaneViewport.width).toBeGreaterThanOrEqual(580);
+        expect(result.editorPaneViewport.width).toBeLessThanOrEqual(600);
+        expect(result.previewAreaViewport.width).toBeGreaterThanOrEqual(880);
+        expect(result.previewAreaViewport.width).toBeLessThanOrEqual(900);
+        // 179/300 ≈ 0.597; preserved against 1124 ⇒ ~670 preview height
+        expect(result.previewAreaViewport.height).toBeGreaterThanOrEqual(660);
+        expect(result.previewAreaViewport.height).toBeLessThanOrEqual(680);
+    });
+
+    it('preview pane absorbs rounding error so width axis still sums exactly', () => {
+        // Pick numbers that force Math.round to introduce a 1px discrepancy
+        // on the editor pane, and verify the preview absorbs it rather than
+        // the totals desyncing from the container. Container widths kept
+        // well above DEBUG_PANE_CONFIGURATION.minWidth so the rounding-only
+        // property is isolated from the minSize clamp.
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 3000, height: 100 },
+            current: { width: 3001, height: 100 },
+            editorPaneWidth: 1000, // 1000 * (3001/3000) = 1000.333 → rounds to 1000
+            previewAreaHeight: 50,
+            debugPaneLatchHeight: 50,
+            isDebugPaneMinimized: false
+        });
+        expect(result.editorPaneViewport.width).toBe(1000);
+        expect(result.previewAreaViewport.width).toBe(2001);
+        expect(
+            result.editorPaneViewport.width +
+                result.previewAreaViewport.width
+        ).toBe(3001);
+    });
+
+    it('debug pane absorbs rounding error so height axis still sums exactly', () => {
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 3 },
+            current: { width: 1500, height: 10 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 1, // 1 * (10/3) = 3.333 → rounds to 3
+            debugPaneLatchHeight: 1,
+            isDebugPaneMinimized: false
+        });
+        expect(result.previewAreaViewport.height).toBe(3);
+        expect(result.debugPaneViewport.height).toBe(7);
+        expect(
+            result.previewAreaViewport.height +
+                result.debugPaneViewport.height
+        ).toBe(10);
+    });
+
+    it('clamps right pane to DEBUG_PANE_CONFIGURATION.minWidth when proportional scale would go below', () => {
+        // Container shrinks from 1500 to 800. Proportional split of a 60/40
+        // (right/editor) ratio yields right=480 — below minWidth=525.
+        // Allotment will render right at 525, so the store must agree;
+        // otherwise the same store-vs-render desync the rescale exists to
+        // prevent reappears at a smaller scale.
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 800 },
+            current: { width: 800, height: 800 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 480,
+            debugPaneLatchHeight: 320,
+            isDebugPaneMinimized: false
+        });
+        expect(result.previewAreaViewport.width).toBe(MIN_RIGHT_WIDTH);
+        expect(result.debugPaneViewport.width).toBe(MIN_RIGHT_WIDTH);
+        expect(result.editorPaneViewport.width).toBe(800 - MIN_RIGHT_WIDTH);
+        expect(
+            result.editorPaneViewport.width +
+                result.previewAreaViewport.width
+        ).toBe(800);
+    });
+
+    it('preserves latch height (scaled) when debug pane is minimized', () => {
+        // When minimized, `getDebugPaneLatchHeight` returns the supplied
+        // latch verbatim — but we scale it before passing in so the
+        // restore-target tracks container height. Container doubles in
+        // height ⇒ latch doubles, even though the debug pane itself is
+        // at toolbarMinSize on screen.
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 800 },
+            current: { width: 1500, height: 1600 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 770, // minimized layout: most space to preview
+            debugPaneLatchHeight: 320,
+            isDebugPaneMinimized: true
+        });
+        expect(result.debugPaneLatchHeight).toBe(640);
+    });
+
+    it('falls back to default percentage latch when scaled debug height is below areaMinSize', () => {
+        // Container shrinks dramatically (height 1000 → 200). Scaled debug
+        // height (30) is below areaMinSize (100), so the latch falls back
+        // to `floor(contentHeight * preferredHeightPercentage)` =
+        // floor(200 * 0.4) = 80. Without routing through
+        // getDebugPaneLatchHeight, the latch would naively scale to ~30
+        // (uselessly small on restore).
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 1500, height: 1000 },
+            current: { width: 1500, height: 200 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 850,
+            debugPaneLatchHeight: 150,
+            isDebugPaneMinimized: false
+        });
+        expect(result.debugPaneLatchHeight).toBe(80);
+    });
+});

--- a/packages/app-core/src/app/editor/hooks/__tests__/use-editor-pane-layout-scaling.test.ts
+++ b/packages/app-core/src/app/editor/hooks/__tests__/use-editor-pane-layout-scaling.test.ts
@@ -234,12 +234,14 @@ describe('scalePaneSizesForContainerResize', () => {
         ).toBe(800);
     });
 
-    it('preserves latch height (scaled) when debug pane is minimized', () => {
-        // When minimized, `getDebugPaneLatchHeight` returns the supplied
-        // latch verbatim — but we scale it before passing in so the
-        // restore-target tracks container height. Container doubles in
-        // height ⇒ latch doubles, even though the debug pane itself is
-        // at toolbarMinSize on screen.
+    it('preserves debug height at toolbarMinSize exactly when minimized', () => {
+        // Critical invariant: the toggle-expand effect checks
+        // `debugPaneViewport.height === toolbarMinSize` (strict equality)
+        // to decide whether to fire the programmatic expand. Deriving the
+        // debug height from a proportionally-scaled preview height drifts
+        // (doubling the container produces 2 * toolbarMinSize, not
+        // toolbarMinSize) and silently breaks user-driven expand for the
+        // rest of the session.
         const result = scalePaneSizesForContainerResize({
             prev: { width: 1500, height: 800 },
             current: { width: 1500, height: 1600 },
@@ -248,7 +250,50 @@ describe('scalePaneSizesForContainerResize', () => {
             debugPaneLatchHeight: 320,
             isDebugPaneMinimized: true
         });
+        expect(result.debugPaneViewport.height).toBe(
+            DEBUG_PANE_CONFIGURATION.toolbarMinSize
+        );
+        expect(result.previewAreaViewport.height).toBe(
+            1600 - DEBUG_PANE_CONFIGURATION.toolbarMinSize
+        );
+        // Latch is scaled so the restore target tracks the new container.
+        // `getDebugPaneLatchHeight` passes the latch through verbatim when
+        // minimized, so the scaled value reaches the output.
         expect(result.debugPaneLatchHeight).toBe(640);
+    });
+
+    it('falls back to scale=1 on non-positive prev dimensions instead of producing NaN', () => {
+        // The pure helper is exported for testing. The production caller
+        // already guards against this via the `!prev` check and the
+        // hydration-time seed. For unexpected callers (tests, future bugs
+        // in the seeding path), emit a warning and fall back to scale=1
+        // rather than producing NaN / Infinity outputs. The rest of the
+        // function (minSize clamp, latch routing) still applies.
+        const result = scalePaneSizesForContainerResize({
+            prev: { width: 0, height: 0 },
+            current: { width: 1500, height: 800 },
+            editorPaneWidth: 600,
+            previewAreaHeight: 480,
+            debugPaneLatchHeight: 320,
+            isDebugPaneMinimized: false
+        });
+        // scale=1 ⇒ inputs pass through; preview height absorbs the rest
+        // of the container height; minSize clamp not engaged here.
+        expect(result.editorPaneViewport.width).toBe(600);
+        expect(result.previewAreaViewport.width).toBe(900);
+        expect(result.previewAreaViewport.height).toBe(480);
+        expect(result.debugPaneViewport.height).toBe(320);
+        // No NaN / Infinity in any output value.
+        Object.values(result.editorPaneViewport).forEach((v) => {
+            expect(Number.isFinite(v)).toBe(true);
+        });
+        Object.values(result.previewAreaViewport).forEach((v) => {
+            expect(Number.isFinite(v)).toBe(true);
+        });
+        Object.values(result.debugPaneViewport).forEach((v) => {
+            expect(Number.isFinite(v)).toBe(true);
+        });
+        expect(Number.isFinite(result.debugPaneLatchHeight)).toBe(true);
     });
 
     it('falls back to default percentage latch when scaled debug height is below areaMinSize', () => {

--- a/packages/app-core/src/app/editor/hooks/use-editor-pane-layout.ts
+++ b/packages/app-core/src/app/editor/hooks/use-editor-pane-layout.ts
@@ -61,6 +61,17 @@ export const useEditorPaneLayout = () => {
     const [hasHydratedViewports, setHasHydratedViewports] = useState(false);
     const isDebugPaneMinimizedPrev = usePrevious(isDebugPaneMinimized);
 
+    // Container size at the moment the store was last synced. Compared against
+    // the live observer values to detect post-hydration container resizes (most
+    // commonly the host's iframe expansion that follows editor open) and trigger
+    // a proportional rescale of the stored pane sizes. Without this, the
+    // one-shot hydration below captures a partial-expansion size and Fit
+    // computes against stale values for the rest of the session.
+    const prevContainerSizeRef = useRef<{
+        width: number;
+        height: number;
+    } | null>(null);
+
     // Commit vertical sizes to store (single dispatch)
     const commitVerticalSizes = useCallback(
         (sizes: number[]) => {
@@ -190,6 +201,7 @@ export const useEditorPaneLayout = () => {
                 latchHeightNext
             });
             setHasHydratedViewports(() => true);
+            prevContainerSizeRef.current = { width: cw, height: ch };
             setViewports({
                 editorPaneViewport: editorPaneViewportNext,
                 previewAreaViewport: previewAreaViewportNext,
@@ -210,6 +222,59 @@ export const useEditorPaneLayout = () => {
         isDebugPaneMinimized,
         previewAreaViewport.height,
         previewAreaViewport.width,
+        setViewports
+    ]);
+
+    // Post-hydration: if the container resizes after the one-shot hydration
+    // (most commonly the host's iframe expansion settling, or a window resize
+    // mid-session), proportionally rescale the stored pane sizes so the store
+    // tracks the live container. Allotment auto-rescales its rendered children
+    // on container resize but does not fire onChange/onDragEnd, so without
+    // this sync the store stays at whatever (possibly mid-expansion partial)
+    // sizes the initial hydration captured. Consumers that read pane sizes
+    // from the store (notably `getZoomToFitScale`) would otherwise compute
+    // against stale values.
+    useLayoutEffect(() => {
+        if (!hasHydratedViewports) return;
+        const cw = containerWidth ?? 0;
+        const ch = containerHeight ?? 0;
+        if (cw <= 0 || ch <= 0) return;
+        const prev = prevContainerSizeRef.current;
+        if (!prev) return;
+        if (prev.width === cw && prev.height === ch) return;
+
+        const next = scalePaneSizesForContainerResize({
+            prev,
+            current: { width: cw, height: ch },
+            editorPaneWidth: editorPaneViewport.width,
+            previewAreaHeight: previewAreaViewport.height,
+            debugPaneLatchHeight: debugPaneLatchHeight ?? 0,
+            isDebugPaneMinimized
+        });
+
+        prevContainerSizeRef.current = { width: cw, height: ch };
+
+        logDebug(`[${LOG_PREFIX}] Container resized post-hydration; rescaling`, {
+            prev,
+            current: { width: cw, height: ch },
+            next
+        });
+
+        setViewports({
+            editorPaneViewport: next.editorPaneViewport,
+            previewAreaViewport: next.previewAreaViewport,
+            debugPaneViewport: next.debugPaneViewport,
+            isDebugPaneMinimized,
+            debugPaneLatchHeight: next.debugPaneLatchHeight
+        });
+    }, [
+        containerWidth,
+        containerHeight,
+        debugPaneLatchHeight,
+        editorPaneViewport.width,
+        hasHydratedViewports,
+        isDebugPaneMinimized,
+        previewAreaViewport.height,
         setViewports
     ]);
 
@@ -303,6 +368,69 @@ export const useEditorPaneLayout = () => {
 };
 
 // Helper functions
+
+/**
+ * Proportionally rescale stored pane sizes to a new container size.
+ *
+ * Used by the post-hydration sync effect to keep the editor's pane store in
+ * sync with the live container when it resizes after the one-shot hydration
+ * (host iframe expansion, window resize). Returns new pane sizes such that:
+ * - `editorPaneViewport.width + previewAreaViewport.width === current.width`
+ *   (preview pane absorbs rounding error)
+ * - `previewAreaViewport.height + debugPaneViewport.height === current.height`
+ *   (debug pane absorbs rounding error)
+ * - User-dragged ratios are preserved: `editorPaneViewport.width /
+ *   current.width` and `previewAreaViewport.height / current.height` match
+ *   their pre-resize values (modulo rounding and the `minWidth` clamp).
+ * - Right (preview + debug) pane width is clamped to
+ *   `DEBUG_PANE_CONFIGURATION.minWidth` so the store stays in sync with what
+ *   Allotment renders (the right `Allotment.Pane` enforces the same minSize).
+ * - Latch height is routed through {@link getDebugPaneLatchHeight} so its
+ *   "freeze while minimized" and "fall back to default percentage when
+ *   below `areaMinSize`" semantics apply uniformly across the hydrate,
+ *   drag, and rescale paths.
+ *
+ * Exported for unit tests; the hook is the only production caller.
+ */
+export const scalePaneSizesForContainerResize = ({
+    prev,
+    current,
+    editorPaneWidth,
+    previewAreaHeight,
+    debugPaneLatchHeight,
+    isDebugPaneMinimized
+}: {
+    prev: { width: number; height: number };
+    current: { width: number; height: number };
+    editorPaneWidth: number;
+    previewAreaHeight: number;
+    debugPaneLatchHeight: number;
+    isDebugPaneMinimized: boolean;
+}) => {
+    const scaleX = current.width / prev.width;
+    const scaleY = current.height / prev.height;
+    const proposedEditorW = Math.round(editorPaneWidth * scaleX);
+    const proposedRightW = Math.max(0, current.width - proposedEditorW);
+    const newRightW = Math.max(
+        proposedRightW,
+        DEBUG_PANE_CONFIGURATION.minWidth
+    );
+    const newEditorW = Math.max(0, current.width - newRightW);
+    const newPreviewH = Math.round(previewAreaHeight * scaleY);
+    const newDebugH = Math.max(0, current.height - newPreviewH);
+    const newLatch = getDebugPaneLatchHeight(
+        newDebugH,
+        Math.round(debugPaneLatchHeight * scaleY),
+        current.height,
+        isDebugPaneMinimized
+    );
+    return {
+        editorPaneViewport: { width: newEditorW, height: current.height },
+        previewAreaViewport: { width: newRightW, height: newPreviewH },
+        debugPaneViewport: { width: newRightW, height: newDebugH },
+        debugPaneLatchHeight: newLatch
+    };
+};
 
 const getDebugPaneLatchHeight = (
     currentItemHeight: number,

--- a/packages/app-core/src/app/editor/hooks/use-editor-pane-layout.ts
+++ b/packages/app-core/src/app/editor/hooks/use-editor-pane-layout.ts
@@ -11,7 +11,7 @@ import { usePrevious } from '@uidotdev/usehooks';
 import useResizeObserver from 'use-resize-observer';
 import type { AllotmentHandle } from 'allotment';
 
-import { logDebug } from '@deneb-viz/utils/logging';
+import { logDebug, logWarning } from '@deneb-viz/utils/logging';
 import {
     DEBUG_PANE_CONFIGURATION,
     SPLIT_PANE_CONFIGURATION
@@ -407,8 +407,20 @@ export const scalePaneSizesForContainerResize = ({
     debugPaneLatchHeight: number;
     isDebugPaneMinimized: boolean;
 }) => {
-    const scaleX = current.width / prev.width;
-    const scaleY = current.height / prev.height;
+    if (prev.width <= 0 || prev.height <= 0) {
+        logWarning(
+            `[${LOG_PREFIX}] scalePaneSizesForContainerResize: prev dimensions must be > 0; falling back to scale=1`,
+            { prev, current }
+        );
+    }
+    // Fall back to scale=1 on a non-positive `prev`. The production caller
+    // already guards via the `!prev` check and the hydration-time seed, so
+    // this branch only triggers for direct (test) callers or future bugs in
+    // the seeding path - emit the warning above and let the rest of the
+    // function produce a no-op rescale (clamps and latch routing still
+    // apply) rather than NaN / Infinity outputs.
+    const scaleX = prev.width > 0 ? current.width / prev.width : 1;
+    const scaleY = prev.height > 0 ? current.height / prev.height : 1;
     const proposedEditorW = Math.round(editorPaneWidth * scaleX);
     const proposedRightW = Math.max(0, current.width - proposedEditorW);
     const newRightW = Math.max(
@@ -416,8 +428,16 @@ export const scalePaneSizesForContainerResize = ({
         DEBUG_PANE_CONFIGURATION.minWidth
     );
     const newEditorW = Math.max(0, current.width - newRightW);
-    const newPreviewH = Math.round(previewAreaHeight * scaleY);
-    const newDebugH = Math.max(0, current.height - newPreviewH);
+    // When minimized, debug pane height MUST be exactly `toolbarMinSize` -
+    // the toggle effect's expand branch checks `=== toolbarMinSize` (strict
+    // equality) before firing the programmatic resize. Deriving it from the
+    // proportionally-scaled preview height drifts (e.g., doubling container
+    // height yields debug = 2 * toolbarMinSize) and silently breaks
+    // user-driven expand for the rest of the session.
+    const newDebugH = isDebugPaneMinimized
+        ? DEBUG_PANE_CONFIGURATION.toolbarMinSize
+        : Math.max(0, current.height - Math.round(previewAreaHeight * scaleY));
+    const newPreviewH = Math.max(0, current.height - newDebugH);
     const newLatch = getDebugPaneLatchHeight(
         newDebugH,
         Math.round(debugPaneLatchHeight * scaleY),

--- a/packages/app-core/src/lib/interface/__tests__/layout.test.ts
+++ b/packages/app-core/src/lib/interface/__tests__/layout.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { VISUAL_PREVIEW_ZOOM_CONFIGURATION } from '@deneb-viz/configuration';
+import { computeZoomToFitScale } from '../layout';
+
+/**
+ * Pure-helper tests for the zoom-to-fit computation that backs the editor's
+ * "Fit" zoom level. The function reads from store state in production via
+ * `getZoomToFitScale()`; this characterises the pure inner computation
+ * (`computeZoomToFitScale`) which takes the same inputs as parameters so
+ * the math is testable without mocking Zustand.
+ *
+ * Bug being guarded against: when `previewAreaViewport` is the unhydrated
+ * default `{width: 0, height: 0}` (e.g. the editor was just opened and the
+ * layout `useLayoutEffect` has not yet committed measured viewports), the
+ * unguarded math produced negative scale factors. The popover entry path
+ * silently clamped those to the configured min (10%), and the hotkey entry
+ * path (`handleZoomFit` in `lib/commands/actions.ts`) wrote them through
+ * verbatim — both surfaced as "Fit shrinks the visual to a smaller value
+ * than currently displayed rather than fitting".
+ */
+
+const MIN = VISUAL_PREVIEW_ZOOM_CONFIGURATION.min;
+const MAX = VISUAL_PREVIEW_ZOOM_CONFIGURATION.max;
+const DEFAULT_ZOOM = VISUAL_PREVIEW_ZOOM_CONFIGURATION.default;
+
+describe('computeZoomToFitScale', () => {
+    describe('input guards (the unhydrated/missing-viewport bug)', () => {
+        it('returns the default zoom when previewAreaViewport is the unhydrated {0, 0} initial state', () => {
+            expect(
+                computeZoomToFitScale({
+                    previewAreaViewport: { width: 0, height: 0 },
+                    embedViewport: { width: 600, height: 400 }
+                })
+            ).toBe(DEFAULT_ZOOM);
+        });
+
+        it('returns the default zoom when previewAreaViewport.width is 0', () => {
+            expect(
+                computeZoomToFitScale({
+                    previewAreaViewport: { width: 0, height: 500 },
+                    embedViewport: { width: 600, height: 400 }
+                })
+            ).toBe(DEFAULT_ZOOM);
+        });
+
+        it('returns the default zoom when previewAreaViewport.height is 0', () => {
+            expect(
+                computeZoomToFitScale({
+                    previewAreaViewport: { width: 1000, height: 0 },
+                    embedViewport: { width: 600, height: 400 }
+                })
+            ).toBe(DEFAULT_ZOOM);
+        });
+
+        it('returns the default zoom when embedViewport is null (visual not yet rendered)', () => {
+            expect(
+                computeZoomToFitScale({
+                    previewAreaViewport: { width: 1000, height: 500 },
+                    embedViewport: null
+                })
+            ).toBe(DEFAULT_ZOOM);
+        });
+
+        it('returns the default zoom when embedViewport.width is 0', () => {
+            expect(
+                computeZoomToFitScale({
+                    previewAreaViewport: { width: 1000, height: 500 },
+                    embedViewport: { width: 0, height: 400 }
+                })
+            ).toBe(DEFAULT_ZOOM);
+        });
+
+        it('returns the default zoom when embedViewport.height is 0', () => {
+            expect(
+                computeZoomToFitScale({
+                    previewAreaViewport: { width: 1000, height: 500 },
+                    embedViewport: { width: 600, height: 0 }
+                })
+            ).toBe(DEFAULT_ZOOM);
+        });
+
+        it('returns the default zoom when previewAreaViewport.width is negative (guard covers <= 0, not just == 0)', () => {
+            // Locks the `<= 0` guard against a future refactor that
+            // narrows to `=== 0` — negative dimensions should still fall
+            // through to the safe default, not bypass the guard.
+            expect(
+                computeZoomToFitScale({
+                    previewAreaViewport: { width: -1, height: 500 },
+                    embedViewport: { width: 600, height: 400 }
+                })
+            ).toBe(DEFAULT_ZOOM);
+        });
+    });
+
+    describe('output clamping (never returns out-of-range values)', () => {
+        it('clamps to the configured min when the computed scale would land below min', () => {
+            // Visual tall, preview short — height is the binding constraint
+            // and the math drives scaleFactorHeight below MIN (=10).
+            const result = computeZoomToFitScale({
+                previewAreaViewport: { width: 1000, height: 50 },
+                embedViewport: { width: 600, height: 5000 }
+            });
+            expect(result).toBe(MIN);
+        });
+
+        it('clamps to the configured max when the computed scale would land above max', () => {
+            // Visual much smaller than preview — both scale factors exceed
+            // MAX (=400) but the clamp pulls them back.
+            const result = computeZoomToFitScale({
+                previewAreaViewport: { width: 10000, height: 10000 },
+                embedViewport: { width: 50, height: 50 }
+            });
+            expect(result).toBe(MAX);
+        });
+
+        it('clamps to MIN for a tiny pane whose padded dimensions go negative', () => {
+            // previewAreaViewport=25x25 passes the guard, but
+            // getAdjustedPreviewArea*ForPadding subtracts 20/30 and then
+            // ZOOM_FIT_BUFFER subtracts another 15, driving the numerator
+            // negative for both axes. Both scale factors are negative
+            // (-2, -4), willScaledDimensionFit accepts the smaller scale,
+            // and the clamp recovers it to MIN. Pinned to MIN rather than
+            // a range so a future regression that shifts to zDefault, MAX,
+            // or any other in-range value is caught.
+            const result = computeZoomToFitScale({
+                previewAreaViewport: { width: 25, height: 25 },
+                embedViewport: { width: 800, height: 600 }
+            });
+            expect(result).toBe(MIN);
+        });
+    });
+
+    describe('happy paths (binding-constraint selection)', () => {
+        it('returns the height-derived scale when height is the binding constraint', () => {
+            // Visual 800x600, preview 1000x500 — preview is wider than tall
+            // relative to the visual, so height limits the fit.
+            //   previewHeight (after padding)            = 500 - 6*5     = 470
+            //   scaleFactorHeight = floor(100 * (470 - 15) / 600)        = 75
+            expect(
+                computeZoomToFitScale({
+                    previewAreaViewport: { width: 1000, height: 500 },
+                    embedViewport: { width: 800, height: 600 }
+                })
+            ).toBe(75);
+        });
+
+        it('returns the width-derived scale when width is the binding constraint', () => {
+            // Visual 800x200, preview 500x1000 — visual is much wider relative
+            // to preview, so width limits the fit.
+            //   previewWidth (after padding)             = 500 - 4*5     = 480
+            //   scaleFactorWidth = floor(100 * (480 - 15) / 800)         = 58
+            expect(
+                computeZoomToFitScale({
+                    previewAreaViewport: { width: 500, height: 1000 },
+                    embedViewport: { width: 800, height: 200 }
+                })
+            ).toBe(58);
+        });
+    });
+});

--- a/packages/app-core/src/lib/interface/layout.ts
+++ b/packages/app-core/src/lib/interface/layout.ts
@@ -1,36 +1,75 @@
 import { PREVIEW_PANE_AREA_PADDING, ZOOM_FIT_BUFFER } from './constants';
 import { VISUAL_PREVIEW_ZOOM_CONFIGURATION } from '@deneb-viz/configuration';
 import { getDenebState } from '../../state';
+import type { ContainerViewport } from './types';
 
 /**
  * Derive suitable scale to apply to visual preview if wishing to fit to preview area.
+ *
+ * Thin store-bound wrapper around {@link computeZoomToFitScale}, which holds
+ * the pure computation and is independently unit-tested.
  */
 export const getZoomToFitScale = () => {
     const {
-            editor: { previewAreaViewport },
-            interface: { embedViewport }
-        } = getDenebState(),
-        { height = 0, width = 0 } = embedViewport ?? {},
-        previewWidth = getAdjustedPreviewAreaWidthForPadding(
-            previewAreaViewport.width ?? 0
-        ),
-        previewHeight = getAdjustedPreviewAreaHeightForPadding(
-            previewAreaViewport.height ?? 0
-        ),
-        scaleFactorWidth = Math.floor(
-            100 / (width / (previewWidth - ZOOM_FIT_BUFFER))
-        ),
-        scaleFactorHeight = Math.floor(
-            100 / (height / (previewHeight - ZOOM_FIT_BUFFER))
-        ),
-        { default: zDefault, max } = VISUAL_PREVIEW_ZOOM_CONFIGURATION;
+        editor: { previewAreaViewport },
+        interface: { embedViewport }
+    } = getDenebState();
+    return computeZoomToFitScale({ previewAreaViewport, embedViewport });
+};
+
+type ZoomToFitScaleParams = {
+    previewAreaViewport: ContainerViewport;
+    embedViewport: ContainerViewport | null;
+};
+
+/**
+ * Pure scale-to-fit computation. {@link getZoomToFitScale} is the
+ * store-bound wrapper; this version takes inputs as parameters so the
+ * math can be unit-tested without mocking Zustand.
+ *
+ * Returns `zDefault` (100%) when any input dimension is non-positive
+ * (the unhydrated `{0, 0}` initial-state path that produced the original
+ * "Fit shrinks the visual" bug). Otherwise returns the scale needed to
+ * fit `embedViewport` inside `previewAreaViewport`, clamped to
+ * `[VISUAL_PREVIEW_ZOOM_CONFIGURATION.min, max]`. See the test file for
+ * the bug narrative the guard prevents.
+ */
+export const computeZoomToFitScale = ({
+    previewAreaViewport,
+    embedViewport
+}: ZoomToFitScaleParams) => {
+    const { default: zDefault, min, max } = VISUAL_PREVIEW_ZOOM_CONFIGURATION;
+    const { height = 0, width = 0 } = embedViewport ?? {};
+    const { width: previewAreaWidth, height: previewAreaHeight } =
+        previewAreaViewport;
+    // Bail out to the default when any input dimension is non-positive -
+    // running the math on zero/negative inputs would otherwise be caught
+    // only by the downstream output clamp, masking the real issue.
+    if (
+        previewAreaWidth <= 0 ||
+        previewAreaHeight <= 0 ||
+        width <= 0 ||
+        height <= 0
+    ) {
+        return zDefault;
+    }
+    const previewWidth = getAdjustedPreviewAreaWidthForPadding(previewAreaWidth);
+    const previewHeight =
+        getAdjustedPreviewAreaHeightForPadding(previewAreaHeight);
+    const scaleFactorWidth = Math.floor(
+        100 / (width / (previewWidth - ZOOM_FIT_BUFFER))
+    );
+    const scaleFactorHeight = Math.floor(
+        100 / (height / (previewHeight - ZOOM_FIT_BUFFER))
+    );
+    const clamp = (value: number) => Math.max(min, Math.min(value, max));
     switch (true) {
         case willScaledDimensionFit(width, scaleFactorWidth, previewWidth) &&
             willScaledDimensionFit(height, scaleFactorWidth, previewHeight):
-            return Math.min(scaleFactorWidth, max);
+            return clamp(scaleFactorWidth);
         case willScaledDimensionFit(width, scaleFactorHeight, previewWidth) &&
             willScaledDimensionFit(height, scaleFactorHeight, previewHeight):
-            return Math.min(scaleFactorHeight, max);
+            return clamp(scaleFactorHeight);
         default:
             return zDefault;
     }


### PR DESCRIPTION
Fit could land far below what the preview area implies, with no
diagnostic. Two independent root causes are addressed:

- `computeZoomToFitScale` had no input guard and clamped only the
  upper bound. Unhydrated `{0,0}` viewports produced negative scale
  factors silently flattened to 10% by the popover's downstream
  clamp (and written verbatim by the hotkey path). Pure helper
  extracted, non-positive input guard added, clamp made symmetric.

- `useEditorPaneLayout` hydrated pane sizes once on the first
  non-zero container measurement (typically a partial size captured
  mid-iframe-expansion) and never re-synced. Allotment auto-
  rescales rendered children on container resize but does not fire
  onChange/onDragEnd, so the store stayed stuck while the visible
  preview grew. Added a post-hydration `useLayoutEffect` that
  proportionally rescales pane sizes via a new pure helper
  `scalePaneSizesForContainerResize`. Right-pane width clamps to
  `DEBUG_PANE_CONFIGURATION.minWidth` to match Allotment's enforced
  minSize; latch height routes through `getDebugPaneLatchHeight` so
  its minimized-preservation and areaMinSize semantics apply
  uniformly across hydrate, drag, and rescale paths.
