### PR TITLE
feat(visual): synchronous closes on non-rendering dispatch paths (U8)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,14 @@ export class Deneb implements IVisual {
             this.#coordinator = createRenderingLifecycleCoordinator({
                 emitter: host.eventService,
                 scheduler: renderingLifecycleScheduler,
-                logger: (message, detail) => logHost(message, detail)
+                // `logHost` is variadic; forwarding it directly lets
+                // the coordinator's one-arg `log(message)` calls reach
+                // the underlying `console.debug(...args)` cleanly. The
+                // earlier `(message, detail) => logHost(message, detail)`
+                // wiring forwarded `detail` unconditionally and printed
+                // a literal `undefined` after every lifecycle line
+                // (e.g. "[lifecycle] renderingStarted id=1 undefined").
+                logger: logHost
             });
             const {
                 dataset: { setSelectors },

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,6 +282,15 @@ export class Deneb implements IVisual {
 
         if (action.kind === 'skip') {
             logDebug('Visual dataset has not changed. No need to process.');
+            // Skip is a non-rendering dispatch — no async render will
+            // follow to close this update's lifecycle. Close
+            // synchronously here so the host sees a balanced
+            // renderingStarted / renderingFinished pair (R2, AE1). If
+            // a persist was issued earlier in this update (e.g. an
+            // edit-mode migration), the host's follow-up update
+            // closes on its own dispatch path — no special branch
+            // needed here.
+            this.#coordinator.closeCurrent();
             return;
         }
 
@@ -361,6 +370,14 @@ export class Deneb implements IVisual {
         }
         if (fetchSuccess) {
             logTimeEnd('processDataset');
+            // Host accepted the segment — no render will follow for
+            // this update; the next segment arrives as its own
+            // `update()`. Close this update's lifecycle synchronously
+            // so each segment update produces its own 1:1
+            // started/finished pair (R8, AE2). Order: after the
+            // `processDataset` timing close so the existing diagnostic
+            // pairing is preserved.
+            this.#coordinator.closeCurrent();
             return;
         }
         // Host declined the fetch — fall through to finalise/normal
@@ -450,6 +467,13 @@ export class Deneb implements IVisual {
             rowsLoaded: Math.max(currentStateRowsLoaded, rowsLoaded)
         });
         logTimeEnd('processDataset');
+        // Recover-interrupted-fetch is non-rendering — no setDataset
+        // ran, the existing slice is preserved, and the visual will
+        // re-enter the normal change-detection path on the next
+        // update. Close this update's lifecycle synchronously so it
+        // doesn't orphan a renderingStarted (R2, AE1's recover
+        // variant).
+        this.#coordinator.closeCurrent();
     }
 
     /**


### PR DESCRIPTION
## Summary

U8 from [`docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md`](../blob/feat/lifecycle-sync-closes/docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md): route the three non-rendering dispatch returns through `coordinator.closeCurrent()` so the host sees a balanced `renderingStarted` / `renderingFinished` pair on every update — not just the rendering ones. Builds on U7's coordinator. U9 will handle the rendering paths (`handleNormalFinalise`, `handleFetchMore`'s host-decline fall-through).

A small follow-on log fix piggybacks here: U7's coordinator-logger wiring forwarded `(message, detail) => logHost(message, detail)`, which printed a literal `undefined` after every lifecycle log line because the coordinator's calls pass only one argument. `logHost` is variadic and structurally compatible with `RenderingLifecycleLogger`, so forwarding it directly fixes this cleanly. Surfaced during U8 smoke-testing.

## Sites changed in `src/index.ts`

1. **Skip return** in `resolveDataset` — non-rendering dispatch (no data change, nothing to process). Closes synchronously before `return`. _(R2, AE1.)_
2. **`handleFetchMore` success branch** — host accepted `fetchMoreData(true)`, the next segment will arrive as its own `update()`. Closes synchronously after the existing `logTimeEnd('processDataset')` so this segment update produces its own 1:1 started/finished pair. _(R8, AE2.)_
3. **End of `handleRecoverInterruptedFetch`** — non-volatile update arrived while flagged as fetching; the stuck flag is cleared, dataset slice preserved, no `setDataset` runs. Closes synchronously after `logTimeEnd`. _(R2, AE1 recover variant.)_

Plus the logger-wiring fix in the constructor.

## Explicitly NOT in U8 (U9 owns)

- `handleNormalFinalise` — calls `setDataset` → render path → U9 adds `bindPendingRender` so the async render callback closes the lifecycle via the coordinator's `*PendingRender` adapters.
- `handleFetchMore` host-decline branch — also calls `setDataset` → render path → same U9 treatment.

Until U9 lands, render paths continue to leave a coordinator-side id open — but U7's supersede mechanism terminally closes it when the next update opens, so no orphan accumulates beyond a single id. App.tsx's existing `onRenderingFinished` direct-host call still emits `renderingFinished` to the host for those renders (with the known AE7 attribution-drift problem U9 will fix).

## Persist-intersected case (no special branch needed)

`handlePropertyMigration` runs before `resolveDataset` in the current orchestrator. If migration persisted during this update, the host queues a follow-up update — but the CURRENT update still closes via whichever dispatch path `resolveDataset` resolved to (skip / fetch / recover for U8; normal-finalise for U9). No per-update flag, no defensive assertion — the existing dispatch handlers cover every persist-intersected combination naturally and the safety-net (when armed in U9) catches any handler that forgets to close.

## `logTimeEnd` pairing preserved

All three `closeCurrent` calls land AFTER the existing `logTimeEnd('processDataset')` on their path, so the timing diagnostic pairing is unchanged. The skip path has no `logTimeEnd` pairing because `logTimeStart('processDataset')` is called _after_ the skip-return.

## On tests

The plan's listed scenarios (skip → one finished, fetch-more success → own sync close, recover → sync close, persist-intersected variants) all reduce at the unit level to "open + closeCurrent within the same synchronous frame" — pinned by U7's coordinator tests (29 tests covering open/close/fail / supersede / exactly-once / safety-net). What U8 adds is the wiring that production code actually calls `closeCurrent` at these dispatch points — an integration concern verified by code inspection here plus the dev-overlay tally that U11 will add.

A handler-level Vitest test would require extracting the dispatch handlers from the `Deneb` class into a testable module or instantiating the whole class with substantial mocks. Scope creep for U8 without proportional value; deferred to the U11 tally for end-to-end observability.

## Smoke test (manually verified before opening PR)

`LOG_LEVEL=DEBUG`, `PBIVIZ_DEV_OVERLAY=true`, `npm run dev`, load a working visual with a spec in Power BI Desktop, then drag the resize handle.

Observed console output, in order:

```
HOST  [lifecycle] renderingStarted id=1
HOST  Rendering event finished.
HOST  [lifecycle] renderingFailed id=1 reason=superseded via=superseded
HOST  [lifecycle] renderingStarted id=2
HOST  [lifecycle] renderingFailed id=2 reason=superseded via=superseded
HOST  [lifecycle] renderingStarted id=3
HOST  [lifecycle] renderingFinished id=3 via=sync-current
HOST  [lifecycle] renderingStarted id=4
HOST  [lifecycle] renderingFinished id=4 via=sync-current
HOST  [lifecycle] renderingStarted id=5
HOST  [lifecycle] renderingFinished id=5 via=sync-current
HOST  [lifecycle] renderingStarted id=6
HOST  [lifecycle] renderingFinished id=6 via=sync-current
HOST  Rendering event finished.
HOST  [lifecycle] renderingStarted id=7
HOST  [lifecycle] renderingFinished id=7 via=sync-current
```

Interpretation:

- **ids 1–2** are render paths (reload + first resize landed before change-detection cache had stabilised) → no U8 close → next-update supersede. _U7 doing its job — pre-U7 these would have been orphans._
- **ids 3–6** are skip-path resize updates — U8's new `closeCurrent` fires, balanced pair from the coordinator alone. _This is the U8 behaviour we wanted to verify._
- The mid-stream `Rendering event finished.` (no `[lifecycle]` prefix) is app.tsx's still-direct host call for a real Vega render that settled during the resize burst. Known pre-U9 attribution drift; doesn't break U8.
- **id=7** is the resize-end skip — clean start/finish pair from U8.

## Verification

- [x] 29/29 coordinator tests still pass.
- [x] `npx tsc --noEmit -p tsconfig.webpack.json` clean.
- [x] `npx prettier --config .prettierrc --check src/` clean.
- [x] Full repo vitest: 1350/1377 — same 27 pre-existing failures in `packages/vega-react/__tests__/*` (reproduce on unmodified `next` HEAD), no U8 regressions.
- [x] Manual smoke test (above) confirms skip-path close fires correctly under realistic resize input.

## Reviewer focus

- **`src/index.ts`** — three new `closeCurrent` calls (skip-return, fetch-more success branch, end of `handleRecoverInterruptedFetch`). Each lives after the existing `logTimeEnd('processDataset')` where present. The handler-level diff is intentionally tiny.
- **`src/index.ts` constructor** — `logger: logHost` (direct forward) instead of the U7 wrapping closure. Confirmed against `packages/utils/src/lib/logging.ts:159` — `logHost` is `_log(LogLevel.HOST)` which spreads varargs to `console.debug`.

## Follow-up to

- [a1e7a193](https://github.com/deneb-viz/deneb/commit/a1e7a193) U7 (rendering lifecycle coordinator, [#677](https://github.com/deneb-viz/deneb/pull/677))
- [18e8361b](https://github.com/deneb-viz/deneb/commit/18e8361b) U5 (read-mode property-migration gate, [#675](https://github.com/deneb-viz/deneb/pull/675))
- [4332b102](https://github.com/deneb-viz/deneb/commit/4332b102) Phase A (resolveDataset dispatcher refactor, [#674](https://github.com/deneb-viz/deneb/pull/674))

## Next

- U9: async close attribution + arm safety-net + route `app.tsx` through the coordinator. Removes the remaining direct `host.eventService` calls and fixes the AE7 attribution drift visible in the smoke-test trace above.
