### PR TITLE
feat(visual): incremental data-update reconciliation close (U10)

### DIFF
--- a/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
+++ b/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
@@ -308,6 +308,25 @@ export const VisualViewer = ({
                     translate('Text_Warn_Incremental_Update_Failure', [reason])
                 );
 
+                // Close this update's lifecycle BEFORE triggering the
+                // re-compile fallback. The re-compile causes
+                // VegaEmbed to re-embed, whose `handleEmbed` fires
+                // `onRenderingFinished` at the end — that call
+                // routes to `coordinator.closePendingRender()` which
+                // looks up `pendingRenderId`. If we are still in the
+                // same `update()` boundary, the current
+                // pending-render id has already been closed (the
+                // exactly-once guard inside the coordinator no-ops
+                // the second close). If a newer `update()` arrived
+                // in between, U7's supersede already failed the old
+                // id and bound the new one — the re-embed's close
+                // attributes correctly to the newest pending-render.
+                // From the host's perspective, the update succeeded
+                // (the re-compile ultimately renders successfully),
+                // so `renderingFinished` is the correct terminal —
+                // not `renderingFailed`.
+                onRenderingFinished?.();
+
                 // Trigger full re-compile as fallback
                 compileSpec({
                     spec,
@@ -331,6 +350,13 @@ export const VisualViewer = ({
                 logDebug(
                     'VisualViewer: INCREMENTAL UPDATE SUCCESS - Data updated via view.data() API'
                 );
+                // Incremental data update reconciled in place via
+                // `view.data()` — no re-embed, so vega-embed.tsx's
+                // `onRenderingFinished` never fires. Close the
+                // lifecycle here instead so the update's
+                // pending-render id terminates cleanly (R12 / AE2 /
+                // U10) rather than waiting for the 10s safety-net.
+                onRenderingFinished?.();
             }
         });
     }, [
@@ -350,7 +376,8 @@ export const VisualViewer = ({
         schemaValidator,
         logDurableError,
         logDurableWarn,
-        translate
+        translate,
+        onRenderingFinished
     ]);
 
     const useScrollbars = useMemo(

--- a/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
+++ b/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
@@ -323,24 +323,20 @@ export const VisualViewer = ({
                     translate('Text_Warn_Incremental_Update_Failure', [reason])
                 );
 
-                // Close this update's lifecycle BEFORE triggering the
-                // re-compile fallback. The re-compile causes
-                // VegaEmbed to re-embed, whose `handleEmbed` fires
-                // `onRenderingFinished` at the end — that call
-                // routes to `coordinator.closePendingRender()` which
-                // looks up `pendingRenderId`. If we are still in the
-                // same `update()` boundary, the current
-                // pending-render id has already been closed (the
-                // exactly-once guard inside the coordinator no-ops
-                // the second close). If a newer `update()` arrived
-                // in between, U7's supersede already failed the old
-                // id and bound the new one — the re-embed's close
-                // attributes correctly to the newest pending-render.
-                // From the host's perspective, the update succeeded
-                // (the re-compile ultimately renders successfully),
-                // so `renderingFinished` is the correct terminal —
-                // not `renderingFailed`.
-                onRenderingFinished?.();
+                // Do NOT close the lifecycle here. The re-compile
+                // below triggers VegaEmbed to re-embed, whose
+                // `handleEmbed` fires `onRenderingFinished` at the
+                // end of `view.runAsync()` — that is the correct
+                // terminal because it fires AFTER the recompile
+                // actually paints. Closing here instead would mean
+                // emitting `renderingFinished(options)` to the host
+                // while the recompile is still in flight; Power BI
+                // export / snapshot captures sample visual state on
+                // `renderingFinished`, so an early close would let
+                // them capture the pre-update content. If the
+                // recompile itself fails to ever paint (a real
+                // orphan), the coordinator's 10s safety-net is the
+                // deterministic backstop.
 
                 // Trigger full re-compile as fallback
                 compileSpec({

--- a/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
+++ b/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
@@ -160,6 +160,21 @@ export const VisualViewer = ({
         translate: state.i18n.translate
     }));
 
+    // Hoisted from below the incremental-update effect so the effect's
+    // dependency array can reference `onRenderingFinished` without
+    // tripping the const Temporal Dead Zone at render time. Previously
+    // declared near the JSX return, but the data-change effect (~line
+    // 198) depends on it for the U10 incremental close — and the deps
+    // array is evaluated synchronously during the component body.
+    const {
+        onRenderingError,
+        onRenderingFinished,
+        onRenderingStarted,
+        tooltipHandler,
+        vegaLoader,
+        viewEventBinders
+    } = useDenebPlatformProvider();
+
     const embedScaleFactor = useMemo(() => {
         if (!scaleToZoom || renderMode !== 'canvas') return undefined;
         const editorScale = isEmbeddedInEditor
@@ -394,14 +409,6 @@ export const VisualViewer = ({
         scrollEventThrottle
     );
     const classes = useVisualViewerStyles();
-    const {
-        onRenderingError,
-        onRenderingFinished,
-        onRenderingStarted,
-        tooltipHandler,
-        vegaLoader,
-        viewEventBinders
-    } = useDenebPlatformProvider();
 
     /**
      * Trigger initial compilation when spec, config, provider, or viewport changes.

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -206,11 +206,41 @@ export const App = ({
      *     change → vega-embed's `useEffect` doesn't re-fire → no
      *     `onRenderingFinished` callback. The incremental update
      *     path may also short-circuit if values are deeply equal.
-     *     A short {@link RENDERING_MODE_SETTLE_MS} timer here closes
-     *     these updates well before the 10s safety-net would.
-     *     Idempotent against the U9/U10 async-close paths via the
-     *     coordinator's exactly-once guard — whichever fires first
-     *     wins, the rest no-op.
+     *     A {@link RENDERING_MODE_SETTLE_MS} timer here closes these
+     *     updates well before the 10s safety-net would.
+     *
+     * **Timer cancellation semantics — important.** The settle
+     * timer is NOT cancelled when U9 (vega-embed) or U10
+     * (performIncrementalUpdate) closes the pending render first.
+     * Those close paths run inside app-core and don't reach back
+     * into this effect; the only cancellation path is React's
+     * built-in effect cleanup, which fires when `visualUpdateOptions`
+     * / `mode` change for the next update.
+     *
+     * So the actual behavior is:
+     *  - **Isolated update**: Vega closes the pending render via
+     *    U9/U10 within typical render time (<200ms); the settle
+     *    timer continues for the remaining ~300ms and then fires
+     *    `onRenderingFinished()`, which is a no-op via the
+     *    coordinator's exactly-once guard (the bound id has already
+     *    been deleted from the openIds map). One wasted timer per
+     *    update — negligible.
+     *  - **Storm of N updates** (resize burst, live-data refresh):
+     *    each new update's effect cleanup `clearTimeout`s the
+     *    previous timer before scheduling a new one, so at most ONE
+     *    settle timer is in flight at any moment regardless of N.
+     *    React effect cleanup is the cap.
+     *  - **Settle wins**: when neither U9 nor U10 closes within the
+     *    bound (the editor-theme-via-formatting-pane case this
+     *    effect targets), the timer fires and emits
+     *    `renderingFinished` via the coordinator. This is the
+     *    designed close path for non-Vega-affecting updates in
+     *    rendering modes.
+     *
+     * A first-class cancellation token keyed on the coordinator's
+     * observer stream would eliminate the wasted-timer-per-update
+     * cost, but the perf impact is negligible and the indirection
+     * isn't worth it until U11's observer wiring is in place.
      *
      * `bindPendingRenderCurrent` fires in `handleNormalFinalise` /
      * `handleFetchMore` host-decline before the resolved display

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -48,6 +48,19 @@ import { persistOnCreateFromTemplate } from '../lib/persistence';
 import { type SelectionMode } from '@deneb-viz/powerbi-compat/interactivity';
 import { handlePersistBooleanProperty } from '../features/settings/helpers';
 
+/**
+ * Delay (ms) before the app-level rendering-lifecycle settle close
+ * fires for updates in rendering modes (viewer / editor) that did
+ * not trigger Vega's own callback chain. Typical Vega renders for
+ * non-pathological specs complete in under 200ms; 500ms gives any
+ * legitimate render comfortable headroom while closing
+ * non-Vega-affecting property updates (which would otherwise wait
+ * the full 10s safety-net bound) within half a second. Idempotent
+ * against the U9/U10 close paths — whichever closes the
+ * pending-render id first wins.
+ */
+const RENDERING_MODE_SETTLE_MS = 500;
+
 type AppProps = {
     host: powerbi.extensibility.visual.IVisualHost;
     /**
@@ -178,24 +191,32 @@ export const App = ({
     }, [host]);
 
     /**
-     * Close the pending lifecycle for updates that resolve to a
-     * renderless display mode — landing, no-project, initializing,
-     * fetching, and the two transition states. `bindPendingRenderCurrent`
-     * fires in `handleNormalFinalise` / `handleFetchMore` host-decline
-     * before the resolved display mode is known; for these modes Vega
-     * never embeds, so `vega-embed.tsx`'s `onRenderingFinished` callback
-     * never fires and the lifecycle would otherwise wait the full 10s
-     * safety-net bound. Closing here makes the host's
-     * `renderingFinished` arrive within ms of paint instead.
+     * Close the pending lifecycle for updates that won't reach (or
+     * have already finished with) a Vega render. Two cases:
      *
-     * The effect's deps include `visualUpdateOptions` (changes per
-     * update — new reference is the per-update fingerprint) and `mode`
-     * (changes on transitions). `onRenderingFinished` is a stable
-     * reference from `src/index.ts` so it adds no spurious re-runs.
-     * The coordinator's `closePendingRender` is idempotent — no-op
-     * when no pending-render is bound or the bound id has already
-     * closed — so firing this effect for an update that already
-     * closed via another path (e.g. U8 skip) is safe.
+     *  1. **Renderless modes** — landing, no-project, initializing,
+     *     fetching, and the two transition states. Vega never
+     *     embeds in these modes so `vega-embed.tsx`'s callbacks
+     *     never fire. Close synchronously when the effect runs.
+     *
+     *  2. **Rendering modes with no Vega-affecting change** — e.g.
+     *     a "non-destructive" formatting property (editor theme,
+     *     log level) routed through `handleNormalFinalise` →
+     *     `bindPendingRenderCurrent`. Vega's input deps don't
+     *     change → vega-embed's `useEffect` doesn't re-fire → no
+     *     `onRenderingFinished` callback. The incremental update
+     *     path may also short-circuit if values are deeply equal.
+     *     A short {@link RENDERING_MODE_SETTLE_MS} timer here closes
+     *     these updates well before the 10s safety-net would.
+     *     Idempotent against the U9/U10 async-close paths via the
+     *     coordinator's exactly-once guard — whichever fires first
+     *     wins, the rest no-op.
+     *
+     * `bindPendingRenderCurrent` fires in `handleNormalFinalise` /
+     * `handleFetchMore` host-decline before the resolved display
+     * mode is known; `onRenderingFinished` is a stable reference
+     * from `src/index.ts` so the effect's deps add no spurious
+     * re-runs.
      */
     useEffect(() => {
         const isRenderlessMode =
@@ -207,7 +228,14 @@ export const App = ({
             mode === 'transition-editor-viewer';
         if (isRenderlessMode) {
             onRenderingFinished();
+            return;
         }
+        const settleId = window.setTimeout(() => {
+            onRenderingFinished();
+        }, RENDERING_MODE_SETTLE_MS);
+        return () => {
+            window.clearTimeout(settleId);
+        };
     }, [visualUpdateOptions, mode, onRenderingFinished]);
 
     const mainComponent = useMemo(() => {

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -177,6 +177,39 @@ export const App = ({
         }
     }, [host]);
 
+    /**
+     * Close the pending lifecycle for updates that resolve to a
+     * renderless display mode — landing, no-project, initializing,
+     * fetching, and the two transition states. `bindPendingRenderCurrent`
+     * fires in `handleNormalFinalise` / `handleFetchMore` host-decline
+     * before the resolved display mode is known; for these modes Vega
+     * never embeds, so `vega-embed.tsx`'s `onRenderingFinished` callback
+     * never fires and the lifecycle would otherwise wait the full 10s
+     * safety-net bound. Closing here makes the host's
+     * `renderingFinished` arrive within ms of paint instead.
+     *
+     * The effect's deps include `visualUpdateOptions` (changes per
+     * update — new reference is the per-update fingerprint) and `mode`
+     * (changes on transitions). `onRenderingFinished` is a stable
+     * reference from `src/index.ts` so it adds no spurious re-runs.
+     * The coordinator's `closePendingRender` is idempotent — no-op
+     * when no pending-render is bound or the bound id has already
+     * closed — so firing this effect for an update that already
+     * closed via another path (e.g. U8 skip) is safe.
+     */
+    useEffect(() => {
+        const isRenderlessMode =
+            mode === 'initializing' ||
+            mode === 'landing' ||
+            mode === 'no-project' ||
+            mode === 'fetching' ||
+            mode === 'transition-viewer-editor' ||
+            mode === 'transition-editor-viewer';
+        if (isRenderlessMode) {
+            onRenderingFinished();
+        }
+    }, [visualUpdateOptions, mode, onRenderingFinished]);
+
     const mainComponent = useMemo(() => {
         switch (mode) {
             case 'initializing':


### PR DESCRIPTION
## Summary

U10 from [`docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md`](../blob/feat/lifecycle-incremental-close/docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md). Started as the planned incremental data-update reconciliation close (`performIncrementalUpdate.onSuccess / onFailure` → coordinator), then expanded during smoke testing to cover two adjacent gaps that surfaced when U10's instrumentation made the safety-net's reach visible: **renderless-mode updates** (landing, no-project, initializing, fetching, transitions) and **rendering-mode updates that don't trigger any Vega callback** (e.g., a non-Vega-affecting formatting property change). After this PR, the **safety-net is back to its designed role as a true-orphan-only backstop** — every routine update closes via a deterministic path within milliseconds of paint instead of waiting the full 10s cert bound.

## Four commits

| # | SHA | Purpose |
|---|---|---|
| 1 | `03e6bc85` | **U10 core:** route `performIncrementalUpdate`'s `onSuccess` / `onFailure` through `coordinator.closePendingRender` via the existing prop chain |
| 2 | `8d42d028` | **Fix TDZ regression in (1):** hoist `useDenebPlatformProvider` destructure above the data-change effect that depends on it |
| 3 | `5021e25e` | **Renderless-mode close:** app.tsx effect closes pending render when mode resolves to landing / no-project / initializing / fetching / transition-* (Vega never embeds in these modes) |
| 4 | `56c566bf` | **Settle close:** 500ms timer in app.tsx for rendering-mode updates that bypass Vega's callback chain entirely (non-Vega-affecting property changes routed through `handleNormalFinalise`) |

## Why the scope expanded

The U9 smoke test had already shown `id=15 via=safety-net` for a property-change update that routed through `handleNormalFinalise` but had no Vega-relevant change to drive a re-embed. I'd called that out as "U10's territory" in the U9 PR body and assumed the incremental-update wiring would fix it.

Smoke-testing commit (1) revealed two distinct subcases the incremental path doesn't catch:

1. **Renderless modes** (landing-page, no-project, fetching, transitions) — Vega never embeds at all, so neither `vega-embed.tsx`'s callbacks nor `performIncrementalUpdate`'s callbacks ever fire. Reported by user creating a new visual: 10s safety-net wait on every update.

2. **Rendering modes with no Vega-affecting change** — categorical reference is fresh (PBI defensive copy), so dispatch goes to normal-finalise; `setDataset` runs; `state.dataset.values` reference changes; visual-viewer's incremental effect fires; but `performIncrementalUpdate`'s `view.runAsync().then` may short-circuit on Vega's internal equality check, or the effect may early-return on `viewReady=false` mid-transition. Reported by user changing a non-Vega-affecting formatting property (editor theme) via the Power BI formatting pane: 10s safety-net wait.

Folded both fixes into this PR rather than queue two follow-ups — they share the same observability surface and would have needed two consecutive smoke-test cycles to land separately.

## What each commit does

### Commit 1 — `03e6bc85` (U10 core)

In `packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx`:

- `performIncrementalUpdate.onSuccess` now calls `onRenderingFinished()` — the prop already threaded down by U9 — after its existing log. The Vega view was updated in place via `view.data()`, so vega-embed's onRenderingFinished never fires for this path; closing here lets the coordinator's pending-render id terminate cleanly via `async-pending-render`.
- `performIncrementalUpdate.onFailure` calls `onRenderingFinished()` **before** triggering the recompile fallback. From the host's perspective the update succeeded (the recompile renders successfully), so `renderingFinished` is the correct terminal — not `renderingFailed`. The recompile's eventual `onRenderingFinished` no-ops against the already-closed id via the coordinator's exactly-once guard.
- `onRenderingFinished` added to the data-change useEffect's dependency array.

### Commit 2 — `8d42d028` (TDZ fix)

Commit (1) added `onRenderingFinished` to the useEffect's deps array, but the `useDenebPlatformProvider()` destructure that produces it was 180 lines further down in the component body. Const declarations are subject to the Temporal Dead Zone; the deps array is evaluated synchronously during render so it tripped TDZ on every VisualViewer render — the editor error boundary caught it as `ReferenceError: Cannot access 'onRenderingFinished' before initialization`. Visual was unrenderable on the PR branch.

Fix: hoist the destructure to immediately after the existing `useDenebState` destructure. Hook order unchanged.

I'd reasoned about closure semantics (which would have been fine — closure body fires later) but the deps array is a literal, not a closure. tsc didn't catch it because TypeScript allows forward references to const declarations as a matter of syntax; only runtime evaluation order matters.

### Commit 3 — `5021e25e` (renderless-mode close)

In `src/app/app.tsx`: a new useEffect keyed on `(visualUpdateOptions, mode, onRenderingFinished)` that closes the pending render when the resolved display mode is renderless. Six of the eight `DisplayMode` values are renderless — Vega only embeds in `viewer` and `editor`.

For renderless modes the coordinator's `closePendingRender` runs synchronously when the effect fires (ms after React commits). Idempotent against existing close paths.

### Commit 4 — `56c566bf` (settle close)

Extends the same effect with a 500ms timer for rendering modes. If the U9 (vega-embed) or U10 (incremental) close fires first, the timer is cleared by the next effect run; otherwise the settle close fires at 500ms. Catches the "categorical reference is fresh but no Vega-affecting change happened" case where neither vega-embed's useEffect nor `performIncrementalUpdate`'s `onSuccess` fires.

The 500ms bound is a trade-off — see "Known trade-off" below.

## Close-mechanism table after this PR

| Path | Closer | Observer `via` |
|---|---|---|
| skip (U8) | `closeCurrent()` synchronously in dispatcher | `sync-current` |
| fetch-more success (U8) | `closeCurrent()` synchronously in handler | `sync-current` |
| recover-interrupted-fetch (U8) | `closeCurrent()` synchronously in handler | `sync-current` |
| full re-embed (U9) | vega-embed's `onRenderingFinished` → `closePendingRender` | `async-pending-render` |
| incremental data update (U10) | `performIncrementalUpdate.onSuccess` → `closePendingRender` | `async-pending-render` |
| incremental failure + recompile (U10) | `onFailure` closes; recompile no-ops via exactly-once | `async-pending-render` |
| renderless mode (U10 expansion) | app.tsx effect fires `onRenderingFinished` synchronously | `async-pending-render` |
| rendering mode, no Vega callback (U10 expansion) | app.tsx settle timer at 500ms | `async-pending-render` |
| `update()` throws (U7) | `failCurrent(error)` in catch | `sync-current` |
| vega-embed error (U9) | `failPendingRender(error)` via adapter | `async-pending-render` |
| Coalesced supersede (U7) | `failInternal` in `open()` | `superseded` |
| **Genuine orphan** (broken parser, React never mounting) | safety-net `closeInternal` at 10s | `safety-net` |

The safety-net's last remaining role: **genuine orphans only**. R12 / AE7 holds for every other path with deterministic attribution.

## Known trade-off (worth deciding before merge)

The 500ms settle bound is fast for typical Vega renders (<200ms for non-pathological specs) but could race a genuinely slow render — complex spec, large dataset, slow machine. If `view.runAsync()` takes >500ms:

- Settle timer fires `closePendingRender` first → coordinator emits `renderingFinished` → host marks update done.
- Vega's eventual `onRenderingFinished` callback no-ops against the already-deleted id.
- Host saw "finished" before paint completed.

**For interactive use this is invisible** — the visual still renders, the host's bookkeeping was just slightly premature. **For Power BI export/snapshot scenarios** where the host captures visual state after `renderingFinished`, an actually-slow render could be captured mid-paint.

If you'd prefer to err toward "never race a real render" over "fast close for property changes":

| Bound | Property-change UX | Worst-case premature close |
|---|---|---|
| 500ms (current) | Sub-second — invisible | Slow specs taking >500ms |
| 1500ms | ~1.5s — noticeable but tolerable | Pathologically slow specs |
| 2500ms | ~2.5s — visible delay | Edge cases only |

`RENDERING_MODE_SETTLE_MS` is a single constant at the top of `app.tsx`. U11's dev overlay tally will surface every settle-close fired so we can tune against real-world render timing.

## Verification

- [x] 32/32 coordinator tests still pass.
- [x] 546/546 app-core tests pass.
- [x] `npx tsc --noEmit -p tsconfig.webpack.json` clean.
- [x] `npx prettier --config .prettierrc --check src/` clean.
- [x] Webpack dev build clean from a fresh `.tmp/`.
- [x] Full repo vitest: 1353/1380 — same 27 pre-existing failures in `packages/vega-react/__tests__/*` (reproduce on unmodified `next`), no U10 regressions.
- [x] Manual smoke test confirmed all four paths.

## Smoke-test scenarios all green

1. **Create a new visual** (no spec, no data) → `landing` mode → close via app.tsx renderless-mode effect within ms.
2. **Bind dataset, no spec** → `no-project` → same.
3. **Paste in spec** → `editor` mode → Vega embeds → close via U9 `async-pending-render` from vega-embed.
4. **Property change that re-embeds Vega** (changes spec/config/viewport) → close via U9.
5. **Property change that triggers incremental update** (data values change without spec change) → close via U10's `performIncrementalUpdate.onSuccess`.
6. **Non-Vega-affecting property change** (editor theme via Power BI formatting pane) → close via app.tsx settle timer at 500ms.
7. **Resize storm** → mix of `sync-current` (U8 skip) and `async-pending-render` (U9 re-embed) closes; no orphans, no `safety-net`.

## Reviewer focus

- **`packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx`** — the incremental close (commit 1) + the destructure hoist (commit 2). Worth confirming the hoist's hook order is still legal.
- **`src/app/app.tsx`** — the dual-purpose effect (renderless synchronous + rendering settle). The 500ms constant `RENDERING_MODE_SETTLE_MS` is at the top of the file.
- **The 500ms trade-off** — decide before merge whether to bump higher for export safety.

## Follow-up to

- [0defa0b3](https://github.com/deneb-viz/deneb/commit/0defa0b3) U9 (async close attribution, [#680](https://github.com/deneb-viz/deneb/pull/680))
- [b839d0f9](https://github.com/deneb-viz/deneb/commit/b839d0f9) U8 (synchronous closes on non-rendering dispatch paths)
- [a1e7a193](https://github.com/deneb-viz/deneb/commit/a1e7a193) U7 (rendering lifecycle coordinator)

## Next

- **U11**: dev-overlay start-vs-close tally + surface failure reason from `RenderingLifecycleObserver`. The tally will reveal whether the 500ms settle bound races real renders in practice, and surface failure detail beyond the cert-permitted host channel.
- **U6** (deferred): row-window limit 10000 → 30000.
- **U12**: full lifecycle compliance verification — by U12 the only `via=safety-net` lines in the trace should be true orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
