### PR TITLE
fix: dev startup reliability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,7 @@ Common issues:
 
 - **Constructor not firing** → Check `_DEBUG` suffix in webpack.common.config.js
 - **Slow rebuilds (>5s)** → Ensure `certificationFix: false` in dev mode
-- **Visual doesn't load** → Clear `.tmp/`, restart `npm run dev` (auto-primes)
+- **Visual doesn't load** → Restart `npm run dev` (it clears `.tmp/`, rebuilds packages, and re-primes on every start)
 - **Type errors unnoticed** → Run `npm run webpack:package` or `npx tsc --noEmit`
 
 ## Known Workarounds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ npm run sync-packages                # Sync package versions across monorepo
 
 ```bash
 npm install       # Install dependencies
-npm run dev       # Start development (auto-primes assets if needed)
+npm run dev       # Start development (clears .tmp/, builds packages, primes assets, starts server)
 ```
 
 > **Details**: See [First-time setup](doc/DEVELOPMENT.md#first-time-setup) in DEVELOPMENT.md
@@ -241,7 +241,7 @@ Per-field configuration of which support fields (`__highlight__`, `__format__`, 
 
 **Quick Start:**
 
-1. `npm run dev` → auto-primes assets, starts watchers + dev server
+1. `npm run dev` → clears `.tmp/`, builds packages, primes assets, starts watchers + dev server (~22s first build per session)
 2. Open Power BI pointing to `https://localhost:8080/assets/visual.js`
 3. Edit code → webpack auto-rebuilds (~1-2s) → page reloads
 

--- a/bin/dev-with-prime.js
+++ b/bin/dev-with-prime.js
@@ -31,22 +31,22 @@ const run = (label, command) => {
         execSync(command, { stdio: 'inherit', cwd: repoRoot });
     } catch (error) {
         console.error(`✗ ${label} failed`);
-        process.exit(1);
+        if (error.message) console.error(error.message);
+        process.exit(error.status ?? 1);
     }
 };
 
-// 1. Clear .tmp for a predictable dev start.
-if (fs.existsSync(tmpDir)) {
-    console.log('🧹 Clearing .tmp for a predictable dev start...');
-    try {
-        fs.rmSync(tmpDir, { recursive: true, force: true });
-    } catch (error) {
-        console.error(
-            '✗ Failed to clear .tmp — close any processes using files inside it and retry'
-        );
-        console.error(error.message);
-        process.exit(1);
-    }
+// 1. Reset .tmp for a predictable dev start. rmSync with force:true no-ops
+//    on ENOENT, so no existsSync guard is needed.
+console.log('🧹 Resetting .tmp for a predictable dev start...');
+try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+} catch (error) {
+    console.error(
+        '✗ Failed to clear .tmp — close any processes using files inside it and retry'
+    );
+    console.error(error.message);
+    process.exit(1);
 }
 
 // 2. Build workspace packages so webpack can resolve @deneb-viz/* imports.
@@ -57,14 +57,29 @@ run('Building workspace packages', 'npm run build:package');
 run('Priming dev assets', 'npm run webpack:prime');
 console.log('✓ Assets primed successfully');
 
-// 4. Start the dev server alongside package watchers.
+// 4. Start the dev server alongside package watchers. `npx --no` resolves
+//    `turbo` through node_modules/.bin regardless of whether the script was
+//    invoked via `npm run dev` (PATH set) or directly (PATH not set).
 console.log('\n→ Starting dev server...');
 try {
-    execSync('turbo run dev webpack:start --parallel --concurrency=25', {
-        stdio: 'inherit',
-        cwd: repoRoot
-    });
+    execSync(
+        'npx --no turbo run dev webpack:start --parallel --concurrency=25',
+        { stdio: 'inherit', cwd: repoRoot }
+    );
 } catch (error) {
-    // User likely pressed Ctrl+C to stop the server
-    process.exit(0);
+    // Distinguish clean shutdown (Ctrl+C, SIGTERM) from a real failure so
+    // outer wrappers (CI gates, agent harnesses) see the genuine exit code.
+    // POSIX: SIGINT/SIGTERM set error.signal, or the shell propagates 130.
+    // Windows: Ctrl+C surfaces as status 3221225786 (0xC000013A — STATUS_CONTROL_C_EXIT).
+    const isCleanShutdown =
+        error.signal === 'SIGINT' ||
+        error.signal === 'SIGTERM' ||
+        error.status === 130 ||
+        error.status === 3221225786;
+    if (isCleanShutdown) {
+        process.exit(0);
+    }
+    console.error('✗ Dev server exited with error');
+    if (error.message) console.error(error.message);
+    process.exit(error.status ?? 1);
 }

--- a/bin/dev-with-prime.js
+++ b/bin/dev-with-prime.js
@@ -1,56 +1,68 @@
 #!/usr/bin/env node
 /**
- * Dev script that primes assets if needed, then starts dev server
+ * Dev script that ensures a predictable starting state for `npm run dev`:
+ *
+ *   1. Clears `.tmp/` so each session starts free of stale webpack persistent
+ *      cache, stale `.tmp/precompile` / `.tmp/drop` assets, and any leftover
+ *      state from previous branches.
+ *   2. Builds the workspace packages so webpack can resolve `@deneb-viz/*`
+ *      imports during the prime step (workspace exports point at `dist/`).
+ *      Turbo's task cache makes this near-instant when nothing has changed.
+ *   3. Primes dev assets (`.tmp/precompile/visualPlugin.ts` and
+ *      `.tmp/drop/pbiviz.json`).
+ *   4. Starts the dev server alongside the package watchers.
+ *
+ * The trade-off for clearing `.tmp/` is a ~22s first build per session
+ * versus the unpredictable warnings/errors that result from stale cache
+ * (e.g. cross-branch webpack cache reporting missing re-exports that exist
+ * in the current source).
  */
 
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const pbivizPath = path.join(__dirname, '..', '.tmp', 'drop', 'pbiviz.json');
-const pluginPath = path.join(
-    __dirname,
-    '..',
-    '.tmp',
-    'precompile',
-    'visualPlugin.ts'
-);
+const repoRoot = path.join(__dirname, '..');
+const tmpDir = path.join(repoRoot, '.tmp');
 
-// Check if assets exist AND pbiviz.json has resources (not just metadata)
-let allExist = fs.existsSync(pbivizPath) && fs.existsSync(pluginPath);
-
-if (allExist) {
-    // Verify pbiviz.json has stringResources (means it was fully generated)
+const run = (label, command) => {
+    console.log(`\n→ ${label}`);
     try {
-        const pbiviz = JSON.parse(fs.readFileSync(pbivizPath, 'utf8'));
-        if (!pbiviz.stringResources || Object.keys(pbiviz.stringResources).length === 0) {
-            console.log('⚠ pbiviz.json exists but lacks resources');
-            allExist = false;
-        }
+        execSync(command, { stdio: 'inherit', cwd: repoRoot });
     } catch (error) {
-        console.log('⚠ pbiviz.json is invalid or corrupted');
-        allExist = false;
-    }
-}
-
-if (!allExist) {
-    console.log('⚠ Dev assets missing, priming...');
-    try {
-        execSync('npm run webpack:prime', { stdio: 'inherit' });
-        console.log('✓ Assets primed successfully');
-    } catch (error) {
-        console.error('✗ Failed to prime assets');
+        console.error(`✗ ${label} failed`);
         process.exit(1);
     }
-} else {
-    console.log('✓ Dev assets already exist, skipping prime step');
+};
+
+// 1. Clear .tmp for a predictable dev start.
+if (fs.existsSync(tmpDir)) {
+    console.log('🧹 Clearing .tmp for a predictable dev start...');
+    try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch (error) {
+        console.error(
+            '✗ Failed to clear .tmp — close any processes using files inside it and retry'
+        );
+        console.error(error.message);
+        process.exit(1);
+    }
 }
 
-// Now start the dev server
-console.log('Starting dev server...');
+// 2. Build workspace packages so webpack can resolve @deneb-viz/* imports.
+//    turbo's cache makes this fast (~1-2s) when packages are unchanged.
+run('Building workspace packages', 'npm run build:package');
+
+// 3. Prime dev assets.
+run('Priming dev assets', 'npm run webpack:prime');
+console.log('✓ Assets primed successfully');
+
+// 4. Start the dev server alongside package watchers.
+console.log('\n→ Starting dev server...');
 try {
     execSync('turbo run dev webpack:start --parallel --concurrency=25', {
-        stdio: 'inherit'
+        stdio: 'inherit',
+        cwd: repoRoot
     });
 } catch (error) {
     // User likely pressed Ctrl+C to stop the server

--- a/bin/dev-with-prime.js
+++ b/bin/dev-with-prime.js
@@ -25,11 +25,24 @@ const path = require('path');
 const repoRoot = path.join(__dirname, '..');
 const tmpDir = path.join(repoRoot, '.tmp');
 
+// Distinguish clean shutdown (Ctrl+C, SIGTERM) from a real failure so outer
+// wrappers (CI gates, agent harnesses) see the genuine exit code.
+// POSIX: SIGINT/SIGTERM set error.signal, or the shell propagates 130.
+// Windows: Ctrl+C surfaces as status 3221225786 (0xC000013A — STATUS_CONTROL_C_EXIT).
+const isCleanShutdown = (error) =>
+    error.signal === 'SIGINT' ||
+    error.signal === 'SIGTERM' ||
+    error.status === 130 ||
+    error.status === 3221225786;
+
 const run = (label, command) => {
     console.log(`\n→ ${label}`);
     try {
         execSync(command, { stdio: 'inherit', cwd: repoRoot });
     } catch (error) {
+        if (isCleanShutdown(error)) {
+            process.exit(0);
+        }
         console.error(`✗ ${label} failed`);
         if (error.message) console.error(error.message);
         process.exit(error.status ?? 1);
@@ -67,16 +80,7 @@ try {
         { stdio: 'inherit', cwd: repoRoot }
     );
 } catch (error) {
-    // Distinguish clean shutdown (Ctrl+C, SIGTERM) from a real failure so
-    // outer wrappers (CI gates, agent harnesses) see the genuine exit code.
-    // POSIX: SIGINT/SIGTERM set error.signal, or the shell propagates 130.
-    // Windows: Ctrl+C surfaces as status 3221225786 (0xC000013A — STATUS_CONTROL_C_EXIT).
-    const isCleanShutdown =
-        error.signal === 'SIGINT' ||
-        error.signal === 'SIGTERM' ||
-        error.status === 130 ||
-        error.status === 3221225786;
-    if (isCleanShutdown) {
+    if (isCleanShutdown(error)) {
         process.exit(0);
     }
     console.error('✗ Dev server exited with error');

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -52,7 +52,14 @@ Deneb uses a two-branch trunk:
 
 Copy `.env.example` to `.env` (see ".env Setup" below) so local dev toggles like `LOG_LEVEL` are picked up.
 
-> **Note:** The `npm run dev` command automatically detects if required assets are missing and runs a one-time build to generate them. You no longer need to manually run `npm run package` before first dev run.
+> **Note:** The `npm run dev` command performs the following steps automatically each time it runs:
+>
+> 1. **Clears `.tmp/`** for a predictable starting state. This avoids stale webpack persistent cache (which can survive branch switches and report ghost errors against source that no longer exists), plus stale prime artefacts under `.tmp/precompile` and `.tmp/drop`.
+> 2. **Builds workspace packages** via `npm run build:package` so webpack can resolve `@deneb-viz/*` imports (their `exports` map points at `dist/`). Turbo's cache makes this near-instant when packages are unchanged.
+> 3. **Primes dev assets** (`.tmp/precompile/visualPlugin.ts` and `.tmp/drop/pbiviz.json`).
+> 4. **Starts the dev server** alongside the workspace package watchers.
+>
+> Cost: ~22s first build per dev session (one-off; in-session rebuilds are still ~1–2s via webpack's in-memory cache). Benefit: no manual cache clearing, no missing-export warnings from old cache, no need to pre-build packages on a fresh clone.
 
 ### Typical development
 

--- a/docs/solutions/build-errors/webpack-persistent-cache-ghost-export-warnings-2026-05-27.md
+++ b/docs/solutions/build-errors/webpack-persistent-cache-ghost-export-warnings-2026-05-27.md
@@ -1,0 +1,138 @@
+---
+title: "Webpack persistent cache emits ghost export warnings after branch switch; dev broken on clean clone"
+date: 2026-05-27
+category: docs/solutions/build-errors/
+module: dev-tooling
+problem_type: build_error
+component: development_workflow
+related_components: [tooling]
+symptoms:
+  - "WARNING in ./src/lib/dataset/processing.ts — `export 'getEncodedFieldName' was not found in './fields'` despite being present in source"
+  - Line numbers in the webpack warning do not match current file content — they reference a stale snapshot
+  - "`npm run dev` fails on fresh clone: webpack cannot resolve `@deneb-viz/*` imports because `dist/` does not exist"
+  - "`.tmp/` cache persists across branch switches, accumulating drift that produces incorrect cross-module export analysis"
+root_cause: config_error
+resolution_type: workflow_improvement
+severity: high
+tags: [webpack, persistent-cache, monorepo, dev-startup, clean-clone, ghost-warning, turbo, worktree]
+---
+
+# Webpack persistent cache emits ghost export warnings after branch switch; dev broken on clean clone
+
+## Problem
+
+`npm run dev` on a clean worktree emitted ghost webpack export warnings (e.g. `export 'getEncodedFieldName' was not found in './fields'`) even though the export exists at [`src/lib/dataset/fields.ts:82`](../../../src/lib/dataset/fields.ts#L82). CI never caught it because CI always runs on fresh clones. Two related issues compounded the problem: workspace packages were not built before webpack ran, so fresh clones couldn't resolve `@deneb-viz/*` imports at all; and `.tmp/` accumulated stale cache state across sessions with no automatic reset.
+
+## Symptoms
+
+- Webpack warned: `export 'getEncodedFieldName' (imported as 'getEncodedFieldName') was not found in './fields' (possible exports: getDatumFieldMetadataFromDataView, ...)` — the export was present in source but missing from the cached module graph.
+- Warning line numbers (169, 224, 257, 309, 315, 325) did not match current line numbers in [`src/lib/dataset/processing.ts`](../../../src/lib/dataset/processing.ts) (actual usages at 276, 346, 382, 434, 443, 456) — confirming the warning derived from a stale cached module snapshot, not current source.
+- Deleting `.tmp/webpack-cache` and re-running `npm run webpack:build` made all warnings vanish; a second build was also clean.
+- On a fresh clone, `npm run dev` failed because workspace `dist/` directories did not exist — `webpack:prime` had no `dependsOn: ["^build"]` and ran before packages were built.
+- `.tmp/` persisted indefinitely between dev sessions, requiring manual `rm -rf .tmp` to recover from drift.
+
+## What Didn't Work
+
+- Re-reading [`src/lib/dataset/processing.ts`](../../../src/lib/dataset/processing.ts) — the source was correct; the bug was not in the file.
+- Checking the compiled `dist/` of `@deneb-viz/data-core` for the `getEncodedFieldName` export — the dist was also correct; the import target was fine.
+- Investigating TypeScript re-export semantics (`isolatedModules`, `verbatimModuleSyntax`) — both are off; the `export { getEncodedFieldName }` pattern at [`fields.ts:82`](../../../src/lib/dataset/fields.ts#L82) is standard and compiles correctly.
+- Searching for a webpack config bug that might suppress the re-export — the config was fine; the problem was cached state, not configuration.
+
+## Solution
+
+Rewrote [`bin/dev-with-prime.js`](../../../bin/dev-with-prime.js) to:
+1. Clear `.tmp/` at startup (no `existsSync` guard needed — `fs.rmSync` with `force: true` no-ops on ENOENT)
+2. Build workspace packages via `npm run build:package` before webpack runs (turbo's cache makes this ~190ms when packages are unchanged)
+3. Prime dev assets via `npm run webpack:prime`
+4. Start the dev server via `npx --no turbo run dev webpack:start --parallel --concurrency=25`, with signal-aware exit handling
+
+```javascript
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..');
+const tmpDir = path.join(repoRoot, '.tmp');
+
+// Distinguish clean shutdown (Ctrl+C, SIGTERM) from a real failure so outer
+// wrappers (CI gates, agent harnesses) see the genuine exit code.
+// POSIX: SIGINT/SIGTERM set error.signal, or the shell propagates 130.
+// Windows: Ctrl+C surfaces as status 3221225786 (0xC000013A — STATUS_CONTROL_C_EXIT).
+const isCleanShutdown = (error) =>
+    error.signal === 'SIGINT' ||
+    error.signal === 'SIGTERM' ||
+    error.status === 130 ||
+    error.status === 3221225786;
+
+const run = (label, command) => {
+    console.log(`\n→ ${label}`);
+    try {
+        execSync(command, { stdio: 'inherit', cwd: repoRoot });
+    } catch (error) {
+        if (isCleanShutdown(error)) {
+            process.exit(0);
+        }
+        console.error(`✗ ${label} failed`);
+        if (error.message) console.error(error.message);
+        process.exit(error.status ?? 1);
+    }
+};
+
+// 1. Reset .tmp for a predictable dev start.
+console.log('🧹 Resetting .tmp for a predictable dev start...');
+try {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+} catch (error) {
+    console.error('✗ Failed to clear .tmp — close any processes using files inside it and retry');
+    console.error(error.message);
+    process.exit(1);
+}
+
+// 2. Build workspace packages so webpack can resolve @deneb-viz/* imports.
+run('Building workspace packages', 'npm run build:package');
+
+// 3. Prime dev assets.
+run('Priming dev assets', 'npm run webpack:prime');
+console.log('✓ Assets primed successfully');
+
+// 4. Start the dev server alongside package watchers.
+console.log('\n→ Starting dev server...');
+try {
+    execSync(
+        'npx --no turbo run dev webpack:start --parallel --concurrency=25',
+        { stdio: 'inherit', cwd: repoRoot }
+    );
+} catch (error) {
+    if (isCleanShutdown(error)) {
+        process.exit(0);
+    }
+    console.error('✗ Dev server exited with error');
+    if (error.message) console.error(error.message);
+    process.exit(error.status ?? 1);
+}
+```
+
+Two stale `auto-primes assets` references in [`CLAUDE.md`](../../../CLAUDE.md) (L54 First-Time Setup, L244 Quick Start) were updated to accurately describe the new startup sequence.
+
+Trade-off accepted: every dev start does a fresh first build (~22s when turbo cache cold, ~5s when warm) rather than skipping when cached assets exist. In-session rebuilds remain ~1–2s via webpack's in-memory cache.
+
+## Why This Works
+
+**(a) Clearing `.tmp/` defeats stale-cache ghost warnings.** Webpack's filesystem cache at `.tmp/webpack-cache` stores the full module graph including cross-module export analysis. The `buildDependencies: { config: [__filename] }` setting at [`webpack.dev.config.js:30-36`](../../../webpack.dev.config.js#L30-L36) invalidates the cache when the webpack config changes, but not when workspace package source changes in ways that alter re-export topology. Deleting `.tmp/` at startup guarantees webpack rebuilds the module graph from scratch each dev session, eliminating the class of stale-cache warnings entirely.
+
+**(b) Running `build:package` before `webpack:prime` is necessary on fresh clones.** All workspace packages in `packages/` declare `main` and `exports` pointing at `dist/`. If `dist/` does not exist, webpack's resolver cannot find `@deneb-viz/*` imports and fails at bundle time. `webpack:prime` is defined as `webpack --env generateResources=true` with no `dependsOn: ["^build"]` in [`turbo.json`](../../../turbo.json), so it has no mechanism to trigger package builds. Starting with `npm run build:package` (which turbo orchestrates with full `dependsOn` awareness) ensures all `dist/` outputs exist before webpack runs.
+
+**(c) Signal-aware exit codes matter for outer wrappers.** When a developer presses Ctrl+C to stop the dev server, `execSync` throws with `error.signal === 'SIGINT'` (POSIX) or `error.status === 3221225786` (Windows `STATUS_CONTROL_C_EXIT`). Without the `isCleanShutdown` guard, the script would call `process.exit(1)`, which CI systems and agent harnesses interpret as a build failure — triggering alerts, retries, or branch protection blocks. Exiting 0 for clean shutdowns preserves the correct signal: the dev session ended normally, not in error.
+
+## Prevention
+
+- **The smoking gun for stale-cache ghost warnings is line numbers in the warning that don't match the current file.** When an agent or developer sees this pattern, the first action is: delete `.tmp/webpack-cache` (or all of `.tmp/`) and re-run. Do not spend time reading the source file or the dist of the imported package.
+- **In a monorepo where workspace packages declare `main`/`exports` pointing at `dist/`, `dist/` must exist before webpack runs.** Never rely on `--parallel` turbo execution for build ordering — `--parallel` ignores `dependsOn` and does not guarantee ordering. Use an explicit sequential build step before starting the webpack server.
+- **Always invoke turbo via `npx --no turbo` in scripts that may be called outside an `npm run` context.** `npx --no` prevents downloading a new version and uses the project-local binary; bare `turbo` is PATH-dependent and will fail if turbo is not globally installed (e.g. when the script is invoked directly via `node bin/dev-with-prime.js` from an IDE run config).
+- **For dev scripts that wrap long-running processes, distinguish Ctrl+C / SIGTERM (exit 0) from genuine failures (propagate the non-zero exit code).** On POSIX, check `error.signal`; on Windows, check for status `3221225786` (`0xC000013A`). CI systems and agent harnesses treat any non-zero exit as a failure.
+- **Webpack's `cache: { type: 'filesystem', buildDependencies: { config: [...] } }` only invalidates the cache when the listed config files change.** It does not detect all cross-module export topology changes — particularly re-exports from workspace packages that were rebuilt externally. In multi-branch workflows, either accept residual stale-cache risk between branch switches or adopt a per-session `.tmp/` wipe.
+
+## Related Issues
+
+None — this is the first entry in `docs/solutions/` on monorepo dev-startup reliability and webpack persistent-cache hygiene.


### PR DESCRIPTION
The environment wasn't priming correctly on new installs, and webpack cache errors were causing concerns, making debugging more difficult.