### PR TITLE
feat(visual): dev-overlay start-vs-close tally + failure-reason surfacing (U11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,10 @@ packages/configuration/src/generated.ts
 # Compound engineering
 .context/
 
+# Repowise local update-queue marker (regenerated on every commit by
+# the local repowise hook; not project-relevant)
+.repowise/
+
 # Windows Shell Cache (created when dev server accesses icon files)
 # This folder is created because Node.js/PowerShell doesn't expand %SystemDrive%
 # properly when Windows Shell creates icon/thumbnail cache during pbiviz:start

--- a/.repowise/.update.queued
+++ b/.repowise/.update.queued
@@ -1,0 +1,1 @@
+{"target_commit":"bfcb228b91bb15b5507bd3bf4c5263c84a913fba","queued_at":1780874044}

--- a/.repowise/.update.queued
+++ b/.repowise/.update.queued
@@ -1,1 +1,0 @@
-{"target_commit":"bfcb228b91bb15b5507bd3bf4c5263c84a913fba","queued_at":1780874044}

--- a/src/features/dev-overlay-shell/components/dev-overlay-shell.tsx
+++ b/src/features/dev-overlay-shell/components/dev-overlay-shell.tsx
@@ -1,0 +1,142 @@
+import { useState, type CSSProperties, type ReactNode } from 'react';
+
+/**
+ * Where the overlay anchors against the visual surface. Both
+ * supported positions are corner-anchored — the visual canvas only
+ * has so many corners and overlays are dev-only HUDs, so this is
+ * sufficient.
+ */
+export type DevOverlayPosition = 'top-left' | 'top-right';
+
+export type DevOverlayShellProps = {
+    /** Header label shown in the title bar. */
+    title: string;
+    position: DevOverlayPosition;
+    /**
+     * Maximum width (px) when expanded. The shell will not exceed
+     * this width; content beyond wraps or scrolls horizontally
+     * depending on its own styling.
+     */
+    maxWidth?: number;
+    /**
+     * Maximum height (px) for the expanded body. Content beyond this
+     * scrolls vertically. The title bar is excluded from this
+     * measurement.
+     */
+    maxHeight?: number;
+    /** Optional initial collapsed state (default: false). */
+    initiallyCollapsed?: boolean;
+    children: ReactNode;
+};
+
+const PALETTE = {
+    background: 'rgba(0, 0, 0, 0.78)',
+    foreground: '#fff',
+    border: 'rgba(255, 255, 255, 0.2)'
+};
+
+const FONT_FAMILY =
+    'Consolas, "Courier New", Menlo, monospace, ui-monospace, SFMono-Regular';
+
+const TITLE_BAR_HEIGHT = 22;
+
+/**
+ * Shared shell for dev-only HUD overlays. Provides:
+ *
+ *  - **Consistent positioning** — corner-anchored with a fixed
+ *    8px inset.
+ *  - **Consistent styling** — dark translucent background, monospace
+ *    typography, subtle border.
+ *  - **Minimize / restore** — a button in the top-right of the title
+ *    bar collapses the panel to just the bar; clicking again
+ *    expands it. State is component-local (resets on visual reload),
+ *    which is fine for dev tooling.
+ *  - **Scroll on overflow** — when expanded, the body region honours
+ *    a `maxHeight` and scrolls vertically beyond it.
+ *
+ * Used by both {@link VisualUpdateHistoryOverlay} (lifecycle + history
+ * + failures, top-left) and {@link ViewportGateDebugOverlay}
+ * (viewport-match debug, top-right).
+ */
+export const DevOverlayShell = ({
+    title,
+    position,
+    maxWidth,
+    maxHeight,
+    initiallyCollapsed = false,
+    children
+}: DevOverlayShellProps) => {
+    const [collapsed, setCollapsed] = useState(initiallyCollapsed);
+
+    const positionStyle: CSSProperties =
+        position === 'top-left' ? { top: 8, left: 8 } : { top: 8, right: 8 };
+
+    const shellStyle: CSSProperties = {
+        position: 'fixed',
+        ...positionStyle,
+        backgroundColor: PALETTE.background,
+        color: PALETTE.foreground,
+        fontFamily: FONT_FAMILY,
+        fontSize: '11px',
+        lineHeight: 1.35,
+        border: `1px solid ${PALETTE.border}`,
+        borderRadius: 4,
+        zIndex: 999999,
+        maxWidth,
+        pointerEvents: 'auto',
+        userSelect: 'none',
+        overflow: 'hidden'
+    };
+
+    const titleBarStyle: CSSProperties = {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '2px 6px',
+        height: TITLE_BAR_HEIGHT,
+        boxSizing: 'border-box',
+        fontWeight: 600,
+        borderBottom: collapsed ? 'none' : `1px solid ${PALETTE.border}`,
+        cursor: 'default'
+    };
+
+    const buttonStyle: CSSProperties = {
+        background: 'transparent',
+        color: 'inherit',
+        border: 'none',
+        cursor: 'pointer',
+        fontFamily: 'inherit',
+        fontSize: '14px',
+        lineHeight: 1,
+        padding: '0 4px',
+        marginLeft: 6
+    };
+
+    const bodyStyle: CSSProperties = {
+        padding: '6px 8px',
+        maxHeight,
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        whiteSpace: 'pre-wrap'
+    };
+
+    return (
+        <div style={shellStyle}>
+            <div style={titleBarStyle}>
+                <span>{title}</span>
+                <button
+                    type='button'
+                    style={buttonStyle}
+                    onClick={() => setCollapsed((current) => !current)}
+                    title={collapsed ? 'Restore' : 'Minimize'}
+                    aria-label={
+                        collapsed ? 'Restore overlay' : 'Minimize overlay'
+                    }
+                >
+                    {collapsed ? '+' : '−'}
+                </button>
+            </div>
+            {!collapsed && <div style={bodyStyle}>{children}</div>}
+        </div>
+    );
+};

--- a/src/features/dev-overlay-shell/components/dev-overlay-shell.tsx
+++ b/src/features/dev-overlay-shell/components/dev-overlay-shell.tsx
@@ -156,3 +156,63 @@ export const DevOverlayShell = ({
         </div>
     );
 };
+
+// ─── CollapsibleSection ──────────────────────────────────────────────────────
+
+export type CollapsibleSectionProps = {
+    /** Header label. */
+    title: string;
+    /** Default collapsed state (default: false). */
+    initiallyCollapsed?: boolean;
+    children: ReactNode;
+};
+
+const SECTION_HEADER_STYLE: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    cursor: 'pointer',
+    fontWeight: 600,
+    marginBottom: 4,
+    color: 'rgba(255, 255, 255, 0.7)',
+    userSelect: 'none'
+};
+
+const SECTION_DISCLOSURE_STYLE: CSSProperties = {
+    fontSize: '9px',
+    lineHeight: 1,
+    opacity: 0.6,
+    marginLeft: 6
+};
+
+/**
+ * Single-section disclosure inside a {@link DevOverlayShell}. Click
+ * the header to toggle. Used to keep noisy panels (update history,
+ * verbose state dumps) hidden by default so the developer sees the
+ * compact summary first and expands only when they need detail.
+ * Component-local collapse state — same lifetime semantics as the
+ * shell's minimize state.
+ */
+export const CollapsibleSection = ({
+    title,
+    initiallyCollapsed = false,
+    children
+}: CollapsibleSectionProps) => {
+    const [collapsed, setCollapsed] = useState(initiallyCollapsed);
+    return (
+        <div>
+            <div
+                style={SECTION_HEADER_STYLE}
+                onClick={() => setCollapsed((current) => !current)}
+                role='button'
+                aria-expanded={!collapsed}
+            >
+                <span>{title}</span>
+                <span style={SECTION_DISCLOSURE_STYLE}>
+                    {collapsed ? '▶' : '▼'}
+                </span>
+            </div>
+            {!collapsed && <div>{children}</div>}
+        </div>
+    );
+};

--- a/src/features/dev-overlay-shell/components/dev-overlay-shell.tsx
+++ b/src/features/dev-overlay-shell/components/dev-overlay-shell.tsx
@@ -18,12 +18,6 @@ export type DevOverlayShellProps = {
      * depending on its own styling.
      */
     maxWidth?: number;
-    /**
-     * Maximum height (px) for the expanded body. Content beyond this
-     * scrolls vertically. The title bar is excluded from this
-     * measurement.
-     */
-    maxHeight?: number;
     /** Optional initial collapsed state (default: false). */
     initiallyCollapsed?: boolean;
     children: ReactNode;
@@ -58,22 +52,37 @@ const TITLE_BAR_HEIGHT = 22;
  * + failures, top-left) and {@link ViewportGateDebugOverlay}
  * (viewport-match debug, top-right).
  */
+const INSET_PX = 8;
+
 export const DevOverlayShell = ({
     title,
     position,
     maxWidth,
-    maxHeight,
     initiallyCollapsed = false,
     children
 }: DevOverlayShellProps) => {
     const [collapsed, setCollapsed] = useState(initiallyCollapsed);
 
     const positionStyle: CSSProperties =
-        position === 'top-left' ? { top: 8, left: 8 } : { top: 8, right: 8 };
+        position === 'top-left'
+            ? { top: INSET_PX, left: INSET_PX }
+            : { top: INSET_PX, right: INSET_PX };
 
     const shellStyle: CSSProperties = {
         position: 'fixed',
         ...positionStyle,
+        // Anchor vertical sizing to the iframe viewport. The shell
+        // can grow to its content's natural height, capped at the
+        // visual's available height (minus an 8px inset top and
+        // bottom). When the content exceeds the cap, the body's
+        // overflow-y handles scroll. Critically this means the
+        // scrollbar engages in small visuals too — the previous
+        // fixed `maxHeight={420}` left small visuals with no
+        // scroll because the shell extended past the visible
+        // bottom edge before its own cap kicked in.
+        maxHeight: `calc(100vh - ${INSET_PX * 2}px)`,
+        display: 'flex',
+        flexDirection: 'column',
         backgroundColor: PALETTE.background,
         color: PALETTE.foreground,
         fontFamily: FONT_FAMILY,
@@ -89,6 +98,7 @@ export const DevOverlayShell = ({
     };
 
     const titleBarStyle: CSSProperties = {
+        flex: '0 0 auto',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
@@ -113,8 +123,14 @@ export const DevOverlayShell = ({
     };
 
     const bodyStyle: CSSProperties = {
+        // `flex: 1 1 auto` lets the body fill the remaining shell
+        // height; `minHeight: 0` is the flex-child trick that allows
+        // a child of a flex column to shrink past its content's
+        // intrinsic height — without it `overflow-y: auto` does
+        // nothing because the body refuses to shrink below content.
+        flex: '1 1 auto',
+        minHeight: 0,
         padding: '6px 8px',
-        maxHeight,
         overflowY: 'auto',
         overflowX: 'hidden',
         whiteSpace: 'pre-wrap'

--- a/src/features/dev-overlay-shell/components/dev-overlay-shell.tsx
+++ b/src/features/dev-overlay-shell/components/dev-overlay-shell.tsx
@@ -199,12 +199,24 @@ export const CollapsibleSection = ({
     children
 }: CollapsibleSectionProps) => {
     const [collapsed, setCollapsed] = useState(initiallyCollapsed);
+    const toggle = () => setCollapsed((current) => !current);
     return (
         <div>
             <div
                 style={SECTION_HEADER_STYLE}
-                onClick={() => setCollapsed((current) => !current)}
+                onClick={toggle}
+                // role='button' requires both Tab reachability
+                // (tabIndex={0}) and Enter/Space activation per ARIA
+                // authoring practices. Without these, keyboard users
+                // and screen readers can't toggle the section.
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        toggle();
+                    }
+                }}
                 role='button'
+                tabIndex={0}
                 aria-expanded={!collapsed}
             >
                 <span>{title}</span>

--- a/src/features/dev-overlay-shell/index.ts
+++ b/src/features/dev-overlay-shell/index.ts
@@ -1,0 +1,5 @@
+export {
+    DevOverlayShell,
+    type DevOverlayPosition,
+    type DevOverlayShellProps
+} from './components/dev-overlay-shell';

--- a/src/features/dev-overlay-shell/index.ts
+++ b/src/features/dev-overlay-shell/index.ts
@@ -1,5 +1,7 @@
 export {
+    CollapsibleSection,
     DevOverlayShell,
+    type CollapsibleSectionProps,
     type DevOverlayPosition,
     type DevOverlayShellProps
 } from './components/dev-overlay-shell';

--- a/src/features/viewport-gate-debug-overlay/components/viewport-gate-debug-overlay.tsx
+++ b/src/features/viewport-gate-debug-overlay/components/viewport-gate-debug-overlay.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 
 import { toBoolean } from '@deneb-viz/utils/type-conversion';
 import { useDenebVisualState } from '../../../state';
+import { DevOverlayShell } from '../../dev-overlay-shell';
 
 /**
  * Read-only HUD that surfaces the live values consumed by the
@@ -22,22 +23,11 @@ export const IS_OVERLAY_ENABLED = toBoolean(
 
 const POLL_INTERVAL_MS = 100;
 
-const overlayStyle: React.CSSProperties = {
-    position: 'fixed',
-    top: '8px',
-    right: '8px',
-    zIndex: 999999,
-    backgroundColor: 'rgba(0, 0, 0, 0.78)',
-    color: '#fff',
-    fontFamily:
-        'Consolas, "Courier New", Menlo, monospace, ui-monospace, SFMono-Regular',
+const PRE_STYLE: CSSProperties = {
+    margin: 0,
     fontSize: '11px',
     lineHeight: 1.35,
-    padding: '6px 8px',
-    borderRadius: '4px',
-    pointerEvents: 'none',
-    whiteSpace: 'pre',
-    userSelect: 'none'
+    whiteSpace: 'pre'
 };
 
 const formatNumber = (value: number | undefined): string =>
@@ -96,5 +86,13 @@ export const ViewportGateDebugOverlay = () => {
         `ev.h      ${formatNumber(evh)}    Δ ${formatDelta(ih, evh)}`
     ];
 
-    return <div style={overlayStyle}>{lines.join('\n')}</div>;
+    return (
+        <DevOverlayShell
+            title='viewport gate'
+            position='top-right'
+            maxWidth={240}
+        >
+            <pre style={PRE_STYLE}>{lines.join('\n')}</pre>
+        </DevOverlayShell>
+    );
 };

--- a/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
+++ b/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
@@ -3,6 +3,7 @@ import { useMemo, type CSSProperties } from 'react';
 import { toBoolean } from '@deneb-viz/utils/type-conversion';
 import { useDenebVisualState } from '../../../state';
 import { CollapsibleSection, DevOverlayShell } from '../../dev-overlay-shell';
+import { type RenderingLifecycleEvent } from '../../../lib/rendering-lifecycle';
 import { computeLifecycleTally } from '../lib/compute-tally';
 
 const IS_OVERLAY_ENABLED = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
@@ -70,7 +71,14 @@ export const VisualUpdateHistoryOverlay = () => {
     const recentFailures = useMemo(
         () =>
             lifecycleEvents
-                .filter((event) => event.kind === 'failed')
+                .filter(
+                    (
+                        event
+                    ): event is Extract<
+                        RenderingLifecycleEvent,
+                        { kind: 'failed' }
+                    > => event.kind === 'failed'
+                )
                 .slice(-6),
         [lifecycleEvents]
     );
@@ -111,18 +119,14 @@ export const VisualUpdateHistoryOverlay = () => {
                 <>
                     <hr style={HR_STYLE} />
                     <div style={SECTION_HEADING_STYLE}>recent failures</div>
-                    {recentFailures.map((event, index) => {
-                        if (event.kind !== 'failed') return null;
-                        return (
-                            <div
-                                key={`${event.id}-${index}`}
-                                style={FAILURE_LINE_STYLE}
-                            >
-                                id={event.id} via={event.via} reason=
-                                {event.reason}
-                            </div>
-                        );
-                    })}
+                    {recentFailures.map((event, index) => (
+                        <div
+                            key={`${event.id}-${index}`}
+                            style={FAILURE_LINE_STYLE}
+                        >
+                            id={event.id} via={event.via} reason={event.reason}
+                        </div>
+                    ))}
                 </>
             )}
 

--- a/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
+++ b/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
@@ -2,7 +2,7 @@ import { useMemo, type CSSProperties } from 'react';
 
 import { toBoolean } from '@deneb-viz/utils/type-conversion';
 import { useDenebVisualState } from '../../../state';
-import { DevOverlayShell } from '../../dev-overlay-shell';
+import { CollapsibleSection, DevOverlayShell } from '../../dev-overlay-shell';
 import { computeLifecycleTally } from '../lib/compute-tally';
 
 const IS_OVERLAY_ENABLED = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
@@ -127,10 +127,11 @@ export const VisualUpdateHistoryOverlay = () => {
             )}
 
             <hr style={HR_STYLE} />
-            <div style={SECTION_HEADING_STYLE}>update history</div>
-            <pre style={HISTORY_PRE_STYLE}>
-                {JSON.stringify(history, null, 2)}
-            </pre>
+            <CollapsibleSection title='update history' initiallyCollapsed>
+                <pre style={HISTORY_PRE_STYLE}>
+                    {JSON.stringify(history, null, 2)}
+                </pre>
+            </CollapsibleSection>
         </DevOverlayShell>
     );
 };

--- a/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
+++ b/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
@@ -1,30 +1,152 @@
+import { useMemo } from 'react';
+
 import { toBoolean } from '@deneb-viz/utils/type-conversion';
 import { useDenebVisualState } from '../../../state';
+import { computeLifecycleTally } from '../lib/compute-tally';
 
 const IS_OVERLAY_ENABLED = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
 
+const PANEL_BASE_STYLE: React.CSSProperties = {
+    position: 'absolute',
+    backgroundColor: 'rgba(0, 0, 0, 0.65)',
+    color: 'white',
+    fontFamily: 'Consolas, monospace',
+    fontSize: '11px',
+    lineHeight: 1.3,
+    padding: '6px 8px',
+    border: '1px solid rgba(255, 255, 255, 0.2)',
+    zIndex: 9999,
+    pointerEvents: 'auto'
+};
+
+const TALLY_PANEL_STYLE: React.CSSProperties = {
+    ...PANEL_BASE_STYLE,
+    top: '0',
+    left: '0',
+    minWidth: '240px',
+    whiteSpace: 'pre',
+    display: 'block'
+};
+
+const FAILURES_PANEL_STYLE: React.CSSProperties = {
+    ...PANEL_BASE_STYLE,
+    top: '0',
+    left: '260px',
+    maxWidth: '420px',
+    maxHeight: '160px',
+    overflowY: 'auto',
+    color: 'rgba(255, 200, 120, 0.95)',
+    display: 'block'
+};
+
+const HISTORY_TEXTAREA_STYLE: React.CSSProperties = {
+    position: 'absolute',
+    top: '170px',
+    left: '0',
+    width: '20px',
+    height: '20px',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    color: 'white',
+    zIndex: 9999,
+    display: 'block'
+};
+
 /**
- * Provides a simple textarea that we can view the visual update history from the store. Is intended for debugging
- * status changes based on the update options from the Power BI visual host.
+ * Dev-only HUD for the visual's rendering-lifecycle observability.
+ * Three panels stack at the top-left of the visual surface when
+ * `PBIVIZ_DEV_OVERLAY=true`:
+ *
+ *  1. **Tally panel** — live counts of opens, render-starts, closes
+ *     (broken out by `via` discriminator: `sync-current` for U8
+ *     synchronous dispatch closes, `async-pending-render` for
+ *     U9/U10 vega-embed/incremental closes, `safety-net` for the
+ *     coordinator's 10s backstop), fails (also discriminated),
+ *     safety-net activity, and the count of currently-pending ids.
+ *     A non-zero `pending` count sustained across multiple updates
+ *     is the orphan signal — for healthy traces it stabilises at
+ *     0 or 1.
+ *
+ *  2. **Failures panel** — the most recent `failed` events with
+ *     their reason strings. This is the **only surface** that can
+ *     show error context in certified builds: Power BI cert rules
+ *     forbid `console.error`, and the host's `renderingFailed`
+ *     reason string is a write-only sink. The observer stream
+ *     captures the original `error` value alongside the reason
+ *     string at the coordinator's emission point, and this panel
+ *     surfaces them for the developer.
+ *
+ *  3. **History textarea** — the pre-existing legacy visual update
+ *     history JSON dump (~20×20 px at the bottom-left). Preserved
+ *     unchanged; the textarea is resizable so a developer can
+ *     drag it open when needed.
  */
 export const VisualUpdateHistoryOverlay = () => {
     const history = useDenebVisualState((state) => state.updates.history);
-    return IS_OVERLAY_ENABLED ? (
-        <textarea
-            style={{
-                position: 'absolute',
-                top: '0',
-                left: '0',
-                width: '20px',
-                height: '20px',
-                backgroundColor: 'rgba(0, 0, 0, 0.5)',
-                color: 'white',
-                zIndex: 9999,
-                display: 'block'
-            }}
-            value={JSON.stringify(history, null, 2)}
-        />
-    ) : (
-        <></>
+    const lifecycleEvents = useDenebVisualState(
+        (state) => state.updates.lifecycleEvents
+    );
+    const tally = useMemo(
+        () => computeLifecycleTally(lifecycleEvents),
+        [lifecycleEvents]
+    );
+    const recentFailures = useMemo(
+        () =>
+            lifecycleEvents
+                .filter((event) => event.kind === 'failed')
+                .slice(-6),
+        [lifecycleEvents]
+    );
+
+    if (!IS_OVERLAY_ENABLED) return <></>;
+
+    const tallyText = [
+        `opens:        ${tally.opens}`,
+        `render-start: ${tally.renderStarts}`,
+        `closes:       ${tally.closes.total}` +
+            `  (sync: ${tally.closes.syncCurrent},` +
+            ` async: ${tally.closes.asyncPendingRender},` +
+            ` net: ${tally.closes.safetyNet})`,
+        `fails:        ${tally.fails.total}` +
+            `  (sync: ${tally.fails.syncCurrent},` +
+            ` async: ${tally.fails.asyncPendingRender},` +
+            ` sup: ${tally.fails.superseded})`,
+        `safety-net:   armed ${tally.safetyNet.armed}` +
+            ` / ticks: closed ${tally.safetyNet.closedByTick},` +
+            ` def ${tally.safetyNet.deferred},` +
+            ` inert ${tally.safetyNet.inert}`,
+        `pending:      ${tally.pending}` +
+            (tally.pendingIds.length > 0
+                ? `  [${tally.pendingIds.join(', ')}]`
+                : '')
+    ].join('\n');
+
+    return (
+        <>
+            <div style={TALLY_PANEL_STYLE}>{tallyText}</div>
+            {recentFailures.length > 0 && (
+                <div style={FAILURES_PANEL_STYLE}>
+                    <div style={{ fontWeight: 600, marginBottom: '4px' }}>
+                        recent failures
+                    </div>
+                    {recentFailures.map((event, index) => {
+                        if (event.kind !== 'failed') return null;
+                        return (
+                            <div
+                                key={`${event.id}-${index}`}
+                                style={{ marginBottom: '3px' }}
+                            >
+                                id={event.id} via={event.via} reason=
+                                {event.reason}
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+            <textarea
+                style={HISTORY_TEXTAREA_STYLE}
+                value={JSON.stringify(history, null, 2)}
+                readOnly
+            />
+        </>
     );
 };

--- a/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
+++ b/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
@@ -103,7 +103,6 @@ export const VisualUpdateHistoryOverlay = () => {
             title='lifecycle + history'
             position='top-left'
             maxWidth={520}
-            maxHeight={420}
         >
             <div style={SECTION_HEADING_STYLE}>lifecycle tally</div>
             <pre style={HISTORY_PRE_STYLE}>{tallyText}</pre>

--- a/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
+++ b/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
@@ -1,84 +1,62 @@
-import { useMemo } from 'react';
+import { useMemo, type CSSProperties } from 'react';
 
 import { toBoolean } from '@deneb-viz/utils/type-conversion';
 import { useDenebVisualState } from '../../../state';
+import { DevOverlayShell } from '../../dev-overlay-shell';
 import { computeLifecycleTally } from '../lib/compute-tally';
 
 const IS_OVERLAY_ENABLED = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
 
-const PANEL_BASE_STYLE: React.CSSProperties = {
-    position: 'absolute',
-    backgroundColor: 'rgba(0, 0, 0, 0.65)',
-    color: 'white',
-    fontFamily: 'Consolas, monospace',
-    fontSize: '11px',
-    lineHeight: 1.3,
-    padding: '6px 8px',
-    border: '1px solid rgba(255, 255, 255, 0.2)',
-    zIndex: 9999,
-    pointerEvents: 'auto'
+const SECTION_HEADING_STYLE: CSSProperties = {
+    fontWeight: 600,
+    marginBottom: 4,
+    color: 'rgba(255, 255, 255, 0.7)'
 };
 
-const TALLY_PANEL_STYLE: React.CSSProperties = {
-    ...PANEL_BASE_STYLE,
-    top: '0',
-    left: '0',
-    minWidth: '240px',
-    whiteSpace: 'pre',
-    display: 'block'
+const HR_STYLE: CSSProperties = {
+    border: 'none',
+    borderTop: '1px solid rgba(255, 255, 255, 0.18)',
+    margin: '8px 0'
 };
 
-const FAILURES_PANEL_STYLE: React.CSSProperties = {
-    ...PANEL_BASE_STYLE,
-    top: '0',
-    left: '260px',
-    maxWidth: '420px',
-    maxHeight: '160px',
-    overflowY: 'auto',
+const FAILURE_LINE_STYLE: CSSProperties = {
     color: 'rgba(255, 200, 120, 0.95)',
-    display: 'block'
+    marginBottom: 2
 };
 
-const HISTORY_TEXTAREA_STYLE: React.CSSProperties = {
-    position: 'absolute',
-    top: '170px',
-    left: '0',
-    width: '20px',
-    height: '20px',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    color: 'white',
-    zIndex: 9999,
-    display: 'block'
+const HISTORY_PRE_STYLE: CSSProperties = {
+    margin: 0,
+    fontSize: '10px',
+    lineHeight: 1.3,
+    color: 'rgba(220, 220, 220, 0.9)'
 };
 
 /**
- * Dev-only HUD for the visual's rendering-lifecycle observability.
- * Three panels stack at the top-left of the visual surface when
- * `PBIVIZ_DEV_OVERLAY=true`:
+ * Dev-only HUD that surfaces rendering-lifecycle observability and
+ * visual update history in a single consolidated overlay (top-left).
+ * Enabled by `PBIVIZ_DEV_OVERLAY=true`.
  *
- *  1. **Tally panel** — live counts of opens, render-starts, closes
- *     (broken out by `via` discriminator: `sync-current` for U8
- *     synchronous dispatch closes, `async-pending-render` for
- *     U9/U10 vega-embed/incremental closes, `safety-net` for the
- *     coordinator's 10s backstop), fails (also discriminated),
- *     safety-net activity, and the count of currently-pending ids.
- *     A non-zero `pending` count sustained across multiple updates
- *     is the orphan signal — for healthy traces it stabilises at
- *     0 or 1.
+ * Three stacked sections inside one collapsible shell:
  *
- *  2. **Failures panel** — the most recent `failed` events with
- *     their reason strings. This is the **only surface** that can
- *     show error context in certified builds: Power BI cert rules
- *     forbid `console.error`, and the host's `renderingFailed`
- *     reason string is a write-only sink. The observer stream
- *     captures the original `error` value alongside the reason
- *     string at the coordinator's emission point, and this panel
- *     surfaces them for the developer.
+ *  1. **Lifecycle tally** — live counts of opens, render-starts,
+ *     closes (broken out by `via`: `sync-current` for U8 sync
+ *     closes, `async-pending-render` for U9/U10, `safety-net` for
+ *     the 10s backstop), fails (also discriminated), safety-net
+ *     activity, and pending ids. A sustained `pending > 1`
+ *     indicates a real orphan.
  *
- *  3. **History textarea** — the pre-existing legacy visual update
- *     history JSON dump (~20×20 px at the bottom-left). Preserved
- *     unchanged; the textarea is resizable so a developer can
- *     drag it open when needed.
+ *  2. **Recent failures** — shown only when at least one `failed`
+ *     event exists. The **only surface** that can show error
+ *     context in certified builds: Power BI cert rules forbid
+ *     `console.error`, and the host's `renderingFailed` reason
+ *     string is a write-only sink. The observer stream captures
+ *     the original error value alongside the reason string at the
+ *     coordinator's emission point; this section surfaces them for
+ *     the developer.
+ *
+ *  3. **Update history** — JSON dump of the recent display-history
+ *     records (replaces the old hidden-by-default 20×20 textarea —
+ *     now visible by default and scrollable in the shell body).
  */
 export const VisualUpdateHistoryOverlay = () => {
     const history = useDenebVisualState((state) => state.updates.history);
@@ -121,32 +99,39 @@ export const VisualUpdateHistoryOverlay = () => {
     ].join('\n');
 
     return (
-        <>
-            <div style={TALLY_PANEL_STYLE}>{tallyText}</div>
+        <DevOverlayShell
+            title='lifecycle + history'
+            position='top-left'
+            maxWidth={520}
+            maxHeight={420}
+        >
+            <div style={SECTION_HEADING_STYLE}>lifecycle tally</div>
+            <pre style={HISTORY_PRE_STYLE}>{tallyText}</pre>
+
             {recentFailures.length > 0 && (
-                <div style={FAILURES_PANEL_STYLE}>
-                    <div style={{ fontWeight: 600, marginBottom: '4px' }}>
-                        recent failures
-                    </div>
+                <>
+                    <hr style={HR_STYLE} />
+                    <div style={SECTION_HEADING_STYLE}>recent failures</div>
                     {recentFailures.map((event, index) => {
                         if (event.kind !== 'failed') return null;
                         return (
                             <div
                                 key={`${event.id}-${index}`}
-                                style={{ marginBottom: '3px' }}
+                                style={FAILURE_LINE_STYLE}
                             >
                                 id={event.id} via={event.via} reason=
                                 {event.reason}
                             </div>
                         );
                     })}
-                </div>
+                </>
             )}
-            <textarea
-                style={HISTORY_TEXTAREA_STYLE}
-                value={JSON.stringify(history, null, 2)}
-                readOnly
-            />
-        </>
+
+            <hr style={HR_STYLE} />
+            <div style={SECTION_HEADING_STYLE}>update history</div>
+            <pre style={HISTORY_PRE_STYLE}>
+                {JSON.stringify(history, null, 2)}
+            </pre>
+        </DevOverlayShell>
     );
 };

--- a/src/features/visual-update-history-overlay/lib/__test__/compute-tally.test.ts
+++ b/src/features/visual-update-history-overlay/lib/__test__/compute-tally.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeLifecycleTally } from '../compute-tally';
+import {
+    SUPERSEDED_FAILURE_REASON,
+    type RenderingLifecycleEvent,
+    type RenderingLifecycleId
+} from '../../../../lib/rendering-lifecycle';
+
+const id = (value: number): RenderingLifecycleId =>
+    value as RenderingLifecycleId;
+
+const FAKE_OPTIONS = {} as never;
+
+// ─── Happy path & exact counts ───────────────────────────────────────────────
+
+describe('computeLifecycleTally — happy path', () => {
+    it('empty event log → zeroed tally with empty pendingIds', () => {
+        const tally = computeLifecycleTally([]);
+        expect(tally.opens).toBe(0);
+        expect(tally.renderStarts).toBe(0);
+        expect(tally.closes.total).toBe(0);
+        expect(tally.fails.total).toBe(0);
+        expect(tally.safetyNet.armed).toBe(0);
+        expect(tally.pending).toBe(0);
+        expect(tally.pendingIds).toEqual([]);
+    });
+
+    it('N opens each with one sync-current close → N starts, N closes, 0 pending', () => {
+        const events: RenderingLifecycleEvent[] = [];
+        for (let n = 1; n <= 5; n++) {
+            events.push({
+                kind: 'opened',
+                id: id(n),
+                options: FAKE_OPTIONS
+            });
+            events.push({
+                kind: 'closed',
+                id: id(n),
+                via: 'sync-current'
+            });
+        }
+        const tally = computeLifecycleTally(events);
+        expect(tally.opens).toBe(5);
+        expect(tally.closes.total).toBe(5);
+        expect(tally.closes.syncCurrent).toBe(5);
+        expect(tally.closes.asyncPendingRender).toBe(0);
+        expect(tally.closes.safetyNet).toBe(0);
+        expect(tally.pending).toBe(0);
+        expect(tally.pendingIds).toEqual([]);
+    });
+
+    it('counts close discriminators independently', () => {
+        const events: RenderingLifecycleEvent[] = [
+            { kind: 'opened', id: id(1), options: FAKE_OPTIONS },
+            { kind: 'closed', id: id(1), via: 'sync-current' },
+            { kind: 'opened', id: id(2), options: FAKE_OPTIONS },
+            { kind: 'closed', id: id(2), via: 'async-pending-render' },
+            { kind: 'opened', id: id(3), options: FAKE_OPTIONS },
+            { kind: 'closed', id: id(3), via: 'safety-net' }
+        ];
+        const tally = computeLifecycleTally(events);
+        expect(tally.closes).toEqual({
+            total: 3,
+            syncCurrent: 1,
+            asyncPendingRender: 1,
+            safetyNet: 1
+        });
+    });
+
+    it('counts fail discriminators independently', () => {
+        const error = new Error('boom');
+        const events: RenderingLifecycleEvent[] = [
+            { kind: 'opened', id: id(1), options: FAKE_OPTIONS },
+            {
+                kind: 'failed',
+                id: id(1),
+                reason: 'boom',
+                error,
+                via: 'sync-current'
+            },
+            { kind: 'opened', id: id(2), options: FAKE_OPTIONS },
+            {
+                kind: 'failed',
+                id: id(2),
+                reason: 'render error',
+                error,
+                via: 'async-pending-render'
+            },
+            { kind: 'opened', id: id(3), options: FAKE_OPTIONS },
+            {
+                kind: 'failed',
+                id: id(3),
+                reason: SUPERSEDED_FAILURE_REASON,
+                via: 'superseded'
+            }
+        ];
+        const tally = computeLifecycleTally(events);
+        expect(tally.fails).toEqual({
+            total: 3,
+            syncCurrent: 1,
+            asyncPendingRender: 1,
+            superseded: 1
+        });
+    });
+});
+
+// ─── Pending tracking — the orphan-detection surface ─────────────────────────
+
+describe('computeLifecycleTally — pending ids', () => {
+    it('open with no close → 1 pending; pendingIds contains the id', () => {
+        const events: RenderingLifecycleEvent[] = [
+            { kind: 'opened', id: id(42), options: FAKE_OPTIONS }
+        ];
+        const tally = computeLifecycleTally(events);
+        expect(tally.pending).toBe(1);
+        expect(tally.pendingIds).toEqual([42]);
+    });
+
+    it('open with no close, then safety-net closes it → 0 pending', () => {
+        const events: RenderingLifecycleEvent[] = [
+            { kind: 'opened', id: id(42), options: FAKE_OPTIONS },
+            { kind: 'safety-net-armed', id: id(42) },
+            { kind: 'safety-net-tick', id: id(42), result: 'closed' },
+            { kind: 'closed', id: id(42), via: 'safety-net' }
+        ];
+        const tally = computeLifecycleTally(events);
+        expect(tally.pending).toBe(0);
+        expect(tally.pendingIds).toEqual([]);
+        expect(tally.safetyNet.armed).toBe(1);
+        expect(tally.safetyNet.closedByTick).toBe(1);
+        expect(tally.closes.safetyNet).toBe(1);
+    });
+
+    it('multiple opens with mixed terminals → pending equals open-minus-closed-minus-failed', () => {
+        const events: RenderingLifecycleEvent[] = [
+            { kind: 'opened', id: id(1), options: FAKE_OPTIONS },
+            { kind: 'closed', id: id(1), via: 'sync-current' },
+            { kind: 'opened', id: id(2), options: FAKE_OPTIONS },
+            // id=2 superseded by id=3 below
+            { kind: 'opened', id: id(3), options: FAKE_OPTIONS },
+            {
+                kind: 'failed',
+                id: id(2),
+                reason: 'superseded',
+                via: 'superseded'
+            },
+            { kind: 'opened', id: id(4), options: FAKE_OPTIONS }
+            // ids 3 and 4 are still pending
+        ];
+        const tally = computeLifecycleTally(events);
+        expect(tally.pending).toBe(2);
+        expect(tally.pendingIds).toEqual([3, 4]);
+    });
+
+    it('pendingIds is sorted numerically (not lexicographically)', () => {
+        const events: RenderingLifecycleEvent[] = [
+            { kind: 'opened', id: id(9), options: FAKE_OPTIONS },
+            { kind: 'opened', id: id(11), options: FAKE_OPTIONS },
+            { kind: 'opened', id: id(2), options: FAKE_OPTIONS }
+        ];
+        const tally = computeLifecycleTally(events);
+        expect(tally.pendingIds).toEqual([2, 9, 11]);
+    });
+});
+
+// ─── Exactly-once / stale-event resilience ───────────────────────────────────
+
+describe('computeLifecycleTally — resilience to stale events', () => {
+    it('a stale double-close attempt does not double-count closes', () => {
+        // The coordinator's exactly-once guard means a second
+        // close(id) call no-ops and does NOT emit a second `closed`
+        // observer event. But if the slice's ring somehow contained
+        // a duplicate event, the tally should still produce the
+        // correct count by treating the second close on an already-
+        // closed id as a no-op for pending tracking.
+        const events: RenderingLifecycleEvent[] = [
+            { kind: 'opened', id: id(1), options: FAKE_OPTIONS },
+            { kind: 'closed', id: id(1), via: 'sync-current' },
+            // Stale duplicate — the tally counts both close events
+            // (because the discriminator counts are raw counts of
+            // observed events) but `pending` stays at 0.
+            { kind: 'closed', id: id(1), via: 'sync-current' }
+        ];
+        const tally = computeLifecycleTally(events);
+        expect(tally.closes.total).toBe(2);
+        expect(tally.pending).toBe(0);
+        expect(tally.pendingIds).toEqual([]);
+    });
+
+    it('counts safety-net-tick results separately from closes', () => {
+        // A tick with result `closed` increments `safetyNet.closedByTick`
+        // AND emits a separate `closed` event with `via: 'safety-net'`
+        // that increments `closes.safetyNet`. The tally surfaces
+        // both — `closedByTick` is the safety-net's perspective,
+        // `closes.safetyNet` is the close surface's perspective.
+        // A tick with result `deferred` or `inert` is observed but
+        // does NOT emit a separate `closed` event.
+        const events: RenderingLifecycleEvent[] = [
+            { kind: 'opened', id: id(1), options: FAKE_OPTIONS },
+            { kind: 'safety-net-armed', id: id(1) },
+            { kind: 'safety-net-tick', id: id(1), result: 'deferred' },
+            { kind: 'safety-net-tick', id: id(1), result: 'closed' },
+            { kind: 'closed', id: id(1), via: 'safety-net' }
+        ];
+        const tally = computeLifecycleTally(events);
+        expect(tally.safetyNet.deferred).toBe(1);
+        expect(tally.safetyNet.closedByTick).toBe(1);
+        expect(tally.closes.safetyNet).toBe(1);
+        expect(tally.closes.total).toBe(1);
+    });
+});
+
+// ─── End-to-end scenario the U7-U10 chain produces in production ─────────────
+
+describe('computeLifecycleTally — end-to-end scenarios', () => {
+    it('U8 skip update + U9 render update + U10 incremental update → all three close discriminators populated', () => {
+        const events: RenderingLifecycleEvent[] = [
+            // U9: full re-embed (reload)
+            { kind: 'opened', id: id(1), options: FAKE_OPTIONS },
+            { kind: 'safety-net-armed', id: id(1) },
+            { kind: 'render-started', id: id(1) },
+            { kind: 'closed', id: id(1), via: 'async-pending-render' },
+            // U8: skip path (resize)
+            { kind: 'opened', id: id(2), options: FAKE_OPTIONS },
+            { kind: 'safety-net-armed', id: id(2) },
+            { kind: 'closed', id: id(2), via: 'sync-current' },
+            // U10: incremental update
+            { kind: 'opened', id: id(3), options: FAKE_OPTIONS },
+            { kind: 'safety-net-armed', id: id(3) },
+            { kind: 'closed', id: id(3), via: 'async-pending-render' }
+        ];
+        const tally = computeLifecycleTally(events);
+        expect(tally.opens).toBe(3);
+        expect(tally.closes.total).toBe(3);
+        expect(tally.closes.syncCurrent).toBe(1);
+        expect(tally.closes.asyncPendingRender).toBe(2);
+        expect(tally.safetyNet.armed).toBe(3);
+        expect(tally.pending).toBe(0);
+    });
+
+    it('coalesced updates: open(A), open(B) supersedes A, B closes → 1 fail-superseded + 1 close', () => {
+        const events: RenderingLifecycleEvent[] = [
+            { kind: 'opened', id: id(1), options: FAKE_OPTIONS },
+            { kind: 'safety-net-armed', id: id(1) },
+            {
+                kind: 'failed',
+                id: id(1),
+                reason: SUPERSEDED_FAILURE_REASON,
+                via: 'superseded'
+            },
+            { kind: 'opened', id: id(2), options: FAKE_OPTIONS },
+            { kind: 'safety-net-armed', id: id(2) },
+            { kind: 'closed', id: id(2), via: 'async-pending-render' }
+        ];
+        const tally = computeLifecycleTally(events);
+        expect(tally.opens).toBe(2);
+        expect(tally.fails.superseded).toBe(1);
+        expect(tally.closes.asyncPendingRender).toBe(1);
+        expect(tally.pending).toBe(0);
+    });
+});

--- a/src/features/visual-update-history-overlay/lib/compute-tally.ts
+++ b/src/features/visual-update-history-overlay/lib/compute-tally.ts
@@ -1,0 +1,162 @@
+import { type RenderingLifecycleEvent } from '../../../lib/rendering-lifecycle';
+
+/**
+ * Per-discriminator close counts. Mirrors the
+ * {@link RenderingLifecycleEvent} `closed` union's `via` field exactly
+ * so a future addition to the discriminator surfaces here as a type
+ * error at the `switch (event.via)` site below — not as a silently
+ *-uncategorised count.
+ */
+export type CloseTally = {
+    total: number;
+    syncCurrent: number;
+    asyncPendingRender: number;
+    safetyNet: number;
+};
+
+/**
+ * Per-discriminator fail counts. Same drift-protection rationale as
+ * {@link CloseTally}.
+ */
+export type FailTally = {
+    total: number;
+    syncCurrent: number;
+    asyncPendingRender: number;
+    superseded: number;
+};
+
+/**
+ * Per-result safety-net tick counts. The `armed` count is incremented
+ * by the `safety-net-armed` event (every `armSafetyNet` call); the
+ * three result-keyed counts are incremented when a tick actually
+ * fires.
+ */
+export type SafetyNetTally = {
+    armed: number;
+    closedByTick: number;
+    deferred: number;
+    inert: number;
+};
+
+/**
+ * Aggregated, deterministic view of the rendering-lifecycle event
+ * stream. Pure function output — same input array always produces
+ * the same tally. The dev overlay re-renders by recomputing from
+ * the underlying `lifecycleEvents` ring on every render; cost is
+ * O(events) and bounded by the slice's `LIFECYCLE_EVENTS_RING_LIMIT`.
+ */
+export type LifecycleTally = {
+    /** Total `open()` calls observed. */
+    opens: number;
+    /** Total `markRenderStarted` / `markPendingRenderStarted` calls. */
+    renderStarts: number;
+    closes: CloseTally;
+    fails: FailTally;
+    safetyNet: SafetyNetTally;
+    /**
+     * Number of ids that received an `opened` event but no matching
+     * `closed` / `failed` terminal — i.e. ids still in flight from
+     * the slice's perspective. For a healthy run with the overlay
+     * watching, this stabilises at 0 or 1 (the most recent
+     * still-rendering id). A value > 1 sustained across multiple
+     * updates indicates a real orphan situation worth investigating.
+     */
+    pending: number;
+    /** The ids currently pending (open without terminal). */
+    pendingIds: number[];
+};
+
+/**
+ * Compute the live tally from the lifecycle event ring. Pure;
+ * O(events). Drives the dev overlay's UI as well as the unit tests
+ * that pin the expected aggregation behaviour.
+ */
+export const computeLifecycleTally = (
+    events: readonly RenderingLifecycleEvent[]
+): LifecycleTally => {
+    const tally: LifecycleTally = {
+        opens: 0,
+        renderStarts: 0,
+        closes: {
+            total: 0,
+            syncCurrent: 0,
+            asyncPendingRender: 0,
+            safetyNet: 0
+        },
+        fails: {
+            total: 0,
+            syncCurrent: 0,
+            asyncPendingRender: 0,
+            superseded: 0
+        },
+        safetyNet: {
+            armed: 0,
+            closedByTick: 0,
+            deferred: 0,
+            inert: 0
+        },
+        pending: 0,
+        pendingIds: []
+    };
+    const open = new Set<number>();
+    for (const event of events) {
+        switch (event.kind) {
+            case 'opened':
+                tally.opens++;
+                open.add(event.id);
+                break;
+            case 'render-started':
+                tally.renderStarts++;
+                break;
+            case 'closed':
+                tally.closes.total++;
+                switch (event.via) {
+                    case 'sync-current':
+                        tally.closes.syncCurrent++;
+                        break;
+                    case 'async-pending-render':
+                        tally.closes.asyncPendingRender++;
+                        break;
+                    case 'safety-net':
+                        tally.closes.safetyNet++;
+                        break;
+                }
+                open.delete(event.id);
+                break;
+            case 'failed':
+                tally.fails.total++;
+                switch (event.via) {
+                    case 'sync-current':
+                        tally.fails.syncCurrent++;
+                        break;
+                    case 'async-pending-render':
+                        tally.fails.asyncPendingRender++;
+                        break;
+                    case 'superseded':
+                        tally.fails.superseded++;
+                        break;
+                }
+                open.delete(event.id);
+                break;
+            case 'safety-net-armed':
+                tally.safetyNet.armed++;
+                break;
+            case 'safety-net-tick':
+                switch (event.result) {
+                    case 'closed':
+                        tally.safetyNet.closedByTick++;
+                        break;
+                    case 'deferred':
+                        tally.safetyNet.deferred++;
+                        break;
+                    case 'inert':
+                        tally.safetyNet.inert++;
+                        break;
+                }
+                break;
+        }
+    }
+    tally.pending = open.size;
+    tally.pendingIds = Array.from(open).sort((a, b) => a - b);
+    return tally;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,17 @@ import {
 const IS_DEVELOPER_MODE = toBoolean(process.env.PBIVIZ_DEV_MODE);
 
 /**
+ * Gate for the rendering-lifecycle coordinator's observer wiring.
+ * When the dev-overlay env var is on, every coordinator event is
+ * pushed into the visual store's bounded ring (the tally surface
+ * consumed by `VisualUpdateHistoryOverlay`). When off, the observer
+ * slot is left undefined and the coordinator's internal observe
+ * call is a typed no-op — production builds pay no per-event
+ * cost.
+ */
+const IS_LIFECYCLE_OBSERVER_ENABLED = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
+
+/**
  * Bound (ms) after which the rendering-lifecycle safety-net checks an
  * armed id. If the id is still open and no render ever began
  * (`state.renderStarted === false`), the safety-net closes it as an
@@ -156,10 +167,13 @@ export class Deneb implements IVisual {
         try {
             const { host } = options;
             this.#host = host;
-            // Coordinator owns ALL host.eventService.rendering* emission
-            // from this point forward. The host event service is the
-            // structural emitter; the safety-net uses real setTimeout in
-            // prod. U11 will inject an observer for the dev overlay.
+            // Coordinator owns ALL host.eventService.rendering*
+            // emission from this point forward. The host event
+            // service is the structural emitter; the safety-net uses
+            // real setTimeout in prod; the observer is gated by
+            // PBIVIZ_DEV_OVERLAY so the dev overlay's tally surface
+            // is fed without paying the per-event store-write cost in
+            // production builds.
             this.#coordinator = createRenderingLifecycleCoordinator({
                 emitter: host.eventService,
                 scheduler: renderingLifecycleScheduler,
@@ -170,7 +184,20 @@ export class Deneb implements IVisual {
                 // wiring forwarded `detail` unconditionally and printed
                 // a literal `undefined` after every lifecycle line
                 // (e.g. "[lifecycle] renderingStarted id=1 undefined").
-                logger: logHost
+                logger: logHost,
+                // U11: forward every coordinator event into the
+                // visual store's bounded ring so the dev overlay can
+                // compute a live start-vs-close tally. The setter is
+                // a stable closure created once when the store
+                // hydrates, so capturing it via `.getState()` here
+                // is safe — subsequent slice rebuilds do not replace
+                // it. Left undefined when the env gate is off (the
+                // coordinator's optional observer slot skips the
+                // call entirely).
+                observer: IS_LIFECYCLE_OBSERVER_ENABLED
+                    ? useDenebVisualState.getState().updates
+                          .recordLifecycleEvent
+                    : undefined
             });
             // U9: render-callback adapters routed through the
             // coordinator. App-core never imports the coordinator —

--- a/src/state/updates.ts
+++ b/src/state/updates.ts
@@ -12,13 +12,41 @@ import {
     isVisualUpdateTypeVolatile,
     type DisplayHistoryRecord
 } from '../lib/state';
+import { type RenderingLifecycleEvent } from '../lib/rendering-lifecycle';
+
+/**
+ * Maximum number of rendering-lifecycle events retained in the
+ * `UpdatesSlice.lifecycleEvents` ring buffer. Sized so a typical
+ * resize storm (10-20 events per second) leaves several seconds of
+ * history without unbounded memory growth across a long session.
+ */
+const LIFECYCLE_EVENTS_RING_LIMIT = 200;
 
 export type UpdatesSlice = {
     __hydrated__: boolean;
     count: number;
     history: DisplayHistoryRecord[];
     options: powerbi.extensibility.visual.VisualUpdateOptions | null;
+    /**
+     * Bounded ring of recent rendering-lifecycle observer events. The
+     * coordinator (constructed in `src/index.ts`) is wired to push
+     * each event into this slice; the dev-overlay tally
+     * (`src/features/visual-update-history-overlay`) reads it to
+     * compute and render a live start-vs-close tally for Desktop
+     * export testing. Capped at {@link LIFECYCLE_EVENTS_RING_LIMIT}
+     * — older events are dropped from the head.
+     */
+    lifecycleEvents: RenderingLifecycleEvent[];
     setVisualUpdateOptions: (payload: VisualUpdateDataPayload) => Promise<void>;
+    /**
+     * Append a single observer event to {@link lifecycleEvents}. The
+     * ring is trimmed from the head to maintain its bound. Designed
+     * for the coordinator's observer callback — production code in
+     * `src/index.ts` captures this setter once at constructor time
+     * and passes it directly into
+     * {@link createRenderingLifecycleCoordinator}'s `observer` slot.
+     */
+    recordLifecycleEvent: (event: RenderingLifecycleEvent) => void;
 };
 
 export type VisualUpdateDataPayload = {
@@ -37,6 +65,29 @@ export const createUpdatesSlice = (): StateCreator<
         count: 0,
         history: [],
         options: null,
+        lifecycleEvents: [],
+        recordLifecycleEvent: (event: RenderingLifecycleEvent) =>
+            set(
+                (state) => {
+                    const next = [...state.updates.lifecycleEvents, event];
+                    // Trim from the head — JS Array.slice is O(n) but
+                    // for n ≤ 200 the cost is trivial and predictable.
+                    const trimmed =
+                        next.length > LIFECYCLE_EVENTS_RING_LIMIT
+                            ? next.slice(
+                                  next.length - LIFECYCLE_EVENTS_RING_LIMIT
+                              )
+                            : next;
+                    return {
+                        updates: {
+                            ...state.updates,
+                            lifecycleEvents: trimmed
+                        }
+                    };
+                },
+                false,
+                'updates.recordLifecycleEvent'
+            ),
         setVisualUpdateOptions: async (payload) => {
             const { options, isDeveloperMode } = payload;
             const settings = getVisualFormattingModel(options?.dataViews?.[0]);


### PR DESCRIPTION
## Summary

U11 from [`docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md`](../blob/feat/lifecycle-dev-overlay-tally/docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md): instrument a per-update start-vs-close tally and surface it in the `PBIVIZ_DEV_OVERLAY` HUD for Desktop export testing. Started there, then expanded during smoke testing to fix a handful of dev-overlay UX papercuts that the new tally surface made visible (fragmented overlays, no minimize, fixed height that didn't engage scroll on small visuals, noisy update-history dump dominating the panel). The result is a small reusable dev-overlay shell module that both U11's lifecycle observability and the pre-existing viewport-gate debug overlay now sit inside.

After this PR, **the cert-relevant lifecycle behavior is observable in Power BI Desktop without DevTools** — including failure reasons that would otherwise be invisible because cert rules forbid `console.error` and the host's `renderingFailed` reason string is write-only.

## Five commits

| # | SHA | Purpose |
|---|-----|---------|
| 1 | `7e607a7c` | **U11 core:** coordinator observer wired into a new bounded ring on `UpdatesSlice`; pure `computeLifecycleTally` aggregation + 12 unit tests; initial three-panel overlay rendering tally / failures / history |
| 2 | `5b762fef` | **Chore:** gitignore `.repowise/` and untrack a marker file accidentally swept up by `git add -A` |
| 3 | `5af2e61c` | **Consolidate dev overlays:** new `<DevOverlayShell>` primitive; both `VisualUpdateHistoryOverlay` and `ViewportGateDebugOverlay` rebuild on it; lifecycle + history collapsed into a single top-left panel with `<hr/>` separators |
| 4 | `4deae399` | **Viewport-anchored sizing:** shell becomes a flex column with `maxHeight: calc(100vh - 16px)`; scroll bar engages on small visuals where the fixed `maxHeight={420}` previously left the body extending past the visible edge |
| 5 | `ce9f10b3` | **Collapsible sections:** new `<CollapsibleSection>` primitive; update history defaults to collapsed so the high-signal tally + failures sit above the fold |

## U11 core (commit 1) — the plan-mapped work

### Coordinator observer wired into the visual store

`src/index.ts` passes `useDenebVisualState.getState().updates.recordLifecycleEvent` as the coordinator's `observer` slot, **gated by `PBIVIZ_DEV_OVERLAY=true`**. When the env gate is off the slot is left `undefined` and the coordinator's optional-observer call is a typed no-op — production builds pay no per-event store-write cost. The setter is a stable closure created once when the store hydrates, so capturing it via `.getState()` at constructor time is safe — subsequent slice rebuilds don't replace it.

### New slice fields

```ts
type UpdatesSlice = {
    // ...existing fields...
    lifecycleEvents: RenderingLifecycleEvent[];  // bounded ring, cap 200
    recordLifecycleEvent: (event: RenderingLifecycleEvent) => void;
};
```

The ring is capped at `LIFECYCLE_EVENTS_RING_LIMIT = 200`. Sized so a typical resize storm (10-20 events / sec) leaves several seconds of history without unbounded memory growth across a long session. Tunable in one place at the top of `updates.ts`.

### Pure tally aggregation

New module `src/features/visual-update-history-overlay/lib/compute-tally.ts`:

```ts
type LifecycleTally = {
    opens: number;
    renderStarts: number;
    closes: { total, syncCurrent, asyncPendingRender, safetyNet };
    fails: { total, syncCurrent, asyncPendingRender, superseded };
    safetyNet: { armed, closedByTick, deferred, inert };
    pending: number;          // count of open ids with no terminal yet
    pendingIds: number[];     // the actual ids (sorted numerically)
};

computeLifecycleTally(events: readonly RenderingLifecycleEvent[]): LifecycleTally
```

Per-discriminator counters mirror the `RenderingLifecycleEvent` union exactly so a future addition surfaces here as a TypeScript error at the `switch (event.via)` site — not as a silently-uncategorised count.

**12 unit tests** in `__test__/compute-tally.test.ts` cover:

- Happy path (empty / N opens-with-closes / each discriminator counted independently)
- Pending tracking (orphan detection, safety-net resolution, numerical sort, mixed terminals)
- Stale-event resilience (duplicate close, safety-net tick vs close emission separation)
- End-to-end scenarios matching the U7-U10 chain in production

All pass.

## Commits 3–5 — dev-overlay infrastructure (scope expansion)

### Why expanded

The initial three-panel overlay (commit 1) was functional but ugly: separate floating panels in different positions, no way to minimize when working with the visual, fixed height that didn't engage scroll on small visuals, and an update-history JSON dump that dominated the panel after enough updates. Surfaced during the post-merge smoke test — folded the fixes in here rather than queue four follow-up PRs.

### `<DevOverlayShell>`

New `src/features/dev-overlay-shell/` module exposing a reusable shell that both dev overlays (`VisualUpdateHistoryOverlay` top-left, `ViewportGateDebugOverlay` top-right) now sit inside:

| Property | Behaviour |
|---|---|
| Positioning | Corner-anchored (`top-left` / `top-right`), 8px inset |
| Sizing | `maxHeight: calc(100vh - 16px)` — anchored to the visual's iframe viewport so the body's `overflow-y: auto` engages even on small visuals |
| Layout | Flex column: fixed-height title bar + `flex: 1 1 auto` body with `minHeight: 0` so scroll actually works |
| Minimize / restore | `−` / `+` button in the title bar's top-right. Component-local state, resets on visual reload |
| Pointer events | `auto` (was `none` on viewport-gate previously) — required for the minimize button to be clickable. Trade-off: visual under the overlay isn't clickable while expanded; minimize when you need to interact |

### `<CollapsibleSection>`

Companion primitive in the same module. Single-section disclosure with click-anywhere-in-header toggle, triangle indicator (`▶` collapsed, `▼` expanded), `role='button'` + `aria-expanded` for screen readers, component-local state.

Used to wrap the update-history JSON dump in `VisualUpdateHistoryOverlay`. **Defaults collapsed** so the high-signal tally + failures sit above the fold. Available for other panels with their own noisy sections.

### `VisualUpdateHistoryOverlay` — final shape

Single overlay anchored top-left, three sections separated by `<hr/>`:

1. **Lifecycle tally** — always visible. Six rows of monospace counts.
2. **Recent failures** — shown only when at least one `failed` event exists. The **cert-channel-forbidden observability surface**: Power BI cert rules forbid `console.error`, and the host's `renderingFailed` reason string is a write-only sink, so this is the only way to see error context in a certified build.
3. **Update history** — JSON dump of `DisplayHistoryRecord[]`. Collapsed by default via `<CollapsibleSection>`.

### `ViewportGateDebugOverlay` — final shape

Wrapped in the same shell, anchored top-right, max 240px wide. Inherits the minimize behaviour. Content (mode, `iw`, `ih`, `ov.w/h`, `ev.w/h`, deltas) and 100ms polling unchanged.

## Verification

- [x] **12/12** `compute-tally.test.ts` tests pass.
- [x] **32/32** coordinator tests still pass.
- [x] `npx tsc --noEmit -p tsconfig.webpack.json` clean.
- [x] `npx prettier --config .prettierrc --check src/` clean.
- [x] Webpack dev build clean from a fresh `.tmp/`.
- [x] Full repo vitest: **1365/1392** — same 27 pre-existing failures in `packages/vega-react/__tests__/*` (reproduce on unmodified `next`), no U11 regressions. +12 from the new tally tests.

## Manual smoke-test recipe

`.env`: `PBIVIZ_DEV_OVERLAY=true` AND `PBIVIZ_VIEWPORT_GATE_OVERLAY=true`. `npm run dev`, load a working visual in Power BI Desktop.

**Two overlays appear:**

1. **Top-left** — "lifecycle + history". Lifecycle tally always visible; recent failures appear when present; update history hidden behind a `▶ update history` disclosure.
2. **Top-right** — "viewport gate". Live `iw`/`ih`, host viewport, embed viewport with deltas.

**Both overlays:**

- Minimize via `−` button in the title bar; restore via `+`.
- Body scrolls if content exceeds visual height — verifiable by resizing the visual to ~300px tall.

**The cert-relevant behavior to watch for:**

- **Tally counts** update live as each update flows through. A balanced run shows `opens === closes.total + fails.total` over time.
- **`pending` count** oscillates between 0 and 1 during normal use. Sustained `pending > 1` indicates a real orphan the U7-U10 chain didn't catch.
- **Resize storm** produces a mix of `closes.sync` (skip path) and `closes.async` (re-embed). No `safety-net` increments for typical use.
- **Edit the spec into invalid JSON** to trigger an `onRenderingError` — the recent-failures section appears with `id`, `via=async-pending-render`, `reason=<error message>`.

## Reviewer focus

- **`src/features/dev-overlay-shell/`** — the reusable shell + collapsible primitives. New module, small surface area, no special framework integration. Worth a sanity check on the flex-column `minHeight: 0` trick that makes the body actually scroll.
- **`src/state/updates.ts`** — the new ring + setter. Trim semantics (head-trim to cap) matter for the smoke test under load.
- **`src/features/visual-update-history-overlay/lib/compute-tally.ts`** — the pure aggregation. Per-discriminator switch statements are exhaustive so a future addition to the `via` union surfaces at compile time.
- **`src/index.ts:81`** — observer wiring gated on `PBIVIZ_DEV_OVERLAY`. Coordinator's optional-observer slot does the right thing (skips the call) when `undefined`.

## Known and accepted

- **Observer is env-gated**, so production builds skip the per-event Zustand `set` work. Trade-off: you can't get the tally on a certified prod build, but the tally is dev observability, not user-facing functionality.
- **Collapsed state is component-local** — resets on visual reload. Persistence (local storage / state slice) would have been overkill for dev tooling.
- **Pointer events on the shell are `auto`** so the minimize button works, which means the visual under an expanded overlay isn't clickable. Minimize when you need to interact with that area.

## Follow-up to

- [952badb8](https://github.com/deneb-viz/deneb/commit/952badb8) U10 incremental + renderless + settle ([#681](https://github.com/deneb-viz/deneb/pull/681))
- [0defa0b3](https://github.com/deneb-viz/deneb/commit/0defa0b3) U9 async close attribution ([#680](https://github.com/deneb-viz/deneb/pull/680))
- [a1e7a193](https://github.com/deneb-viz/deneb/commit/a1e7a193) U7 rendering lifecycle coordinator ([#677](https://github.com/deneb-viz/deneb/pull/677))

## Next

- **U12** (compliance verification) — run all scenarios with the U11 tally watching. By U12 the only `via=safety-net` lines should be true orphans; everything else closes via `sync-current` or `async-pending-render`.
- **U6** (deferred) — capabilities row-window limit 10000 → 30000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
