### PR TITLE
feat(visual): async close attribution + arm safety-net + route app.tsx through coordinator (U9)

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,8 +1,8 @@
 import powerbi from 'powerbi-visuals-api';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { type View } from 'vega';
 
-import { logHost, logRender } from '@deneb-viz/utils/logging';
+import { logRender } from '@deneb-viz/utils/logging';
 import { ReportViewRouter } from './report-view-router';
 import {
     DenebProvider,
@@ -50,9 +50,28 @@ import { handlePersistBooleanProperty } from '../features/settings/helpers';
 
 type AppProps = {
     host: powerbi.extensibility.visual.IVisualHost;
+    /**
+     * Rendering-lifecycle adapters built in `src/index.ts` and passed
+     * down through the platform provider. App-core / vega-embed call
+     * these without arguments (or with an `Error` for the error
+     * variant); the adapters route to the coordinator's
+     * `*PendingRender` methods. No `visualUpdateOptions` capture is
+     * needed here — the pending-render binding is performed
+     * synchronously in the visual's dispatch handlers BEFORE
+     * `update()` returns, so by the time these async callbacks fire
+     * the coordinator already knows which id they target.
+     */
+    onRenderingStarted: () => void;
+    onRenderingFinished: () => void;
+    onRenderingError: (error: Error) => void;
 };
 
-export const App = ({ host }: AppProps) => {
+export const App = ({
+    host,
+    onRenderingStarted,
+    onRenderingFinished,
+    onRenderingError
+}: AppProps) => {
     const [isDownloadPermitted, setIsDownloadPermitted] = useState<
         boolean | undefined
     >(undefined);
@@ -147,27 +166,6 @@ export const App = ({ host }: AppProps) => {
         return binders;
     }, [fields, values, selectionMode, translate]);
 
-    /**
-     * Rendering lifecycle callbacks for Power BI visual host.
-     * These call the event service directly rather than through powerbi-compat.
-     */
-    const onRenderingFinished = useCallback(() => {
-        if (visualUpdateOptions) {
-            logHost('Rendering event finished.');
-            host.eventService.renderingFinished(visualUpdateOptions);
-        }
-    }, [host, visualUpdateOptions]);
-
-    const onRenderingError = useCallback(
-        (error: Error) => {
-            if (visualUpdateOptions) {
-                logHost('Rendering event failed:', error.message);
-                host.eventService.renderingFailed(visualUpdateOptions);
-            }
-        },
-        [host, visualUpdateOptions]
-    );
-
     // Ensure that download permissions are evaluated against the current tenant and sent to the core app
     useEffect(() => {
         if (host) {
@@ -224,6 +222,7 @@ export const App = ({ host }: AppProps) => {
                     handlePersistBooleanProperty('enableHighlight', false),
                 onRenderingError,
                 onRenderingFinished,
+                onRenderingStarted,
                 settingsPaneFooter: <InteractivityFooter />,
                 settingsPanePlatformComponent: [
                     <SemanticModelSettings key={PLATFORM_SECTION_KEYS[0]} />,

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,26 +75,29 @@ const IS_DEVELOPER_MODE = toBoolean(process.env.PBIVIZ_DEV_MODE);
  * (`state.renderStarted === false`), the safety-net closes it as an
  * orphan; if a render is in flight, the close is deferred.
  *
- * Tuning rationale: vega-embed's setup pipeline (parse → compile →
- * embed → run → paint) can take several seconds on cold-start for
- * complex specs against large datasets, and the `onRenderingStarted`
- * callback that flips `renderStarted = true` is fired at the END of
- * that chain (vega-embed.tsx invokes it inside `view.runAsync().then`
- * — see packages/app-core/src/features/visual-viewer/components/vega-embed.tsx).
- * The bound must therefore exceed the worst-case legitimate render
- * time, not the typical one — otherwise the safety-net races a
- * slow-but-valid render and emits a premature `renderingFinished`.
+ * **10s is a Power BI certification ceiling** — values above this are
+ * rejected by the cert team, so this is not a tuning knob we can
+ * trade off against worst-case render time. Whatever genuinely
+ * legitimate-but-slow paths exist must close themselves before the
+ * bound, not rely on a longer safety-net.
  *
- * 30s is generous enough that any render reaching the safety-net
- * tick is almost certainly genuinely stuck (the embed setup never
- * reached its `.then` handler — e.g., promise rejected without
- * surfacing through `onRenderingError`, or React never mounted the
- * embed component), while still short enough to surface a hung
- * update during a dev session rather than waiting on a Power BI
- * tab change. U11's dev overlay will surface every safety-net
- * tick so we can tune this against real-world observations.
+ * Known close paths that fall through to the safety-net today:
+ *  - Incremental data-update path (`performIncrementalUpdate` in
+ *    `packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx`)
+ *    — Vega view is updated in place via `view.data()`, so
+ *    `vega-embed.tsx`'s `onRenderingStarted` / `onRenderingFinished`
+ *    never fire (those only fire on a full embed). Currently closes
+ *    via safety-net; **U10 wires `onSuccess` / `onFailure` of
+ *    `performIncrementalUpdate` through the coordinator's
+ *    `*PendingRender` adapters so these close synchronously and the
+ *    safety-net falls back to a true-orphan-only role.**
+ *
+ * U11's dev overlay will surface every safety-net tick so we can
+ * observe whether any legitimate path exceeds 10s. If one does, the
+ * fix lives in that path (close it synchronously / wire it through
+ * the coordinator), not in raising this constant.
  */
-const SAFETY_NET_BOUND_MS = 30_000;
+const SAFETY_NET_BOUND_MS = 10_000;
 
 /**
  * Real-`setTimeout` scheduler for the rendering-lifecycle coordinator.

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,14 +71,30 @@ const IS_DEVELOPER_MODE = toBoolean(process.env.PBIVIZ_DEV_MODE);
 
 /**
  * Bound (ms) after which the rendering-lifecycle safety-net checks an
- * armed id. If the id is still open and no render ever began, the
- * safety-net closes it as an orphan; if a render is in flight
- * (`renderStarted === true`), the close is deferred to the render's
- * own callback chain. Tuned generously against observed render timing
- * — 5 seconds is well beyond the cert-blocking orphan window while
- * staying short enough to surface a broken update path during dev.
+ * armed id. If the id is still open and no render ever began
+ * (`state.renderStarted === false`), the safety-net closes it as an
+ * orphan; if a render is in flight, the close is deferred.
+ *
+ * Tuning rationale: vega-embed's setup pipeline (parse → compile →
+ * embed → run → paint) can take several seconds on cold-start for
+ * complex specs against large datasets, and the `onRenderingStarted`
+ * callback that flips `renderStarted = true` is fired at the END of
+ * that chain (vega-embed.tsx invokes it inside `view.runAsync().then`
+ * — see packages/app-core/src/features/visual-viewer/components/vega-embed.tsx).
+ * The bound must therefore exceed the worst-case legitimate render
+ * time, not the typical one — otherwise the safety-net races a
+ * slow-but-valid render and emits a premature `renderingFinished`.
+ *
+ * 30s is generous enough that any render reaching the safety-net
+ * tick is almost certainly genuinely stuck (the embed setup never
+ * reached its `.then` handler — e.g., promise rejected without
+ * surfacing through `onRenderingError`, or React never mounted the
+ * embed component), while still short enough to surface a hung
+ * update during a dev session rather than waiting on a Power BI
+ * tab change. U11's dev overlay will surface every safety-net
+ * tick so we can tune this against real-world observations.
  */
-const SAFETY_NET_BOUND_MS = 5000;
+const SAFETY_NET_BOUND_MS = 30_000;
 
 /**
  * Real-`setTimeout` scheduler for the rendering-lifecycle coordinator.
@@ -128,6 +144,15 @@ export class Deneb implements IVisual {
     #root: ReturnType<typeof createRoot>;
     #host: powerbi.extensibility.visual.IVisualHost;
     #coordinator: RenderingLifecycleCoordinator;
+    // Render-callback adapters built once in the constructor (see U9
+    // wiring below). Stored as fields so the same function references
+    // are passed to <App> on the initial render; React then forwards
+    // them through the platform provider's `onRendering*` slots
+    // unchanged across re-renders. App-core never sees the
+    // coordinator itself.
+    #onRenderingStartedAdapter: () => void;
+    #onRenderingFinishedAdapter: () => void;
+    #onRenderingErrorAdapter: (error: Error) => void;
 
     constructor(options: VisualConstructorOptions) {
         logHost('Constructor has been called.', { options });
@@ -150,6 +175,22 @@ export class Deneb implements IVisual {
                 // (e.g. "[lifecycle] renderingStarted id=1 undefined").
                 logger: logHost
             });
+            // U9: render-callback adapters routed through the
+            // coordinator. App-core never imports the coordinator —
+            // these no-arg / one-arg adapters are constructed here
+            // and passed as props to <App>, which threads them to
+            // the platform-provider's `onRendering*` slots. The
+            // pending-render binding is performed synchronously in
+            // the dispatch handlers (see `handleNormalFinalise` and
+            // `handleFetchMore`); React fires these adapters AFTER
+            // the dispatch returns, by which point `pendingRenderId`
+            // is set to this update's id.
+            this.#onRenderingStartedAdapter = () =>
+                this.#coordinator.markPendingRenderStarted();
+            this.#onRenderingFinishedAdapter = () =>
+                this.#coordinator.closePendingRender();
+            this.#onRenderingErrorAdapter = (error: Error) =>
+                this.#coordinator.failPendingRender(error);
             const {
                 dataset: { setSelectors },
                 host: { setHost },
@@ -186,7 +227,14 @@ export class Deneb implements IVisual {
             this.handleSuppressOnObjectFormatting();
             this.bindTabCycling();
             this.#root = createRoot(this.#applicationWrapper);
-            this.#root.render(createElement(App, { host }));
+            this.#root.render(
+                createElement(App, {
+                    host,
+                    onRenderingStarted: this.#onRenderingStartedAdapter,
+                    onRenderingFinished: this.#onRenderingFinishedAdapter,
+                    onRenderingError: this.#onRenderingErrorAdapter
+                })
+            );
             element.oncontextmenu = (ev) => {
                 ev.preventDefault();
             };
@@ -227,31 +275,32 @@ export class Deneb implements IVisual {
             this.#coordinator.failCurrent(e);
             logDebug('Error during visual update.', { error: e });
         } finally {
-            // TODO(U9): Arm the safety-net here once the async render
-            // close paths in `src/app/app.tsx` route through the
-            // coordinator instead of calling `host.eventService`
-            // directly. Arming now would cause every successful render
-            // to emit a duplicate `renderingFinished` ~5s after start
-            // — the coordinator's safety-net would mistakenly classify
-            // the id as an orphan (renderStarted is never flipped
-            // until U9 adds the `onRenderingStarted` adapter), while
-            // app.tsx has already emitted the host's terminal.
+            // Arm the safety-net for this update's id. The safety-net
+            // is the backstop for rendering paths: if React's async
+            // render callback never fires (the embed got stuck, the
+            // page navigated away, the view threw without surfacing),
+            // the safety-net closes the id after a bounded wait so
+            // the host doesn't see an orphan `renderingStarted`.
             //
-            //     if (openId !== undefined) {
-            //         this.#coordinator.armSafetyNet(openId);
-            //     }
-            //
-            // The coordinator's `openIds` map holds at most one
-            // entry (the active id) at any time — terminal paths
-            // delete the entry, and supersede displaces the prior id
-            // before minting the new one. The previously-noted
-            // "accumulates until visual restart" concern was real
-            // before deletion-on-terminal landed and no longer
-            // applies; the only id that can linger at session end is
-            // the very last update's id (never closed via coordinator
-            // because app.tsx's direct host call doesn't route
-            // through it until U9).
-            void openId;
+            // - When the dispatch was a non-rendering path (skip,
+            //   fetch-more success, recover — U8), `closeCurrent` has
+            //   already fired and deleted the id from `openIds`;
+            //   `armSafetyNet` looks up the id, finds nothing, and
+            //   no-ops.
+            // - When the dispatch was a rendering path (normal-
+            //   finalise, fetch-more host-decline — U9), the id stays
+            //   open, the safety-net is armed, the React render
+            //   eventually calls `markPendingRenderStarted()` (so
+            //   the safety-net defers on tick instead of closing
+            //   in-flight work), then `closePendingRender()` fires
+            //   and cancels the safety-net handle as part of the
+            //   close.
+            // - When `open()` itself threw (host rejected
+            //   `renderingStarted`), `openId` stayed `undefined` and
+            //   the guard skips arming.
+            if (openId !== undefined) {
+                this.#coordinator.armSafetyNet(openId);
+            }
         }
     }
 
@@ -396,6 +445,14 @@ export class Deneb implements IVisual {
         });
         setDataset(getMappedDataset(categorical, locale));
         logTimeEnd('processDataset');
+        // Rendering branch: bind the pending-render id BEFORE
+        // returning so the React-side `onRendering*` callbacks
+        // (fired async after Vega embeds and paints) route through
+        // the coordinator's `*PendingRender` adapters and target the
+        // correct id. Without this, the coordinator's id for this
+        // update stays open, and the next `update()` supersede-fails
+        // it (the U7/U8 transition behaviour).
+        this.#coordinator.bindPendingRenderCurrent();
     }
 
     /**
@@ -503,6 +560,11 @@ export class Deneb implements IVisual {
         // Tracking is now only used for export (#486)
         // this.updateTracking();
         logTimeEnd('processDataset');
+        // Rendering branch: bind the pending-render id BEFORE
+        // returning. See the matching call in `handleFetchMore`'s
+        // host-decline branch for the full rationale. Any future
+        // rendering branch added to the dispatch MUST also call this.
+        this.#coordinator.bindPendingRenderCurrent();
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,26 +75,23 @@ const IS_DEVELOPER_MODE = toBoolean(process.env.PBIVIZ_DEV_MODE);
  * (`state.renderStarted === false`), the safety-net closes it as an
  * orphan; if a render is in flight, the close is deferred.
  *
- * Tuning rationale: vega-embed's setup pipeline (parse → compile →
- * embed → run → paint) can take several seconds on cold-start for
- * complex specs against large datasets, and the `onRenderingStarted`
- * callback that flips `renderStarted = true` is fired at the END of
- * that chain (vega-embed.tsx invokes it inside `view.runAsync().then`
- * — see packages/app-core/src/features/visual-viewer/components/vega-embed.tsx).
- * The bound must therefore exceed the worst-case legitimate render
- * time, not the typical one — otherwise the safety-net races a
- * slow-but-valid render and emits a premature `renderingFinished`.
+ * Known close paths that fall through to the safety-net today:
+ *  - Incremental data-update path (`performIncrementalUpdate` in
+ *    `packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx`)
+ *    — Vega view is updated in place via `view.data()`, so
+ *    `vega-embed.tsx`'s `onRenderingStarted` / `onRenderingFinished`
+ *    never fire (those only fire on a full embed). Currently closes
+ *    via safety-net; **U10 wires `onSuccess` / `onFailure` of
+ *    `performIncrementalUpdate` through the coordinator's
+ *    `*PendingRender` adapters so these close synchronously and the
+ *    safety-net falls back to a true-orphan-only role.**
  *
- * 30s is generous enough that any render reaching the safety-net
- * tick is almost certainly genuinely stuck (the embed setup never
- * reached its `.then` handler — e.g., promise rejected without
- * surfacing through `onRenderingError`, or React never mounted the
- * embed component), while still short enough to surface a hung
- * update during a dev session rather than waiting on a Power BI
- * tab change. U11's dev overlay will surface every safety-net
- * tick so we can tune this against real-world observations.
+ * U11's dev overlay will surface every safety-net tick so we can
+ * observe whether any legitimate path exceeds 10s. If one does, the
+ * fix lives in that path (close it synchronously / wire it through
+ * the coordinator), not in raising this constant.
  */
-const SAFETY_NET_BOUND_MS = 30_000;
+const SAFETY_NET_BOUND_MS = 10_000;
 
 /**
  * Real-`setTimeout` scheduler for the rendering-lifecycle coordinator.

--- a/src/lib/rendering-lifecycle/__test__/coordinator.test.ts
+++ b/src/lib/rendering-lifecycle/__test__/coordinator.test.ts
@@ -351,6 +351,42 @@ describe('createRenderingLifecycleCoordinator — pending-render binding', () =>
             1
         );
     });
+
+    it('bindPendingRenderCurrent targets the current open id (no-arg variant for dispatch handlers)', () => {
+        const { coordinator, calls } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        // Dispatch handler does not have direct access to the minted
+        // id — uses the no-arg variant to bind whichever id is open.
+        coordinator.bindPendingRenderCurrent();
+        coordinator.closePendingRender();
+        const finishes = calls.filter((c) => c.method === 'renderingFinished');
+        expect(finishes).toHaveLength(1);
+        expect(finishes[0].options).toBe(FAKE_OPTIONS_A);
+    });
+
+    it('bindPendingRenderCurrent with no current open id → no-op', () => {
+        const { coordinator, calls, events } = buildHarness();
+        // No prior open; the dispatch handler's call should not raise
+        // or bind anything stale.
+        coordinator.bindPendingRenderCurrent();
+        coordinator.closePendingRender();
+        expect(calls).toEqual([]);
+        expect(events).toEqual([]);
+    });
+
+    it('bindPendingRenderCurrent after supersede rebinds to the new id', () => {
+        const { coordinator, calls } = buildHarness();
+        coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRenderCurrent();
+        // Supersede A with B; the dispatch handler for B's update
+        // calls bindPendingRenderCurrent again — should retarget to B.
+        coordinator.open(FAKE_OPTIONS_B);
+        coordinator.bindPendingRenderCurrent();
+        coordinator.closePendingRender();
+        const finishes = calls.filter((c) => c.method === 'renderingFinished');
+        expect(finishes).toHaveLength(1);
+        expect(finishes[0].options).toBe(FAKE_OPTIONS_B);
+    });
 });
 
 describe('createRenderingLifecycleCoordinator — safety-net', () => {

--- a/src/lib/rendering-lifecycle/coordinator.ts
+++ b/src/lib/rendering-lifecycle/coordinator.ts
@@ -223,6 +223,13 @@ export const createRenderingLifecycleCoordinator = (
             pendingRenderId = id;
         };
 
+    const bindPendingRenderCurrent: RenderingLifecycleCoordinator['bindPendingRenderCurrent'] =
+        () => {
+            const id = currentOpenId();
+            if (id === null) return;
+            pendingRenderId = id;
+        };
+
     const armSafetyNet: RenderingLifecycleCoordinator['armSafetyNet'] = (
         id
     ) => {
@@ -290,6 +297,7 @@ export const createRenderingLifecycleCoordinator = (
     return {
         open,
         bindPendingRender,
+        bindPendingRenderCurrent,
         armSafetyNet,
         closeCurrent,
         failCurrent,

--- a/src/lib/rendering-lifecycle/types.ts
+++ b/src/lib/rendering-lifecycle/types.ts
@@ -172,6 +172,20 @@ export type RenderingLifecycleCoordinator = {
      */
     bindPendingRender: (id: RenderingLifecycleId) => void;
     /**
+     * No-arg variant of {@link bindPendingRender} that targets
+     * whichever id is currently open (per invariant #1, at most one
+     * is). Mirrors the {@link closeCurrent} / {@link closePendingRender}
+     * shape — production callers inside the visual's dispatch
+     * handlers don't have direct access to the opened id (it is
+     * minted inside `update()`'s try and captured in a local), so
+     * threading it through `resolveUpdateOptions` → `resolveDataset`
+     * → each handler would require a chain of optional parameters.
+     * The current-open id lookup is identical to what
+     * `closeCurrent` performs internally. No-op when nothing is
+     * open (e.g. `open()` threw before recording the id).
+     */
+    bindPendingRenderCurrent: () => void;
+    /**
      * Arm the bounded safety-net for an id. If the id is still open
      * (no close / no fail) when the bound elapses, the safety-net
      * checks whether the render ever began: if `renderStarted ===


### PR DESCRIPTION
## Summary

U9 from [`docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md`](../blob/feat/lifecycle-async-attribution/docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md): close the cert-blocking R12 / AE7 invariants end-to-end by routing the remaining async render-callback paths through the coordinator and arming the safety-net. Together with U7 (coordinator) and U8 (sync closes), every lifecycle terminal now flows through one owner with proper update-identity attribution.

After this PR: **the coordinator is the single owner of every `host.eventService.rendering*` emission in production code**. `grep eventService.rendering(Started|Finished|Failed)` across the repo returns only doc-comment references — zero production call sites outside `src/lib/rendering-lifecycle/`.

## Three groups of change

### 1. Coordinator extension: `bindPendingRenderCurrent()`

The dispatch handlers (`handleNormalFinalise`, `handleFetchMore`) don't have direct access to the opened id — it is minted inside `update()`'s try block and captured in a local. The plan's literal `bindPendingRender(id)` would have required threading the opened id through `resolveUpdateOptions` → `resolveDataset` → each handler. Added a no-arg variant that mirrors the existing `closeCurrent` / `closePendingRender` shape — internal current-id lookup, no plumbing through three function signatures + the `DatasetUpdateContext` type.

Three new unit tests cover happy path, no-op when nothing is open, and atomic rebind across supersede. Brings the coordinator suite to **32/32**.

### 2. `src/app/app.tsx` — direct host emission removed

- **Removed** the two `useCallback` closures that captured `visualUpdateOptions` and called `host.eventService.rendering*` directly. The captured `visualUpdateOptions` reflected whatever was current at the useCallback rebuild time, not whatever update actually rendered — that was the AE7 attribution-drift problem.
- **Added** three new `AppProps` fields — `onRenderingStarted`, `onRenderingFinished`, `onRenderingError` — built in `src/index.ts` and threaded down through the existing platform provider's `onRendering*` slots.
- The `onRenderingStarted` prop fills an existing optional slot on [`DenebPlatformProviderProps`](packages/app-core/src/components/deneb-platform/types.ts#L55-L57) — **no app-core type changes**. App-core does NOT import the coordinator; it consumes the adapters as plain callbacks identical to the pre-U9 prop shape.

### 3. `src/index.ts` — adapters, bindings, safety-net armed

- Three render-callback adapters constructed once in the constructor and stored as private fields:
  - `onRenderingStarted → coordinator.markPendingRenderStarted()`
  - `onRenderingFinished → coordinator.closePendingRender()`
  - `onRenderingError → coordinator.failPendingRender(error)`
- `bindPendingRenderCurrent()` called synchronously at every rendering branch in the dispatch path, immediately after `setDataset(getMappedDataset(...))` and before the handler returns:
  - `handleNormalFinalise` — the `case 'normal'` branch
  - `handleFetchMore` — the host-decline fall-through branch
  - Any future rendering branch added to the dispatch MUST also call this — flagged in the handler comments.
- **Safety-net is now armed** in `update()`'s finally block. The earlier U7 deferral rationale (rendering paths would double-close because app.tsx emitted to host directly) no longer applies — every close path now goes through the coordinator's exactly-once guard.

## Safety-net bound: 10s, enforced as a cert ceiling

`SAFETY_NET_BOUND_MS = 10_000`. **Microsoft cert team rejects safety-net bounds above 10s** — this is a hard ceiling, not a tuning knob to trade off against worst-case render time. The initial U9 commit (`f52eaa45`) set it to 30s reasoning about slow Vega cold-starts; corrected in [`0ad5ef56`](https://github.com/deneb-viz/deneb/commit/0ad5ef56) once the user flagged the cert constraint.

Whatever genuinely slow paths exist must close themselves explicitly through the coordinator before the bound elapses — by being wired through `closeCurrent` / `closePendingRender` / `failPendingRender` at their own completion points. **The fix for a slow path is to route it, not to widen the bound.**

## Lifecycle-event coverage after U9

| Dispatch path | Close mechanism | Observer `via` discriminator |
|---|---|---|
| skip | `closeCurrent()` (U8) | `sync-current` |
| fetch-more success | `closeCurrent()` (U8) | `sync-current` |
| recover-interrupted-fetch | `closeCurrent()` (U8) | `sync-current` |
| normal-finalise (full re-embed) | `closePendingRender()` via vega-embed (U9) | `async-pending-render` |
| fetch-more host-decline (full re-embed) | `closePendingRender()` via vega-embed (U9) | `async-pending-render` |
| `update()` throws | `failCurrent(error)` (U7) | `sync-current` |
| vega-embed error | `failPendingRender(error)` (U9) | `async-pending-render` |
| Genuine orphan (broken parser, React never mounting) | safety-net `closeInternal` (U9) | `safety-net` |
| Coalesced supersede | `failInternal` in `open()` (U7) | `superseded` |
| **Incremental data update path** (Vega `view.data()` — no re-embed) | safety-net `closeInternal` (U9) — **falls through to safety-net until U10** | `safety-net` |

The incremental data update path is the one remaining orphan path the safety-net catches today. U10 will wire `performIncrementalUpdate`'s `onSuccess` / `onFailure` callbacks through the coordinator's `*PendingRender` adapters, after which the safety-net falls back to a true-orphan-only role.

## What does NOT change

- `packages/app-core/src/features/visual-viewer/components/vega-embed.tsx` — callback signatures untouched. The `() => void` / `(error) => void` shapes are stable; only the meaning changes (adapters instead of direct host calls).
- `performIncrementalUpdate`'s `onSuccess`/`onFailure` callbacks in `visual-viewer.tsx` — U10 owns these.
- The existing supersede semantics — U7's `renderingFailed(options, SUPERSEDED_FAILURE_REASON)` still fires when a new `open()` displaces an open prior id.

## Smoke test (manually verified)

`LOG_LEVEL=DEBUG`, `PBIVIZ_DEV_OVERLAY=true`, `npm run dev`, visual with a working spec in Power BI Desktop. Sequence: reload → resize storm → property change.

```
HOST  [lifecycle] renderingStarted id=1
HOST  [lifecycle] renderStarted id=1
HOST  [lifecycle] renderingFinished id=1 via=async-pending-render
HOST  [lifecycle] renderingStarted id=2
HOST  [lifecycle] renderingFailed id=2 reason=superseded via=superseded
HOST  [lifecycle] renderingStarted id=3
HOST  [lifecycle] renderingFinished id=3 via=sync-current
HOST  [lifecycle] renderingStarted id=4
HOST  [lifecycle] renderingFinished id=4 via=sync-current
... (ids 5–14: more sync-current closes from the resize storm) ...
HOST  [lifecycle] renderingStarted id=15
HOST  [lifecycle] renderingFinished id=15 via=safety-net
```

Interpretation:

- **id=1**: full reload + render → `async-pending-render` close from vega-embed's onRenderingFinished. The old `HOST Rendering event finished.` line is **gone** (app.tsx's direct call removed).
- **id=2**: render-path update displaced by id=3 before it could close → `superseded`.
- **ids 3–14**: resize updates that resolved to `skip` → U8's sync-current closes.
- **id=15**: property change that routed through `handleNormalFinalise` but ended up on Vega's incremental-update path (`view.data()`), which doesn't fire vega-embed's onRenderingFinished. Safety-net at 10s catches it as the deterministic backstop. **This is the U10 case.**

Every host emission balanced. No orphan starts. No double terminals.

## Verification

- [x] 32/32 coordinator tests pass (3 new for `bindPendingRenderCurrent`).
- [x] `npx tsc --noEmit -p tsconfig.webpack.json` clean.
- [x] `npx prettier --config .prettierrc --check src/` clean.
- [x] Webpack dev build clean from a fresh `.tmp/`.
- [x] `grep eventService.rendering(Started|Finished|Failed)` across the repo: zero production call sites outside the coordinator.
- [x] Full repo vitest: 1353/1380 — same 27 pre-existing failures in `packages/vega-react/__tests__/*` (reproduce on unmodified `next`), no U9 regressions.
- [x] Manual smoke test above confirms async attribution + safety-net behaviour.

## Reviewer focus

- **`bindPendingRenderCurrent()` as a no-arg variant** — the deviation from the plan's literal `bindPendingRender(id)`. Rationale: keeps the dispatch handlers simple and matches the existing `closeCurrent` / `closePendingRender` pattern. Detailed in the commit message and the JSDoc on `RenderingLifecycleCoordinator.bindPendingRenderCurrent`.
- **`SAFETY_NET_BOUND_MS = 10_000`** is a cert constraint, not a tuning choice.
- **The incremental-update orphan path** — id=15 in the smoke trace. Acknowledged as U10's territory; the safety-net is doing its designed job here, not papering over a defect.

## Commits

1. `f52eaa45` feat(visual): async close attribution + arm safety-net + route app.tsx through coordinator (U9)
2. `0ad5ef56` fix(u9): cap safety-net bound at 10s (Power BI cert ceiling) and document remaining orphan path

## Follow-up to

- [b839d0f9](https://github.com/deneb-viz/deneb/commit/b839d0f9) U8 (synchronous closes on non-rendering dispatch paths, [#678](https://github.com/deneb-viz/deneb/pull/678))
- [a1e7a193](https://github.com/deneb-viz/deneb/commit/a1e7a193) U7 (rendering lifecycle coordinator, [#677](https://github.com/deneb-viz/deneb/pull/677))
- [18e8361b](https://github.com/deneb-viz/deneb/commit/18e8361b) U5 (read-mode property-migration gate, [#675](https://github.com/deneb-viz/deneb/pull/675))
- [4332b102](https://github.com/deneb-viz/deneb/commit/4332b102) Phase A (resolveDataset dispatcher refactor, [#674](https://github.com/deneb-viz/deneb/pull/674))

## Next

- **U10**: route `performIncrementalUpdate`'s `onSuccess` / `onFailure` callbacks through the coordinator's `*PendingRender` adapters. After U10, the incremental-update path closes via `async-pending-render` (like full re-embed) and the safety-net becomes a true-orphan-only backstop.
- **U11**: dev-overlay start-vs-close tally with failure-reason surfacing from the coordinator's `RenderingLifecycleObserver` stream. Will reveal whether any other legitimate path drifts close to the 10s bound.