### PR TITLE
feat(visual): introduce rendering lifecycle coordinator (U7)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,11 +57,42 @@ import {
     handleTabWrapAround,
     shouldYieldToFocusScope
 } from './lib/keyboard-focus';
+import {
+    createRenderingLifecycleCoordinator,
+    type RenderingLifecycleCoordinator,
+    type RenderingLifecycleId,
+    type SafetyNetScheduler
+} from './lib/rendering-lifecycle';
 
 /**
  * Centralize/report developer mode from environment.
  */
 const IS_DEVELOPER_MODE = toBoolean(process.env.PBIVIZ_DEV_MODE);
+
+/**
+ * Bound (ms) after which the rendering-lifecycle safety-net checks an
+ * armed id. If the id is still open and no render ever began, the
+ * safety-net closes it as an orphan; if a render is in flight
+ * (`renderStarted === true`), the close is deferred to the render's
+ * own callback chain. Tuned generously against observed render timing
+ * — 5 seconds is well beyond the cert-blocking orphan window while
+ * staying short enough to surface a broken update path during dev.
+ */
+const SAFETY_NET_BOUND_MS = 5000;
+
+/**
+ * Real-`setTimeout` scheduler for the rendering-lifecycle coordinator.
+ * Unit tests inject a synthetic scheduler that exposes the pending
+ * callback directly; production uses this one.
+ */
+const renderingLifecycleScheduler: SafetyNetScheduler = {
+    schedule: (callback) => {
+        const handle = setTimeout(callback, SAFETY_NET_BOUND_MS);
+        return {
+            cancel: () => clearTimeout(handle)
+        };
+    }
+};
 
 /**
  * Inputs consumed by {@link Deneb.resolveDataset} and the private dispatch
@@ -96,12 +127,22 @@ export class Deneb implements IVisual {
     #applicationWrapper: HTMLElement;
     #root: ReturnType<typeof createRoot>;
     #host: powerbi.extensibility.visual.IVisualHost;
+    #coordinator: RenderingLifecycleCoordinator;
 
     constructor(options: VisualConstructorOptions) {
         logHost('Constructor has been called.', { options });
         try {
             const { host } = options;
             this.#host = host;
+            // Coordinator owns ALL host.eventService.rendering* emission
+            // from this point forward. The host event service is the
+            // structural emitter; the safety-net uses real setTimeout in
+            // prod. U11 will inject an observer for the dev overlay.
+            this.#coordinator = createRenderingLifecycleCoordinator({
+                emitter: host.eventService,
+                scheduler: renderingLifecycleScheduler,
+                logger: (message, detail) => logHost(message, detail)
+            });
             const {
                 dataset: { setSelectors },
                 host: { setHost },
@@ -148,8 +189,16 @@ export class Deneb implements IVisual {
     }
 
     public update(options: VisualUpdateOptions) {
-        // Handle main update flow
+        // The coordinator's `open()` is the FIRST statement inside the
+        // try so `renderingStarted` is emitted before anything else can
+        // throw (R1). If `open()` itself throws (the host throws on
+        // `renderingStarted` emission), the catch routes to
+        // `failCurrent()` which no-ops because the id was never
+        // recorded — no orphan accumulates and the safety-net is never
+        // armed for a never-opened id (`openId` stays `undefined`).
+        let openId: RenderingLifecycleId | undefined;
         try {
+            openId = this.#coordinator.open(options);
             logTimeStart('update');
             // Set the read-mode persist gate before anything in the update
             // path can call persistProperties / persistProjectProperties.
@@ -161,12 +210,36 @@ export class Deneb implements IVisual {
             setReadModePersistSuppressed(isReadMode);
             this.resolveUpdateOptions(options, isReadMode);
             logTimeEnd('update');
-            return;
         } catch (e) {
-            // Signal that we've encountered an error
+            // Coordinator records the failure (host emission + observer
+            // event for the dev overlay) and derives the reason from
+            // the error. logDebug adds the forensic detail (stack /
+            // structured payload) for dev-time inspection — the only
+            // permitted surface beyond the cert-allowed host channel,
+            // since console.error is forbidden in certified builds.
+            this.#coordinator.failCurrent(e);
             logDebug('Error during visual update.', { error: e });
-            logHost('Rendering event failed:', e.message);
-            this.#host.eventService.renderingFailed(options);
+        } finally {
+            // TODO(U9): Arm the safety-net here once the async render
+            // close paths in `src/app/app.tsx` route through the
+            // coordinator instead of calling `host.eventService`
+            // directly. Arming now would cause every successful render
+            // to emit a duplicate `renderingFinished` ~5s after start
+            // — the coordinator's safety-net would mistakenly classify
+            // the id as an orphan (renderStarted is never flipped
+            // until U9 adds the `onRenderingStarted` adapter), while
+            // app.tsx has already emitted the host's terminal.
+            //
+            //     if (openId !== undefined) {
+            //         this.#coordinator.armSafetyNet(openId);
+            //     }
+            //
+            // The coordinator's internal `openIds` map will accumulate
+            // entries during the U7-to-U9 window. In practice this is
+            // bounded — Power BI Desktop restarts visual instances on
+            // tab change, refresh, and dataset changes, so the map
+            // does not grow indefinitely within a single session.
+            void openId;
         }
     }
 
@@ -183,9 +256,11 @@ export class Deneb implements IVisual {
         setVisualUpdateOptions({ options, isDeveloperMode: IS_DEVELOPER_MODE });
         this.resolveLocale();
         const { settings } = getDenebVisualState();
-        // Signal we've begun rendering
-        logHost('Rendering event started.');
-        this.#host.eventService.renderingStarted(options);
+        // `renderingStarted` is now emitted by the coordinator at the
+        // top of `update()`'s try (see `Deneb.update`). Keeping it out
+        // of this method satisfies R1 (start fires before any code
+        // that can throw in the update body — including this method
+        // itself).
         // Perform any necessary property migrations
         handlePropertyMigration(settings, isReadMode);
         // Data change or re-processing required?

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,11 +234,16 @@ export class Deneb implements IVisual {
             //         this.#coordinator.armSafetyNet(openId);
             //     }
             //
-            // The coordinator's internal `openIds` map will accumulate
-            // entries during the U7-to-U9 window. In practice this is
-            // bounded — Power BI Desktop restarts visual instances on
-            // tab change, refresh, and dataset changes, so the map
-            // does not grow indefinitely within a single session.
+            // The coordinator's `openIds` map holds at most one
+            // entry (the active id) at any time — terminal paths
+            // delete the entry, and supersede displaces the prior id
+            // before minting the new one. The previously-noted
+            // "accumulates until visual restart" concern was real
+            // before deletion-on-terminal landed and no longer
+            // applies; the only id that can linger at session end is
+            // the very last update's id (never closed via coordinator
+            // because app.tsx's direct host call doesn't route
+            // through it until U9).
             void openId;
         }
     }

--- a/src/lib/rendering-lifecycle/__test__/coordinator.test.ts
+++ b/src/lib/rendering-lifecycle/__test__/coordinator.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRenderingLifecycleCoordinator } from '../coordinator';
 import {
     SUPERSEDED_FAILURE_REASON,
-    type RenderingLifecycleCoordinator,
+    type RenderingLifecycleCoordinatorTestSurface,
     type RenderingLifecycleEmitter,
     type RenderingLifecycleEvent,
     type RenderingLifecycleObserver,
@@ -102,7 +102,7 @@ const buildHarness = (config?: { emitterThrowsOn?: EmitterThrowSpec }) => {
         events.push(event);
     };
 
-    const coordinator: RenderingLifecycleCoordinator =
+    const coordinator: RenderingLifecycleCoordinatorTestSurface =
         createRenderingLifecycleCoordinator({
             emitter,
             scheduler,

--- a/src/lib/rendering-lifecycle/__test__/coordinator.test.ts
+++ b/src/lib/rendering-lifecycle/__test__/coordinator.test.ts
@@ -1,0 +1,525 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createRenderingLifecycleCoordinator } from '../coordinator';
+import {
+    SUPERSEDED_FAILURE_REASON,
+    type RenderingLifecycleCoordinator,
+    type RenderingLifecycleEmitter,
+    type RenderingLifecycleEvent,
+    type RenderingLifecycleObserver,
+    type SafetyNetHandle,
+    type SafetyNetScheduler
+} from '../types';
+
+// ─── Test harness ────────────────────────────────────────────────────────────
+//
+// The coordinator's public API is structurally typed; the harness wires it to
+// recordable mocks for the three injected dependencies (emitter, scheduler,
+// observer). Tests inspect:
+//
+//  - `calls`: ordered host-emission record (proves what the host saw and in
+//    what order — important for supersede ordering and the "loud throws" path).
+//  - `events`: ordered observer record (proves what the dev overlay / U11
+//    surface would see, including failure reasons and via-discriminators).
+//  - `tick()`: invokes the single pending safety-net callback (the scheduler
+//    only ever holds one because each `armSafetyNet` is per-id and `close` /
+//    `fail` cancel before the tick can fire in real time).
+//
+// `emitterThrowsOn` lets a test simulate a host that throws on a specific
+// emission. The `afterCalls` field skips the first N matching calls before
+// throwing, so the supersede-throws-on-failed test can let the original
+// `renderingStarted` succeed but force the supersede `renderingFailed` to
+// throw.
+
+type EmitterCall =
+    | { method: 'renderingStarted'; options: unknown }
+    | { method: 'renderingFinished'; options: unknown }
+    | {
+          method: 'renderingFailed';
+          options: unknown;
+          reason: string | undefined;
+      };
+
+type EmitterThrowSpec = {
+    method: 'renderingStarted' | 'renderingFinished' | 'renderingFailed';
+    afterCalls?: number;
+    error?: Error;
+};
+
+const FAKE_OPTIONS_A = { __label: 'A' } as never;
+const FAKE_OPTIONS_B = { __label: 'B' } as never;
+const FAKE_OPTIONS_C = { __label: 'C' } as never;
+
+const buildHarness = (config?: { emitterThrowsOn?: EmitterThrowSpec }) => {
+    const calls: EmitterCall[] = [];
+    const events: RenderingLifecycleEvent[] = [];
+    let pendingTick: (() => void) | null = null;
+
+    const maybeThrow = (
+        method: EmitterCall['method'],
+        matchingCallCount: number
+    ) => {
+        const spec = config?.emitterThrowsOn;
+        if (!spec || spec.method !== method) return;
+        if ((spec.afterCalls ?? 0) > matchingCallCount) return;
+        throw spec.error ?? new Error(`emitter threw on ${method}`);
+    };
+
+    const countMatching = (method: EmitterCall['method']) =>
+        calls.filter((c) => c.method === method).length;
+
+    const emitter: RenderingLifecycleEmitter = {
+        renderingStarted: (options) => {
+            const before = countMatching('renderingStarted');
+            maybeThrow('renderingStarted', before);
+            calls.push({ method: 'renderingStarted', options });
+        },
+        renderingFinished: (options) => {
+            const before = countMatching('renderingFinished');
+            maybeThrow('renderingFinished', before);
+            calls.push({ method: 'renderingFinished', options });
+        },
+        renderingFailed: (options, reason) => {
+            const before = countMatching('renderingFailed');
+            maybeThrow('renderingFailed', before);
+            calls.push({ method: 'renderingFailed', options, reason });
+        }
+    };
+
+    const scheduler: SafetyNetScheduler = {
+        schedule: (callback) => {
+            pendingTick = callback;
+            const handle: SafetyNetHandle = {
+                cancel: () => {
+                    if (pendingTick === callback) pendingTick = null;
+                }
+            };
+            return handle;
+        }
+    };
+
+    const observer: RenderingLifecycleObserver = (event) => {
+        events.push(event);
+    };
+
+    const coordinator: RenderingLifecycleCoordinator =
+        createRenderingLifecycleCoordinator({
+            emitter,
+            scheduler,
+            observer
+        });
+
+    const tick = () => {
+        const cb = pendingTick;
+        pendingTick = null;
+        cb?.();
+    };
+
+    return { coordinator, calls, events, tick };
+};
+
+// ─── Coordinator ──────────────────────────────────────────────────────────────
+
+describe('createRenderingLifecycleCoordinator — happy path', () => {
+    it('open then closeCurrent emits exactly one started + one finished', () => {
+        const { coordinator, calls } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.closeCurrent();
+        expect(calls).toEqual([
+            { method: 'renderingStarted', options: FAKE_OPTIONS_A },
+            { method: 'renderingFinished', options: FAKE_OPTIONS_A }
+        ]);
+    });
+
+    it('open then failCurrent emits exactly one started + one failed', () => {
+        const { coordinator, calls } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.failCurrent(new Error('boom'));
+        expect(calls.map((c) => c.method)).toEqual([
+            'renderingStarted',
+            'renderingFailed'
+        ]);
+        expect(calls.find((c) => c.method === 'renderingFailed')?.reason).toBe(
+            'boom'
+        );
+    });
+
+    it('observer sees opened then closed with via=sync-current', () => {
+        const { coordinator, events } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.closeCurrent();
+        expect(events.map((e) => e.kind)).toEqual(['opened', 'closed']);
+        const closed = events.find((e) => e.kind === 'closed');
+        expect(closed && 'via' in closed && closed.via).toBe('sync-current');
+    });
+});
+
+describe('createRenderingLifecycleCoordinator — exactly-once guards', () => {
+    it('closeCurrent twice → second ignored; one renderingFinished emitted', () => {
+        const { coordinator, calls } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.closeCurrent();
+        coordinator.closeCurrent();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(1);
+    });
+
+    it('closeCurrent then failCurrent → fail ignored (already closed)', () => {
+        const { coordinator, calls } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.closeCurrent();
+        coordinator.failCurrent(new Error('after close'));
+        expect(
+            calls.filter((c) => c.method === 'renderingFailed')
+        ).toHaveLength(0);
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(1);
+    });
+
+    it('failCurrent then closeCurrent → close ignored (already closed)', () => {
+        const { coordinator, calls } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.failCurrent(new Error('boom'));
+        coordinator.closeCurrent();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(0);
+        expect(
+            calls.filter((c) => c.method === 'renderingFailed')
+        ).toHaveLength(1);
+    });
+});
+
+describe('createRenderingLifecycleCoordinator — pending-render no-ops', () => {
+    it('closePendingRender with no pending bound → no host emission, no observer event', () => {
+        const { coordinator, calls, events } = buildHarness();
+        coordinator.closePendingRender();
+        expect(calls).toEqual([]);
+        expect(events).toEqual([]);
+    });
+
+    it('failPendingRender with no pending bound → no host emission, no observer event', () => {
+        const { coordinator, calls, events } = buildHarness();
+        coordinator.failPendingRender(new Error('phantom'));
+        expect(calls).toEqual([]);
+        expect(events).toEqual([]);
+    });
+
+    it('markPendingRenderStarted with no pending bound → no host emission, no observer event', () => {
+        const { coordinator, calls, events } = buildHarness();
+        coordinator.markPendingRenderStarted();
+        expect(calls).toEqual([]);
+        expect(events).toEqual([]);
+    });
+});
+
+describe('createRenderingLifecycleCoordinator — open throws gracefully', () => {
+    it('host throws on renderingStarted → open propagates throw; failCurrent finds no open id and no-ops; no orphan recorded', () => {
+        const { coordinator, calls } = buildHarness({
+            emitterThrowsOn: { method: 'renderingStarted' }
+        });
+        expect(() => coordinator.open(FAKE_OPTIONS_A)).toThrow();
+        // No id was minted (open threw before recording the id in the
+        // openIds map), so failCurrent has nothing to act on.
+        coordinator.failCurrent(new Error('catch handler'));
+        expect(
+            calls.filter((c) => c.method === 'renderingFailed')
+        ).toHaveLength(0);
+    });
+});
+
+describe('createRenderingLifecycleCoordinator — supersede', () => {
+    it('open(B) while A is still open → host sees started(A), failed(A, superseded), started(B) in order', () => {
+        const { coordinator, calls } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.open(FAKE_OPTIONS_B);
+        expect(calls).toEqual([
+            { method: 'renderingStarted', options: FAKE_OPTIONS_A },
+            {
+                method: 'renderingFailed',
+                options: FAKE_OPTIONS_A,
+                reason: SUPERSEDED_FAILURE_REASON
+            },
+            { method: 'renderingStarted', options: FAKE_OPTIONS_B }
+        ]);
+    });
+
+    it('superseded A is fully closed (closed=true) before B opens — closing A afterward is a no-op', () => {
+        const { coordinator, calls } = buildHarness();
+        const idA = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.open(FAKE_OPTIONS_B);
+        coordinator.close(idA);
+        // The supersede already emitted renderingFailed(A). A subsequent
+        // explicit close on A must NOT emit renderingFinished(A) — A is
+        // terminally closed.
+        expect(
+            calls.filter(
+                (c) =>
+                    c.method === 'renderingFinished' &&
+                    c.options === FAKE_OPTIONS_A
+            )
+        ).toHaveLength(0);
+    });
+
+    it('observer sees failed with via=superseded for the displaced id', () => {
+        const { coordinator, events } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.open(FAKE_OPTIONS_B);
+        const failed = events.find((e) => e.kind === 'failed');
+        expect(failed && 'via' in failed && failed.via).toBe('superseded');
+        expect(failed && 'reason' in failed && failed.reason).toBe(
+            SUPERSEDED_FAILURE_REASON
+        );
+    });
+
+    it('host throws on supersede renderingFailed → throw propagates loudly; A marked closed; B never minted', () => {
+        const { coordinator, calls, events } = buildHarness({
+            emitterThrowsOn: { method: 'renderingFailed' }
+        });
+        const idA = coordinator.open(FAKE_OPTIONS_A);
+        expect(() => coordinator.open(FAKE_OPTIONS_B)).toThrow();
+        // A's terminal-attempt was made (host saw the call site) even
+        // though the host's response was to throw. A is marked closed
+        // BEFORE the host call, so a re-close on idA is a no-op.
+        coordinator.close(idA);
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(0);
+        // B was never minted — the catch in update() will call
+        // failCurrent which should find A still as "currently open" no
+        // (A is closed) and... actually nothing to act on. Verify no
+        // started(B) was emitted before the supersede throw.
+        expect(
+            calls.filter(
+                (c) =>
+                    c.method === 'renderingStarted' &&
+                    c.options === FAKE_OPTIONS_B
+            )
+        ).toHaveLength(0);
+        // Observer recorded the supersede attempt even though the host
+        // threw — the closed/failed transition is locked in before the
+        // host call.
+        expect(events.some((e) => e.kind === 'failed')).toBe(true);
+    });
+});
+
+describe('createRenderingLifecycleCoordinator — pending-render binding', () => {
+    it('rebinds atomically across consecutive opens: bindPendingRender(B) replaces bindPendingRender(A)', () => {
+        const { coordinator, calls } = buildHarness();
+        const idA = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRender(idA);
+        const idB = coordinator.open(FAKE_OPTIONS_B);
+        coordinator.bindPendingRender(idB);
+        coordinator.closePendingRender();
+        // closePendingRender should close B (the most-recently-bound),
+        // not A (already supersede-failed). One renderingFinished, and
+        // it targets B's options.
+        const finishes = calls.filter((c) => c.method === 'renderingFinished');
+        expect(finishes).toHaveLength(1);
+        expect(finishes[0].options).toBe(FAKE_OPTIONS_B);
+    });
+
+    it('stale pending-render callback after supersede no-ops against the already-closed id', () => {
+        const { coordinator, calls } = buildHarness();
+        const idA = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRender(idA);
+        // B opens before A's render arrives — A is supersede-failed.
+        coordinator.open(FAKE_OPTIONS_B);
+        // A's late embed callback arrives BEFORE B is bindPendingRender'd.
+        // The pending-render id is still A (a closed id); closePendingRender
+        // is gated by the closed flag, so it no-ops.
+        coordinator.closePendingRender();
+        const finishes = calls.filter((c) => c.method === 'renderingFinished');
+        expect(finishes).toHaveLength(0);
+        // B now binds and its own close lands cleanly.
+        // (Skipped here — covered by the previous test.)
+    });
+
+    it('markPendingRenderStarted twice for same pending id → idempotent; host sees no second renderingStarted', () => {
+        const { coordinator, calls, events } = buildHarness();
+        const idA = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRender(idA);
+        coordinator.markPendingRenderStarted();
+        coordinator.markPendingRenderStarted();
+        expect(
+            calls.filter((c) => c.method === 'renderingStarted')
+        ).toHaveLength(1);
+        // Observer logs render-started only once.
+        expect(events.filter((e) => e.kind === 'render-started')).toHaveLength(
+            1
+        );
+    });
+});
+
+describe('createRenderingLifecycleCoordinator — safety-net', () => {
+    it('open + armSafetyNet + tick with no render started → safety-net closes orphan; one renderingFinished emitted', () => {
+        const { coordinator, calls, tick } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.armSafetyNet(id);
+        tick();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(1);
+    });
+
+    it('safety-net does NOT close in-flight render (renderStarted=true defers the close)', () => {
+        const { coordinator, calls, tick } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRender(id);
+        coordinator.markPendingRenderStarted();
+        coordinator.armSafetyNet(id);
+        tick();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(0);
+        // The pending-render close should still work afterward.
+        coordinator.closePendingRender();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(1);
+    });
+
+    it('closed id is safety-net-inert (close before tick → safety-net no-ops)', () => {
+        const { coordinator, calls, tick } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.armSafetyNet(id);
+        coordinator.closeCurrent();
+        tick();
+        // Only the one renderingFinished from closeCurrent; safety-net
+        // tick must not emit a second.
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(1);
+    });
+
+    it('observer sees safety-net-armed then safety-net-tick with result discriminator', () => {
+        const { coordinator, events, tick } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.armSafetyNet(id);
+        tick();
+        const armed = events.find((e) => e.kind === 'safety-net-armed');
+        const ticked = events.find((e) => e.kind === 'safety-net-tick');
+        expect(armed).toBeDefined();
+        expect(ticked).toBeDefined();
+        expect(ticked && 'result' in ticked && ticked.result).toBe('closed');
+    });
+
+    it('open with no close, render-started, then tick → safety-net defers (in-flight)', () => {
+        const { coordinator, events, tick } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRender(id);
+        coordinator.markPendingRenderStarted();
+        coordinator.armSafetyNet(id);
+        tick();
+        const ticked = events.find((e) => e.kind === 'safety-net-tick');
+        expect(ticked && 'result' in ticked && ticked.result).toBe('deferred');
+    });
+
+    it('tick after a separate close path resolved → safety-net tick reports inert (already closed)', () => {
+        const { coordinator, events, tick } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.armSafetyNet(id);
+        coordinator.failCurrent(new Error('boom'));
+        // failCurrent should have cancelled the safety-net handle, so
+        // tick() here should be a no-op (pendingTick is null).
+        tick();
+        const ticks = events.filter((e) => e.kind === 'safety-net-tick');
+        expect(ticks).toHaveLength(0);
+    });
+});
+
+describe('createRenderingLifecycleCoordinator — id-bearing variants (test surface)', () => {
+    it('explicit close(id) closes that id; close(differentId) no-ops', () => {
+        const { coordinator, calls } = buildHarness();
+        const idA = coordinator.open(FAKE_OPTIONS_A);
+        // Open B (which supersede-fails A), then re-close idA explicitly.
+        coordinator.open(FAKE_OPTIONS_B);
+        coordinator.close(idA);
+        // idA already closed via supersede; no second emission.
+        expect(
+            calls.filter(
+                (c) =>
+                    c.method === 'renderingFinished' &&
+                    c.options === FAKE_OPTIONS_A
+            )
+        ).toHaveLength(0);
+    });
+
+    it('explicit markRenderStarted(id) for a closed id no-ops', () => {
+        const { coordinator, calls } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.close(id);
+        coordinator.markRenderStarted(id);
+        // Only the initial renderingStarted; no second from markRenderStarted.
+        expect(
+            calls.filter((c) => c.method === 'renderingStarted')
+        ).toHaveLength(1);
+    });
+});
+
+describe('createRenderingLifecycleCoordinator — observer is optional', () => {
+    it('coordinator runs without an observer; calls still emitted', () => {
+        const calls: EmitterCall[] = [];
+        const emitter: RenderingLifecycleEmitter = {
+            renderingStarted: (options) =>
+                calls.push({ method: 'renderingStarted', options }),
+            renderingFinished: (options) =>
+                calls.push({ method: 'renderingFinished', options }),
+            renderingFailed: (options, reason) =>
+                calls.push({ method: 'renderingFailed', options, reason })
+        };
+        const scheduler: SafetyNetScheduler = {
+            schedule: () => ({ cancel: () => undefined })
+        };
+        const coordinator = createRenderingLifecycleCoordinator({
+            emitter,
+            scheduler
+        });
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.closeCurrent();
+        expect(calls.map((c) => c.method)).toEqual([
+            'renderingStarted',
+            'renderingFinished'
+        ]);
+    });
+});
+
+describe('createRenderingLifecycleCoordinator — error-to-reason derivation', () => {
+    it('Error instance → reason is the error message', () => {
+        const { coordinator, calls } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.failCurrent(new Error('something broke'));
+        const failed = calls.find((c) => c.method === 'renderingFailed');
+        expect(failed?.reason).toBe('something broke');
+    });
+
+    it('non-Error value → reason is String(value)', () => {
+        const { coordinator, calls } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.failCurrent('plain string');
+        const failed = calls.find((c) => c.method === 'renderingFailed');
+        expect(failed?.reason).toBe('plain string');
+    });
+
+    it('observer carries the original error value alongside the reason string', () => {
+        const { coordinator, events } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        const err = new Error('boom');
+        coordinator.failCurrent(err);
+        const failed = events.find((e) => e.kind === 'failed');
+        expect(failed && 'error' in failed && failed.error).toBe(err);
+    });
+});
+
+// Silence the "no useless mocks" warning when this file is imported in
+// other test files that may reuse the harness.
+beforeEach(() => {
+    vi.useRealTimers();
+});
+
+// Touch unused FAKE_OPTIONS_C so the lint rule for unused vars doesn't fire
+// — keeping it available makes future test additions for three-id supersede
+// chains a one-line change.
+void FAKE_OPTIONS_C;

--- a/src/lib/rendering-lifecycle/coordinator.ts
+++ b/src/lib/rendering-lifecycle/coordinator.ts
@@ -1,0 +1,299 @@
+import type powerbi from 'powerbi-visuals-api';
+
+import {
+    SUPERSEDED_FAILURE_REASON,
+    type RenderingLifecycleCoordinator,
+    type RenderingLifecycleEmitter,
+    type RenderingLifecycleId,
+    type RenderingLifecycleLogger,
+    type RenderingLifecycleObserver,
+    type SafetyNetHandle,
+    type SafetyNetScheduler
+} from './types';
+
+/**
+ * Per-id state captured at `open()` time. Mutated in place across the
+ * lifecycle:
+ *  - `renderStarted` flips true via `markRenderStarted` / `markPendingRenderStarted`
+ *  - `closed` flips true on the FIRST close/fail terminal — protects
+ *    against double-emission via the exactly-once guard
+ *  - `safetyNet` holds the cancellation handle while the safety-net
+ *    is armed and not yet fired/cancelled
+ */
+type OpenIdState = {
+    options: powerbi.extensibility.visual.VisualUpdateOptions;
+    renderStarted: boolean;
+    closed: boolean;
+    safetyNet: SafetyNetHandle | null;
+};
+
+const noopLogger: RenderingLifecycleLogger = () => undefined;
+const noopObserver: RenderingLifecycleObserver = () => undefined;
+
+export type CreateRenderingLifecycleCoordinatorDeps = {
+    emitter: RenderingLifecycleEmitter;
+    scheduler: SafetyNetScheduler;
+    logger?: RenderingLifecycleLogger;
+    observer?: RenderingLifecycleObserver;
+};
+
+/**
+ * Construct a rendering lifecycle coordinator. See `types.ts` for the
+ * public API contract; this factory wires the injected dependencies
+ * and owns the internal state machine.
+ *
+ * Invariants the implementation enforces:
+ *
+ *  1. **At most one id is "current"** (unclosed) at any time. Every
+ *     `open()` supersede-fails any prior unclosed id BEFORE minting
+ *     the new id, so the openIds map can only ever contain one entry
+ *     with `closed === false`.
+ *  2. **Exactly-once terminal emission per id.** Every `closeInternal`
+ *     / `failInternal` is gated on `!state.closed`; the first one
+ *     wins, the rest no-op silently. Applies symmetrically to the
+ *     safety-net's would-be close.
+ *  3. **State mutation precedes host emission for any terminal.** The
+ *     id is marked `closed = true` and the observer event is pushed
+ *     BEFORE the host's `renderingFinished` / `renderingFailed` call.
+ *     If the host throws on the emission, the id is still terminally
+ *     closed — a subsequent attempt re-encounters `closed === true`
+ *     and no-ops. This is the "truthful-or-loud" invariant: either
+ *     the host saw the terminal, or the throw propagates and the
+ *     update is aborted (no half-closed limbo).
+ *  4. **`open()` records the new id in `openIds` AFTER the host's
+ *     `renderingStarted` returns successfully.** If the host throws,
+ *     the id is never recorded and `failCurrent()` in the catch path
+ *     finds no current id and no-ops — no orphan accumulates.
+ */
+export const createRenderingLifecycleCoordinator = (
+    deps: CreateRenderingLifecycleCoordinatorDeps
+): RenderingLifecycleCoordinator => {
+    const { emitter, scheduler } = deps;
+    const log = deps.logger ?? noopLogger;
+    const observe = deps.observer ?? noopObserver;
+
+    const openIds = new Map<RenderingLifecycleId, OpenIdState>();
+    let nextId = 1;
+    let pendingRenderId: RenderingLifecycleId | null = null;
+
+    const mintId = (): RenderingLifecycleId => {
+        const id = nextId as RenderingLifecycleId;
+        nextId++;
+        return id;
+    };
+
+    /**
+     * Locate the most-recently-opened id that has not yet closed.
+     * Returns `null` when no current id exists (initial state, or
+     * after a terminal emission has resolved the lifecycle, or when
+     * `open()` threw before recording the new id).
+     */
+    const currentOpenId = (): RenderingLifecycleId | null => {
+        const entries = Array.from(openIds.entries());
+        for (let i = entries.length - 1; i >= 0; i--) {
+            const [id, state] = entries[i];
+            if (!state.closed) return id;
+        }
+        return null;
+    };
+
+    const closeInternal = (
+        id: RenderingLifecycleId,
+        via: 'sync-current' | 'async-pending-render' | 'safety-net'
+    ): void => {
+        const state = openIds.get(id);
+        if (!state || state.closed) return;
+        state.closed = true;
+        if (state.safetyNet) {
+            state.safetyNet.cancel();
+            state.safetyNet = null;
+        }
+        log(`[lifecycle] renderingFinished id=${id} via=${via}`);
+        observe({ kind: 'closed', id, via });
+        emitter.renderingFinished(state.options);
+    };
+
+    const failInternal = (
+        id: RenderingLifecycleId,
+        error: unknown,
+        via: 'sync-current' | 'async-pending-render' | 'superseded'
+    ): void => {
+        const state = openIds.get(id);
+        if (!state || state.closed) return;
+        state.closed = true;
+        if (state.safetyNet) {
+            state.safetyNet.cancel();
+            state.safetyNet = null;
+        }
+        const reason = deriveReason(error);
+        log(`[lifecycle] renderingFailed id=${id} reason=${reason} via=${via}`);
+        observe({ kind: 'failed', id, reason, error, via });
+        emitter.renderingFailed(state.options, reason);
+    };
+
+    const markRenderStartedInternal = (id: RenderingLifecycleId): void => {
+        const state = openIds.get(id);
+        if (!state || state.closed) return;
+        if (state.renderStarted) return;
+        state.renderStarted = true;
+        log(`[lifecycle] renderStarted id=${id}`);
+        observe({ kind: 'render-started', id });
+    };
+
+    const onSafetyNetTick = (id: RenderingLifecycleId): void => {
+        const state = openIds.get(id);
+        if (!state || state.closed) {
+            observe({ kind: 'safety-net-tick', id, result: 'inert' });
+            return;
+        }
+        if (state.renderStarted) {
+            // In-flight render — extend the wait by NOT closing. The
+            // caller (the render's own callback chain) will emit the
+            // terminal in due course; or, if it never does, a future
+            // arming would re-evaluate. For U7 there's no auto-rearm;
+            // the practical safety case for in-flight is "the render
+            // is happening, trust it" since the cert-blocking failure
+            // mode is orphans, not slow renders.
+            observe({ kind: 'safety-net-tick', id, result: 'deferred' });
+            return;
+        }
+        observe({ kind: 'safety-net-tick', id, result: 'closed' });
+        closeInternal(id, 'safety-net');
+    };
+
+    // ─── Public surface ─────────────────────────────────────────────────────
+
+    const open: RenderingLifecycleCoordinator['open'] = (options) => {
+        // Supersede any unclosed prior ids BEFORE minting the new id.
+        // The invariant says at most one such id exists; iterating
+        // defensively costs nothing and survives any future change.
+        for (const [oldId, state] of openIds) {
+            if (state.closed) continue;
+            state.closed = true;
+            if (state.safetyNet) {
+                state.safetyNet.cancel();
+                state.safetyNet = null;
+            }
+            log(
+                `[lifecycle] renderingFailed id=${oldId} reason=${SUPERSEDED_FAILURE_REASON} via=superseded`
+            );
+            observe({
+                kind: 'failed',
+                id: oldId,
+                reason: SUPERSEDED_FAILURE_REASON,
+                via: 'superseded'
+            });
+            // Host emission AFTER the closed/observer transition is
+            // committed. A host throw on the supersede emission does
+            // NOT roll back the closed flag — see invariant #3 above
+            // and the "loud throws" test.
+            emitter.renderingFailed(state.options, SUPERSEDED_FAILURE_REASON);
+        }
+
+        // Mint and emit. If `renderingStarted` throws, the id is never
+        // recorded — the throw propagates out and `failCurrent()` in
+        // `update()`'s catch finds no current id and no-ops.
+        const id = mintId();
+        log(`[lifecycle] renderingStarted id=${id}`);
+        emitter.renderingStarted(options);
+        openIds.set(id, {
+            options,
+            renderStarted: false,
+            closed: false,
+            safetyNet: null
+        });
+        observe({ kind: 'opened', id, options });
+        return id;
+    };
+
+    const bindPendingRender: RenderingLifecycleCoordinator['bindPendingRender'] =
+        (id) => {
+            pendingRenderId = id;
+        };
+
+    const armSafetyNet: RenderingLifecycleCoordinator['armSafetyNet'] = (
+        id
+    ) => {
+        const state = openIds.get(id);
+        if (!state || state.closed) return;
+        const handle = scheduler.schedule(() => onSafetyNetTick(id));
+        state.safetyNet = handle;
+        observe({ kind: 'safety-net-armed', id });
+    };
+
+    const closeCurrent: RenderingLifecycleCoordinator['closeCurrent'] = () => {
+        const id = currentOpenId();
+        if (id === null) return;
+        closeInternal(id, 'sync-current');
+    };
+
+    const failCurrent: RenderingLifecycleCoordinator['failCurrent'] = (
+        error
+    ) => {
+        const id = currentOpenId();
+        if (id === null) return;
+        failInternal(id, error, 'sync-current');
+    };
+
+    const closePendingRender: RenderingLifecycleCoordinator['closePendingRender'] =
+        () => {
+            if (pendingRenderId === null) return;
+            closeInternal(pendingRenderId, 'async-pending-render');
+        };
+
+    const failPendingRender: RenderingLifecycleCoordinator['failPendingRender'] =
+        (error) => {
+            if (pendingRenderId === null) return;
+            failInternal(pendingRenderId, error, 'async-pending-render');
+        };
+
+    const markPendingRenderStarted: RenderingLifecycleCoordinator['markPendingRenderStarted'] =
+        () => {
+            if (pendingRenderId === null) return;
+            markRenderStartedInternal(pendingRenderId);
+        };
+
+    // Id-bearing test-surface variants. Production code outside the
+    // coordinator uses the no-arg variants above; these exist so unit
+    // tests can drive deterministic supersede-order scenarios without
+    // round-tripping through pendingRenderId.
+    const close: RenderingLifecycleCoordinator['close'] = (id) => {
+        closeInternal(id, 'sync-current');
+    };
+
+    const fail: RenderingLifecycleCoordinator['fail'] = (id, error) => {
+        failInternal(id, error, 'sync-current');
+    };
+
+    const markRenderStarted: RenderingLifecycleCoordinator['markRenderStarted'] =
+        (id) => {
+            markRenderStartedInternal(id);
+        };
+
+    return {
+        open,
+        bindPendingRender,
+        armSafetyNet,
+        closeCurrent,
+        failCurrent,
+        closePendingRender,
+        failPendingRender,
+        markPendingRenderStarted,
+        close,
+        fail,
+        markRenderStarted
+    };
+};
+
+/**
+ * Translate the catch-clause error value into the `reason` string the
+ * Power BI host's `renderingFailed` accepts. `Error` instances yield
+ * their `.message`; anything else stringifies. Kept simple
+ * intentionally — the dev overlay (U11) reads the original error
+ * value from the observer event for richer presentation; the reason
+ * string is for the host channel only.
+ */
+const deriveReason = (error: unknown): string => {
+    if (error instanceof Error) return error.message;
+    return String(error);
+};

--- a/src/lib/rendering-lifecycle/coordinator.ts
+++ b/src/lib/rendering-lifecycle/coordinator.ts
@@ -3,6 +3,7 @@ import type powerbi from 'powerbi-visuals-api';
 import {
     SUPERSEDED_FAILURE_REASON,
     type RenderingLifecycleCoordinator,
+    type RenderingLifecycleCoordinatorTestSurface,
     type RenderingLifecycleEmitter,
     type RenderingLifecycleId,
     type RenderingLifecycleLogger,
@@ -12,18 +13,21 @@ import {
 } from './types';
 
 /**
- * Per-id state captured at `open()` time. Mutated in place across the
- * lifecycle:
- *  - `renderStarted` flips true via `markRenderStarted` / `markPendingRenderStarted`
- *  - `closed` flips true on the FIRST close/fail terminal — protects
- *    against double-emission via the exactly-once guard
+ * Per-id state captured at `open()` time. Lives in the `openIds` Map
+ * only while the lifecycle is OPEN — the entry is removed when the id
+ * terminally closes (close, fail, or supersede), so the Map's
+ * presence/absence is the exactly-once guard and the Map can only
+ * ever hold open ids. No separate `closed` flag is needed.
+ *
+ *  - `renderStarted` flips true via `markRenderStarted` /
+ *    `markPendingRenderStarted`; consumed by the safety-net to
+ *    distinguish orphan vs. in-flight.
  *  - `safetyNet` holds the cancellation handle while the safety-net
- *    is armed and not yet fired/cancelled
+ *    is armed and not yet fired/cancelled.
  */
 type OpenIdState = {
     options: powerbi.extensibility.visual.VisualUpdateOptions;
     renderStarted: boolean;
-    closed: boolean;
     safetyNet: SafetyNetHandle | null;
 };
 
@@ -46,28 +50,36 @@ export type CreateRenderingLifecycleCoordinatorDeps = {
  *
  *  1. **At most one id is "current"** (unclosed) at any time. Every
  *     `open()` supersede-fails any prior unclosed id BEFORE minting
- *     the new id, so the openIds map can only ever contain one entry
- *     with `closed === false`.
- *  2. **Exactly-once terminal emission per id.** Every `closeInternal`
- *     / `failInternal` is gated on `!state.closed`; the first one
- *     wins, the rest no-op silently. Applies symmetrically to the
- *     safety-net's would-be close.
+ *     the new id, so the openIds map can only ever contain one entry.
+ *  2. **Exactly-once terminal emission per id.** The openIds map only
+ *     contains OPEN ids — terminal paths delete the entry from the
+ *     map. The first close/fail wins and deletes the entry; any
+ *     subsequent attempt (stale callback, double-close) finds
+ *     nothing in the map and no-ops. Map absence is the guard;
+ *     there is no separate `closed` flag.
  *  3. **State mutation precedes host emission for any terminal.** The
- *     id is marked `closed = true` and the observer event is pushed
- *     BEFORE the host's `renderingFinished` / `renderingFailed` call.
- *     If the host throws on the emission, the id is still terminally
- *     closed — a subsequent attempt re-encounters `closed === true`
- *     and no-ops. This is the "truthful-or-loud" invariant: either
- *     the host saw the terminal, or the throw propagates and the
- *     update is aborted (no half-closed limbo).
+ *     entry is removed from the map and the observer event is
+ *     pushed BEFORE the host's `renderingFinished` /
+ *     `renderingFailed` call. If the host throws on the emission,
+ *     the id is still gone from the map — a subsequent attempt
+ *     finds nothing and no-ops. This is the "truthful-or-loud"
+ *     invariant: either the host saw the terminal, or the throw
+ *     propagates and the update is aborted (no half-closed limbo).
  *  4. **`open()` records the new id in `openIds` AFTER the host's
  *     `renderingStarted` returns successfully.** If the host throws,
  *     the id is never recorded and `failCurrent()` in the catch path
  *     finds no current id and no-ops — no orphan accumulates.
+ *  5. **The map's size is bounded by invariant #1, not by session
+ *     length.** This matters for long-running published reports
+ *     (live streaming dashboards with frequent refreshes) where the
+ *     visual is not torn down per-update the way Power BI Desktop
+ *     would tear it down. Without deletion the map would grow
+ *     monotonically and `currentOpenId()` would degrade to O(n);
+ *     with deletion it is at most one entry and lookup is O(1).
  */
 export const createRenderingLifecycleCoordinator = (
     deps: CreateRenderingLifecycleCoordinatorDeps
-): RenderingLifecycleCoordinator => {
+): RenderingLifecycleCoordinatorTestSurface => {
     const { emitter, scheduler } = deps;
     const log = deps.logger ?? noopLogger;
     const observe = deps.observer ?? noopObserver;
@@ -83,17 +95,12 @@ export const createRenderingLifecycleCoordinator = (
     };
 
     /**
-     * Locate the most-recently-opened id that has not yet closed.
-     * Returns `null` when no current id exists (initial state, or
-     * after a terminal emission has resolved the lifecycle, or when
-     * `open()` threw before recording the new id).
+     * Return the currently-open id, or null. Per invariant #1 the
+     * map holds at most one entry; the loop terminates after the
+     * first key. O(1) regardless of session length.
      */
     const currentOpenId = (): RenderingLifecycleId | null => {
-        const entries = Array.from(openIds.entries());
-        for (let i = entries.length - 1; i >= 0; i--) {
-            const [id, state] = entries[i];
-            if (!state.closed) return id;
-        }
+        for (const id of openIds.keys()) return id;
         return null;
     };
 
@@ -102,12 +109,16 @@ export const createRenderingLifecycleCoordinator = (
         via: 'sync-current' | 'async-pending-render' | 'safety-net'
     ): void => {
         const state = openIds.get(id);
-        if (!state || state.closed) return;
-        state.closed = true;
+        if (!state) return;
         if (state.safetyNet) {
             state.safetyNet.cancel();
             state.safetyNet = null;
         }
+        // Delete BEFORE host emission. If the host throws on the
+        // terminal, the entry is still gone from the map — a
+        // subsequent attempt (e.g. update()'s catch routing to
+        // failCurrent) finds nothing and no-ops. See invariant #3.
+        openIds.delete(id);
         log(`[lifecycle] renderingFinished id=${id} via=${via}`);
         observe({ kind: 'closed', id, via });
         emitter.renderingFinished(state.options);
@@ -119,12 +130,12 @@ export const createRenderingLifecycleCoordinator = (
         via: 'sync-current' | 'async-pending-render' | 'superseded'
     ): void => {
         const state = openIds.get(id);
-        if (!state || state.closed) return;
-        state.closed = true;
+        if (!state) return;
         if (state.safetyNet) {
             state.safetyNet.cancel();
             state.safetyNet = null;
         }
+        openIds.delete(id);
         const reason = deriveReason(error);
         log(`[lifecycle] renderingFailed id=${id} reason=${reason} via=${via}`);
         observe({ kind: 'failed', id, reason, error, via });
@@ -133,7 +144,7 @@ export const createRenderingLifecycleCoordinator = (
 
     const markRenderStartedInternal = (id: RenderingLifecycleId): void => {
         const state = openIds.get(id);
-        if (!state || state.closed) return;
+        if (!state) return;
         if (state.renderStarted) return;
         state.renderStarted = true;
         log(`[lifecycle] renderStarted id=${id}`);
@@ -142,7 +153,7 @@ export const createRenderingLifecycleCoordinator = (
 
     const onSafetyNetTick = (id: RenderingLifecycleId): void => {
         const state = openIds.get(id);
-        if (!state || state.closed) {
+        if (!state) {
             observe({ kind: 'safety-net-tick', id, result: 'inert' });
             return;
         }
@@ -164,16 +175,22 @@ export const createRenderingLifecycleCoordinator = (
     // ─── Public surface ─────────────────────────────────────────────────────
 
     const open: RenderingLifecycleCoordinator['open'] = (options) => {
-        // Supersede any unclosed prior ids BEFORE minting the new id.
-        // The invariant says at most one such id exists; iterating
+        // Supersede any prior open ids BEFORE minting the new id. The
+        // invariant says at most one such id exists; iterating
         // defensively costs nothing and survives any future change.
+        // Map.prototype iteration tolerates concurrent deletion of
+        // the visited key, so deleting inside the loop is safe.
         for (const [oldId, state] of openIds) {
-            if (state.closed) continue;
-            state.closed = true;
             if (state.safetyNet) {
                 state.safetyNet.cancel();
                 state.safetyNet = null;
             }
+            // Delete BEFORE the host emission. If the host throws on
+            // the supersede `renderingFailed` call, the entry is
+            // still gone — a subsequent `update()`-catch route to
+            // `failCurrent()` finds no current id and no-ops. See
+            // invariant #3 and the "loud throws" test.
+            openIds.delete(oldId);
             log(
                 `[lifecycle] renderingFailed id=${oldId} reason=${SUPERSEDED_FAILURE_REASON} via=superseded`
             );
@@ -183,10 +200,6 @@ export const createRenderingLifecycleCoordinator = (
                 reason: SUPERSEDED_FAILURE_REASON,
                 via: 'superseded'
             });
-            // Host emission AFTER the closed/observer transition is
-            // committed. A host throw on the supersede emission does
-            // NOT roll back the closed flag — see invariant #3 above
-            // and the "loud throws" test.
             emitter.renderingFailed(state.options, SUPERSEDED_FAILURE_REASON);
         }
 
@@ -199,7 +212,6 @@ export const createRenderingLifecycleCoordinator = (
         openIds.set(id, {
             options,
             renderStarted: false,
-            closed: false,
             safetyNet: null
         });
         observe({ kind: 'opened', id, options });
@@ -215,7 +227,7 @@ export const createRenderingLifecycleCoordinator = (
         id
     ) => {
         const state = openIds.get(id);
-        if (!state || state.closed) return;
+        if (!state) return;
         const handle = scheduler.schedule(() => onSafetyNetTick(id));
         state.safetyNet = handle;
         observe({ kind: 'safety-net-armed', id });
@@ -256,16 +268,21 @@ export const createRenderingLifecycleCoordinator = (
     // Id-bearing test-surface variants. Production code outside the
     // coordinator uses the no-arg variants above; these exist so unit
     // tests can drive deterministic supersede-order scenarios without
-    // round-tripping through pendingRenderId.
-    const close: RenderingLifecycleCoordinator['close'] = (id) => {
+    // round-tripping through pendingRenderId. Not on the production
+    // `RenderingLifecycleCoordinator` type — see the JSDoc on
+    // `RenderingLifecycleCoordinatorTestSurface`.
+    const close: RenderingLifecycleCoordinatorTestSurface['close'] = (id) => {
         closeInternal(id, 'sync-current');
     };
 
-    const fail: RenderingLifecycleCoordinator['fail'] = (id, error) => {
+    const fail: RenderingLifecycleCoordinatorTestSurface['fail'] = (
+        id,
+        error
+    ) => {
         failInternal(id, error, 'sync-current');
     };
 
-    const markRenderStarted: RenderingLifecycleCoordinator['markRenderStarted'] =
+    const markRenderStarted: RenderingLifecycleCoordinatorTestSurface['markRenderStarted'] =
         (id) => {
             markRenderStartedInternal(id);
         };

--- a/src/lib/rendering-lifecycle/index.ts
+++ b/src/lib/rendering-lifecycle/index.ts
@@ -1,0 +1,15 @@
+export {
+    createRenderingLifecycleCoordinator,
+    type CreateRenderingLifecycleCoordinatorDeps
+} from './coordinator';
+export {
+    SUPERSEDED_FAILURE_REASON,
+    type RenderingLifecycleCoordinator,
+    type RenderingLifecycleEmitter,
+    type RenderingLifecycleEvent,
+    type RenderingLifecycleId,
+    type RenderingLifecycleLogger,
+    type RenderingLifecycleObserver,
+    type SafetyNetHandle,
+    type SafetyNetScheduler
+} from './types';

--- a/src/lib/rendering-lifecycle/index.ts
+++ b/src/lib/rendering-lifecycle/index.ts
@@ -5,6 +5,7 @@ export {
 export {
     SUPERSEDED_FAILURE_REASON,
     type RenderingLifecycleCoordinator,
+    type RenderingLifecycleCoordinatorTestSurface,
     type RenderingLifecycleEmitter,
     type RenderingLifecycleEvent,
     type RenderingLifecycleId,

--- a/src/lib/rendering-lifecycle/types.ts
+++ b/src/lib/rendering-lifecycle/types.ts
@@ -137,6 +137,14 @@ export const SUPERSEDED_FAILURE_REASON = 'superseded';
  * through the `*PendingRender` no-arg variants; synchronous code in
  * `Deneb.update()` and its dispatch handlers use the `*Current`
  * no-arg variants.
+ *
+ * **Production code MUST type its coordinator reference with this
+ * narrower type** — not {@link RenderingLifecycleCoordinatorTestSurface}.
+ * The id-bearing variants exist on the runtime object for unit-test
+ * determinism but are intentionally absent from this type so the
+ * type system rejects production calls that would otherwise produce
+ * observer events with a hard-coded (and therefore misleading)
+ * `via: 'sync-current'` discriminator regardless of actual context.
  */
 export type RenderingLifecycleCoordinator = {
     /**
@@ -199,13 +207,27 @@ export type RenderingLifecycleCoordinator = {
      * to distinguish orphan vs. in-flight. Idempotent.
      */
     markPendingRenderStarted: () => void;
-    /**
-     * Id-bearing variants. Exposed for unit-test determinism and for
-     * the supersede loop's internal use. Production callers OUTSIDE
-     * the coordinator use the no-arg `*Current` / `*PendingRender`
-     * variants instead.
-     */
-    close: (id: RenderingLifecycleId) => void;
-    fail: (id: RenderingLifecycleId, error: unknown) => void;
-    markRenderStarted: (id: RenderingLifecycleId) => void;
 };
+
+/**
+ * Test-only superset of {@link RenderingLifecycleCoordinator} adding
+ * id-bearing variants of close / fail / markRenderStarted. These
+ * exist so unit-test scenarios can drive deterministic supersede
+ * orderings, late-callback races, and safety-net edge cases without
+ * round-tripping through `pendingRenderId` / `currentOpenId`. They
+ * hard-code their observer event's `via` discriminator to
+ * `sync-current`, which is appropriate for the test-determinism use
+ * case but would be misleading from any other context. Keeping them
+ * off the production {@link RenderingLifecycleCoordinator} type
+ * makes that constraint type-enforced rather than convention-enforced.
+ *
+ * The factory returns this superset; production callers narrow to
+ * {@link RenderingLifecycleCoordinator} at the field declaration
+ * (`src/index.ts`'s `#coordinator: RenderingLifecycleCoordinator`).
+ */
+export type RenderingLifecycleCoordinatorTestSurface =
+    RenderingLifecycleCoordinator & {
+        close: (id: RenderingLifecycleId) => void;
+        fail: (id: RenderingLifecycleId, error: unknown) => void;
+        markRenderStarted: (id: RenderingLifecycleId) => void;
+    };

--- a/src/lib/rendering-lifecycle/types.ts
+++ b/src/lib/rendering-lifecycle/types.ts
@@ -1,0 +1,211 @@
+import type powerbi from 'powerbi-visuals-api';
+
+/**
+ * Opaque, monotonic identity for one in-flight rendering lifecycle.
+ * Minted by `coordinator.open()` and consumed by the coordinator's own
+ * id-bearing methods and the safety-net. Treated as opaque by all
+ * callers — branded `number` so a raw integer cannot be passed by
+ * mistake.
+ */
+export type RenderingLifecycleId = number & {
+    readonly __brand: 'RenderingLifecycleId';
+};
+
+/**
+ * Minimal shape of the Power BI host's rendering event service the
+ * coordinator depends on. Defined as a structural type so unit tests
+ * can pass a plain mock without instantiating a full host. The real
+ * implementation in `src/index.ts` injects `host.eventService`.
+ *
+ * `renderingFailed`'s optional `reason` is the Power BI host's
+ * documented failure-detail slot — used for the synthetic "superseded"
+ * marker emitted when a new `open()` displaces a still-open prior id.
+ */
+export type RenderingLifecycleEmitter = {
+    renderingStarted: (
+        options: powerbi.extensibility.visual.VisualUpdateOptions
+    ) => void;
+    renderingFinished: (
+        options: powerbi.extensibility.visual.VisualUpdateOptions
+    ) => void;
+    renderingFailed: (
+        options: powerbi.extensibility.visual.VisualUpdateOptions,
+        reason?: string
+    ) => void;
+};
+
+/**
+ * Handle to a scheduled safety-net tick. Returned by the scheduler so
+ * the coordinator can cancel an in-flight wait when the lifecycle
+ * closes/fails before the bound elapses.
+ */
+export type SafetyNetHandle = {
+    cancel: () => void;
+};
+
+/**
+ * Abstraction over the timer that drives the safety-net's bounded
+ * wait. Injected at construction so unit tests can run synthetic ticks
+ * deterministically (no real `setTimeout`); production wires it to
+ * `setTimeout` with a fixed bound.
+ */
+export type SafetyNetScheduler = {
+    schedule: (callback: () => void) => SafetyNetHandle;
+};
+
+/**
+ * Diagnostic sink for the coordinator's narrative log lines. Defaults
+ * to a no-op so the coordinator is silent in tests; production wires
+ * it to `logHost` from `@deneb-viz/utils/logging` to preserve the
+ * existing dev-overlay narrative the relocated host emissions used to
+ * carry.
+ */
+export type RenderingLifecycleLogger = (
+    message: string,
+    detail?: unknown
+) => void;
+
+/**
+ * Structured stream of lifecycle transitions. Each event captures
+ * what happened, which id it happened to, and (for failures and
+ * safety-net ticks) why. Consumed by:
+ *
+ *  - The dev overlay added in U11 — pushed into a Zustand slice the
+ *    overlay reads, so a developer running with `LOG_LEVEL=0` can
+ *    still see lifecycle transitions and the error message attached
+ *    to a `renderingFailed` emission. This is the only place
+ *    `renderingFailed` error context can surface during certified
+ *    builds, since `console.error` is forbidden by Power BI cert
+ *    rules and the host's `renderingFailed` reason string is a
+ *    write-only sink.
+ *  - Unit tests — assertions can read the event sequence directly
+ *    rather than inspecting host-emitter calls.
+ *
+ * The observer is optional. When omitted the coordinator's behavior
+ * is identical except no events are delivered (no performance cost
+ * paid for an unused sink).
+ *
+ * `via` discriminators tell the consumer which code path triggered
+ * the transition — important for U11's overlay (distinguishing
+ * "developer right-clicked away → supersede" from "render genuinely
+ * errored" from "safety-net fired") and for test assertions.
+ */
+export type RenderingLifecycleEvent =
+    | {
+          kind: 'opened';
+          id: RenderingLifecycleId;
+          options: powerbi.extensibility.visual.VisualUpdateOptions;
+      }
+    | { kind: 'render-started'; id: RenderingLifecycleId }
+    | {
+          kind: 'closed';
+          id: RenderingLifecycleId;
+          via: 'sync-current' | 'async-pending-render' | 'safety-net';
+      }
+    | {
+          kind: 'failed';
+          id: RenderingLifecycleId;
+          reason: string;
+          error?: unknown;
+          via: 'sync-current' | 'async-pending-render' | 'superseded';
+      }
+    | { kind: 'safety-net-armed'; id: RenderingLifecycleId }
+    | {
+          kind: 'safety-net-tick';
+          id: RenderingLifecycleId;
+          result: 'closed' | 'deferred' | 'inert';
+      };
+
+export type RenderingLifecycleObserver = (
+    event: RenderingLifecycleEvent
+) => void;
+
+/**
+ * Synthetic reason string passed to `renderingFailed` when an existing
+ * open id is displaced by a newer `open()`. Distinct from genuine
+ * render errors so future log inspection / metrics can separate
+ * "render aborted because superseded" from "render failed because of
+ * a real error".
+ */
+export const SUPERSEDED_FAILURE_REASON = 'superseded';
+
+/**
+ * Public surface of the rendering lifecycle coordinator. Owns ALL
+ * `host.eventService.rendering*` emission — no other module in the
+ * visual is permitted to call `renderingStarted` / `renderingFinished`
+ * / `renderingFailed` directly. The async React callbacks route
+ * through the `*PendingRender` no-arg variants; synchronous code in
+ * `Deneb.update()` and its dispatch handlers use the `*Current`
+ * no-arg variants.
+ */
+export type RenderingLifecycleCoordinator = {
+    /**
+     * Begin a lifecycle for this update. Emits `renderingStarted` to
+     * the host as part of opening — if the host throws on emission,
+     * the throw propagates BEFORE the id is recorded in the openIds
+     * map, so a follow-up `failCurrent(e)` from `update()`'s catch
+     * no-ops cleanly (nothing to fail). If a prior id is still open,
+     * it is superseded (closed via `renderingFailed` with the
+     * `SUPERSEDED_FAILURE_REASON` marker) before the new id is
+     * minted — supersede emission is NOT swallowed; a host throw on
+     * the supersede emission propagates out of `open()` and the new
+     * id is never minted (truthful-or-loud invariant).
+     */
+    open: (
+        options: powerbi.extensibility.visual.VisualUpdateOptions
+    ) => RenderingLifecycleId;
+    /**
+     * Bind the id whose async render is being awaited. Called
+     * synchronously from `src/index.ts` immediately after the
+     * dispatch handler commits the dataset / compilation for a
+     * rendering update — before `update()` returns. Subsequent
+     * `*PendingRender` calls from the React side target this id.
+     * Replaces any prior pending-render binding atomically.
+     */
+    bindPendingRender: (id: RenderingLifecycleId) => void;
+    /**
+     * Arm the bounded safety-net for an id. If the id is still open
+     * (no close / no fail) when the bound elapses, the safety-net
+     * checks whether the render ever began: if `renderStarted ===
+     * false`, it's an orphan and the safety-net closes it with
+     * `renderingFinished`; if `renderStarted === true`, the render is
+     * in flight and the safety-net waits (no close emitted). The
+     * exactly-once guard inside `close` / `fail` makes the safety-net
+     * inert against ids that already closed normally.
+     */
+    armSafetyNet: (id: RenderingLifecycleId) => void;
+    /**
+     * Close the currently-open id (used by synchronous code paths
+     * inside `update()`'s body — the dispatch handlers' non-rendering
+     * returns and the catch-via-fail path). No-op if no id is open or
+     * the current id has already closed.
+     */
+    closeCurrent: () => void;
+    /** Fail the currently-open id. Counterpart to `closeCurrent`. */
+    failCurrent: (error: unknown) => void;
+    /**
+     * Close the pending-render id (used by async React callbacks via
+     * `app.tsx`'s no-arg adapters). No-op if no pending-render is
+     * bound, or the pending-render id has already closed (e.g.
+     * superseded by a later `open`).
+     */
+    closePendingRender: () => void;
+    /** Fail the pending-render id. Counterpart to `closePendingRender`. */
+    failPendingRender: (error: unknown) => void;
+    /**
+     * Mark the pending-render id as having started rendering. The
+     * host does NOT see a second `renderingStarted`; this flag is
+     * internal to the coordinator and is consumed by the safety-net
+     * to distinguish orphan vs. in-flight. Idempotent.
+     */
+    markPendingRenderStarted: () => void;
+    /**
+     * Id-bearing variants. Exposed for unit-test determinism and for
+     * the supersede loop's internal use. Production callers OUTSIDE
+     * the coordinator use the no-arg `*Current` / `*PendingRender`
+     * variants instead.
+     */
+    close: (id: RenderingLifecycleId) => void;
+    fail: (id: RenderingLifecycleId, error: unknown) => void;
+    markRenderStarted: (id: RenderingLifecycleId) => void;
+};

--- a/src/lib/state/__test__/create-slice-sync.test.ts
+++ b/src/lib/state/__test__/create-slice-sync.test.ts
@@ -14,6 +14,11 @@ let capturedAppCoreSubscriber: (state: Record<string, unknown>) => void;
 
 const mockPersistProjectProperties = vi.fn();
 
+// Default the read-mode persist gate to inactive so existing slice-sync
+// tests run as if the visual is in edit mode. The read-mode-suppression
+// branch is exercised by a dedicated test below.
+let mockIsReadModePersistSuppressed = false;
+
 vi.mock('@deneb-viz/app-core', () => ({
     getDenebState: vi.fn(() => mockAppCoreState),
     useDenebState: {
@@ -48,7 +53,8 @@ vi.mock('../../../state', () => ({
 
 vi.mock('../../persistence', () => ({
     persistProjectProperties: (...args: unknown[]) =>
-        mockPersistProjectProperties(...args)
+        mockPersistProjectProperties(...args),
+    isReadModePersistSuppressed: () => mockIsReadModePersistSuppressed
 }));
 
 vi.mock('@deneb-viz/utils/logging', () => ({
@@ -184,6 +190,10 @@ describe('createSliceSync', () => {
         mockAppCoreState = {
             test: createSliceState()
         };
+        // Read-mode persist gate defaults to inactive (edit-mode
+        // behavior). The dedicated read-mode test flips this and
+        // relies on beforeEach to reset it between tests.
+        mockIsReadModePersistSuppressed = false;
     });
 
     afterEach(() => {
@@ -656,6 +666,48 @@ describe('createSliceSync', () => {
             fireAppCoreSubscriber(unchangedSlice);
 
             expect(mockPersistProjectProperties).not.toHaveBeenCalled();
+        });
+
+        it('should short-circuit without persisting or recording pending when the read-mode persist gate is active', () => {
+            // Simulate the U5 read-mode gate being live for this
+            // update. Even when the app-core slice changes (here:
+            // user-input-equivalent app-core mutation), the outbound
+            // subscriber must not enqueue host persist work AND must
+            // not record a pendingPersists entry — otherwise the next
+            // inbound sync would treat the genuine host value as a
+            // stale echo against an entry that never landed.
+            mockIsReadModePersistSuppressed = true;
+
+            const initialSlice = createSliceState({
+                __hasHydrated__: true,
+                spec: 'oldSpec'
+            });
+            mockAppCoreState = { test: initialSlice };
+            mockVisualSettings = {
+                ...DEFAULT_VISUAL_SETTINGS,
+                vega: { ...DEFAULT_VISUAL_SETTINGS.vega, spec: 'oldSpec' }
+            };
+            createSliceSync(createTestConfig());
+
+            const changedSlice = createSliceState({
+                __hasHydrated__: true,
+                spec: 'newSpec'
+            });
+            fireAppCoreSubscriber(changedSlice);
+
+            expect(mockPersistProjectProperties).not.toHaveBeenCalled();
+
+            // A subsequent inbound sync with the (unchanged) host value
+            // must NOT be filtered as a stale echo — because the gate
+            // returned early before recording a pending entry.
+            fireVisualSubscriber(
+                {
+                    ...DEFAULT_VISUAL_SETTINGS,
+                    vega: { ...DEFAULT_VISUAL_SETTINGS.vega, spec: 'oldSpec' }
+                },
+                true
+            );
+            expect(mockSyncFn).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## Summary

U7 from [`docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md`](../blob/feat/rendering-lifecycle-coordinator/docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md): introduce the rendering lifecycle coordinator — the single owner for `host.eventService.rendering*` emission. This is the foundation U8 / U9 / U10 attach to.

- **New module** `src/lib/rendering-lifecycle/` — `coordinator.ts`, `types.ts`, `index.ts`, and a 29-test deterministic spec.
- **`src/index.ts`** — coordinator instantiated in the constructor; `coordinator.open(options)` is now the first statement inside `update()`'s try (R1: start fires before any throwing work); the catch routes through `coordinator.failCurrent(e)`; the old direct `renderingStarted` / `renderingFailed` host calls inside `resolveUpdateOptions` and the catch are removed.

A small U5 follow-on test fix piggybacks here: `create-slice-sync.test.ts` was missing `isReadModePersistSuppressed` from its `vi.mock('../../persistence', ...)`, which let the full vitest suite break after U5 merged. Caught it during U7 verification — fixed as the first commit, with a focused regression test for the read-mode-gate branch so the coverage gap closes.

## What does NOT land in U7 (deliberately)

| Deferred | Owner | Why |
|---|---|---|
| **Safety-net arming** in `update()` | U9 | Arming now would cause every successful render to emit a duplicate `renderingFinished` ~5s after start during the U7→U9 window — the safety-net would classify the id as an orphan because `renderStarted` is never flipped (U9 adds the `onRenderingStarted` adapter), while `app.tsx` still emits the host's terminal via the pre-U7 direct call. The machinery is built and tested; arming is a one-line uncomment. |
| **`src/app/app.tsx` swap** | U9 | The plan owns the swap of `onRenderingFinished` / `onRenderingError` to the coordinator's `*PendingRender` adapters together with the new `onRenderingStarted` adapter. Bundling them with safety-net arming keeps U9 atomic. |
| **Direct `host.eventService` calls** in U8 dispatch handlers and U9 render paths | U8 / U9 | The plan's verification "no `host.eventService` call exists outside the coordinator after U8/U9" is the end-state target; U7 only relocates the synchronous `renderingStarted` and the synchronous-catch `renderingFailed`. |

During the U7→U9 window, the coordinator's internal `openIds` map accumulates entries per update. Bounded in practice — Power BI Desktop restarts the visual instance on tab change / refresh / dataset binding change — so the map does not grow indefinitely within a session.

## Design notes

- **Coordinator factory closure** returning an object of methods, mirroring `read-mode-gate.ts` / `persist.ts` patterns.
- **Structural emitter injection** (`RenderingLifecycleEmitter` — three function signatures) keeps the coordinator decoupled from the powerbi-visuals-api host type; tests pass a recorder mock.
- **Injected safety-net scheduler** (`SafetyNetScheduler.schedule(cb) → handle`) — production wires real `setTimeout` with a 5s bound; tests pass a synthetic scheduler that exposes the pending callback for deterministic `tick()` simulation.
- **`RenderingLifecycleObserver`** is the integration hook for U11's dev overlay: each transition (`opened`, `render-started`, `closed`, `failed`, `safety-net-armed`, `safety-net-tick`) is emitted with `id` + `via` discriminator + original error value preserved on `failed`. Critical because Power BI cert rules forbid `console.error`, so the only way to surface failure detail when `LOG_LEVEL=0` (prod-style debugging) is through a visual surface backed by the observer stream.
- **`SUPERSEDED_FAILURE_REASON` constant** is the synthetic reason string passed to `renderingFailed` when a new `open()` displaces a still-open prior id — distinct from genuine render errors so future metrics can separate aborted-because-superseded from failed-because-real-error.
- **`VIEW_MODE_VIEW = 0 satisfies powerbi.ViewMode`** pattern carried into `types.ts` (no new instance, but the same const-enum-vs-test-shim concern motivated the `RenderingLifecycleEmitter` structural type).

## Four invariants the coordinator enforces

1. **At most one id is "current"** at any time. `open()` supersede-fails any prior unclosed id before minting the new id.
2. **Exactly-once terminal emission per id.** Every close / fail path is gated on `!state.closed`; the first one wins, the rest no-op.
3. **State mutation precedes host emission for any terminal.** The id is marked closed and the observer is notified BEFORE the host call. If the host throws on the terminal emission, the id is still terminally closed — no half-closed limbo. This is the "truthful-or-loud" invariant.
4. **`open()` records the new id only after `renderingStarted` returns successfully.** If the host throws on emission, the id is never recorded; `failCurrent()` from `update()`'s catch finds no current id and no-ops — no orphan accumulates and the safety-net is never armed for a never-opened id.

## Test plan

- [x] 29/29 new coordinator unit tests pass (`npx vitest run src/lib/rendering-lifecycle`).
- [x] All other touched-or-adjacent test files pass (`migration`, `read-mode-gate`, `display-mode`, `create-slice-sync` — 22+8+13+3 = 46 tests).
- [x] `npx tsc --noEmit -p tsconfig.webpack.json` clean.
- [x] `npx prettier --config .prettierrc --check src/` clean.
- [x] `npx eslint` on touched files clean.
- [x] `npm run webpack:build` clean from a fresh `.tmp/` (5s build, full bundle produced).
- [x] Full repo vitest: 1350/1377 — the 27 remaining failures are pre-existing in `packages/vega-react/__tests__/*` (reproduce on unmodified `next` HEAD via `git stash`).

## Reviewer focus

- **`src/lib/rendering-lifecycle/coordinator.ts:166-196`** — the `open()` supersede loop. State mutation order is load-bearing; supersede ordering test (`'host throws on supersede renderingFailed → throw propagates loudly'`) is the key proof.
- **`src/lib/rendering-lifecycle/types.ts:60-95`** — `RenderingLifecycleEvent` discriminated union shape. This is the contract U11's dev overlay will consume; worth checking the `via` discriminators map to what an overlay would want to show.
- **`src/index.ts:194-217`** — the relocated `update()` body. The TODO(U9) explanation is intentionally verbose because the safety-net deferral is the most non-obvious decision in the PR.
- **`src/lib/state/__test__/create-slice-sync.test.ts`** — the U5 follow-on test fix + the new read-mode-gate coverage test. Small enough to scan in one read.

## Follow-up to

- 18e8361b U5 (read-mode property-migration gate, [#675](https://github.com/deneb-viz/deneb/pull/675))
- 4332b102 Phase A (resolveDataset dispatcher refactor, [#674](https://github.com/deneb-viz/deneb/pull/674))

## Next

- U8: synchronous closes on non-rendering dispatch paths (skip, fetch-more, recover-interrupted-fetch).
- U9: async close attribution + arm safety-net + route `app.tsx` through the coordinator. Closes the cert-blocking R12 invariant end-to-end.
