### PR TITLE
docs: U12 verification checklist + rendering-lifecycle coordinator pattern

### DIFF
--- a/docs/plans/2026-06-10-001-u12-lifecycle-compliance-verification.md
+++ b/docs/plans/2026-06-10-001-u12-lifecycle-compliance-verification.md
@@ -1,0 +1,236 @@
+---
+status: ready-for-uat
+title: U12 — Full lifecycle compliance verification checklist
+created: 2026-06-10
+related_plan: 2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md
+units_verified: [U5, U6, U7, U8, U9, U10, U11]
+---
+
+# U12 — Lifecycle Compliance Verification Checklist
+
+This is the manual sweep U12 calls for: every R-requirement and AE-acceptance-criterion from the plan, mapped to a concrete observable scenario in Power BI Desktop with the U11 tally as the observability surface.
+
+Once every checkbox passes, the plan is **done** and the cert-blocking lifecycle work is complete.
+
+---
+
+## Prerequisites
+
+```
+.env:
+  PBIVIZ_DEV_OVERLAY=true
+  PBIVIZ_VIEWPORT_GATE_OVERLAY=false   # optional
+  PBIVIZ_DEV_FORCE_READ_MODE=false     # toggle per scenario
+  LOG_LEVEL=DEBUG                       # for the [lifecycle] log narrative
+```
+
+- Branch: `next` at or after the U6 merge commit
+- Power BI Desktop, recent build
+- A small + large test dataset (e.g., 5K rows + 50K rows; 25K rows for U6's single-window verification)
+- A BETA-channel 1.9 `.pbix` fixture for the migration scenarios (per the cross-GUID property-isolation rule in `docs/solutions/best-practices/validate-migrations-on-matching-channel-builds-2026-06-03.md`)
+
+---
+
+## Phase 0 — Automated pre-sweep gate
+
+Run before any manual scenarios. All must pass before the manual sweep starts.
+
+- [ ] `npm run test` — full vitest. Expect 1365/1392 (27 pre-existing vega-react failures, see `next` for parity).
+- [ ] `npm run eslint` — clean.
+- [ ] `npm run prettier-check` — clean.
+- [ ] `rm -rf .tmp/ && npm run webpack:build` — clean dev build from cold cache.
+- [ ] `npm run package-beta` — produces a `.pbiviz` without errors.
+
+---
+
+## Phase 1 — Per-requirement verification
+
+Each row maps a plan requirement to a tally signature and one or more scenarios. **Pass = the tally shows the expected counts and the recent-failures panel is empty (unless a scenario explicitly triggers a failure).**
+
+### R1 — `renderingStarted` fires before any throwing work
+
+Coordinator's `open()` is the first statement inside `update()`'s try.
+
+- [ ] **Scenario:** edit the spec to invalid JSON to force a parse error. Console shows `[lifecycle] renderingStarted id=N` *before* `[lifecycle] renderingFailed id=N reason=<error> via=sync-current`.
+- [ ] **Tally:** `opens` incremented; `fails.syncCurrent` incremented; **no orphan start**.
+
+### R2 — Strict 1:1 started/finished pairs
+
+The headline cert requirement. Every `opens` increment must be matched within the bound by a terminal (`closes.total + fails.total`).
+
+- [ ] **Scenario:** cold load with working spec. After load settles, observe `opens === closes.total + fails.total` and `pending: 0`.
+- [ ] **Tally signature:** `opens: 1`, `render-start: 1`, `closes.asyncPendingRender: 1`, `pending: 0`.
+
+### R3 — Exactly-once terminal per id
+
+No double-close, no double-fail.
+
+- [ ] **Scenario:** rapid property-pane toggles (10+ in 2 seconds). Tally: many `opens`; `closes.total + fails.total === opens`; no impossible inflation in any per-via counter.
+- [ ] **Pending column oscillates** between 0 and 1 — never sticks above 1.
+
+### R4 — Bind-pending-render at every render branch
+
+`coordinator.bindPendingRenderCurrent()` is called at the end of `handleNormalFinalise` AND `handleFetchMore`'s host-decline branch.
+
+- [ ] **Scenario A** (normal-finalise render path): change the spec to swap a chart type. Tally: `closes.asyncPendingRender` increments by 1.
+- [ ] **Scenario B** (fetch-more host-decline): bind a >30K row dataset; when the chain finalises with the segments collected so far, the final close is `async-pending-render` (not `safety-net`).
+
+### R5 — Edit-mode migration persists and closes synchronously
+
+- [ ] **Scenario:** open a BETA 1.9 pbix in BETA 2.0 Desktop with `PBIVIZ_DEV_FORCE_READ_MODE=false`. Tally:
+  - First update: `opens: 1`, then triggers `persistProperties` for migration → host queues a follow-up update.
+  - Second update (host echo): `opens: 2`, `closes.syncCurrent: 1` (the skip path U8 close).
+- [ ] **No safety-net fires.**
+
+### R6 — Coalesced supersede emits `renderingFailed`, not `renderingFinished`
+
+The cert-correct supersede behaviour from U7.
+
+- [ ] **Scenario:** drag the visual's resize handle aggressively to coalesce updates. Tally: `fails.superseded` counter increments multiple times during the storm.
+- [ ] **Console log:** `[lifecycle] renderingFailed id=N reason=superseded via=superseded` for each superseded id.
+
+### R7 — Errors yield a clean started→failed pair
+
+- [ ] **Scenario A** (synchronous catch): wrap a setting change in something that throws inside `update()`. Tally: `fails.syncCurrent` increments.
+- [ ] **Scenario B** (Vega render error): edit spec to a syntactically valid but semantically broken Vega spec. Tally: `fails.asyncPendingRender` increments. Recent-failures panel shows the message.
+- [ ] In both cases, **no `renderingFinished` is emitted for the failed id** (no inflation of `closes.total`).
+
+### R8 — Segmented fetch retained; each segment closes 1:1
+
+- [ ] **Scenario:** bind a 50K-row dataset. Tally:
+  - Multiple `opens` (one per segment update).
+  - All intermediate segments close `via=sync-current` (U8's fetch-more success close).
+  - Final painting segment closes `via=async-pending-render`.
+- [ ] **No orphans, no safety-net fires.**
+
+### R9 — Row-window 10K → 30K
+
+- [ ] **Scenario:** bind a 25K-row dataset. Tally:
+  - `opens: 1` (single update, no segmented chain).
+  - `closes.asyncPendingRender: 1`.
+- [ ] **Console log:** no `Attempting to fetch more data...` line — the entire dataset arrived in one window.
+
+### R10 — No property-migration persistence in read mode
+
+- [ ] **Scenario:** set `PBIVIZ_DEV_FORCE_READ_MODE=true`. Open a BETA 1.9 pbix. Console shows `[read-mode-gate] persistence suppression set to true for the current update`. Tally: `opens: 1`, `closes.asyncPendingRender: 1` (or `safety-net` if Vega doesn't re-embed — see U10 settle path).
+- [ ] **No `persistProperties` calls** observable in console.
+- [ ] **Migrated values are applied in-memory** — verify by inspecting context-menu state after right-click.
+
+### R12 — Every update closes exactly 1:1
+
+The umbrella requirement. Verified by Phase 1's collective tally observations.
+
+- [ ] **Sustained session:** open the visual, interact with it normally for 5 minutes (changes, resizes, filters). At the end, `opens === closes.total + fails.total` exactly.
+- [ ] **Pending count returns to 0** during idle moments — sustained `pending > 1` indicates an undiagnosed orphan path.
+
+### R13 / R14 — Dev-overlay tally available
+
+- [ ] **Scenario:** with `PBIVIZ_DEV_OVERLAY=true`, the lifecycle + history overlay appears top-left; the tally updates live across all scenarios above. Minimize/restore works. History section can be expanded for forensic detail.
+
+---
+
+## Phase 2 — Acceptance-criterion verification
+
+Concrete scenarios tied to specific AEs from the plan.
+
+### AE1 — Skip path: exactly one sync `renderingFinished`
+
+- [ ] **Scenario:** change a property that doesn't affect the dataView (e.g., a Deneb-only `logLevel` toggle while spec/data are stable). Tally: `closes.syncCurrent` increments. **No `async-pending-render` increment** for this update.
+
+### AE2 — Each fetch-more segment closes via its own pair
+
+- [ ] **Verified by R8 scenario above.**
+
+### AE3 — Error path: started → failed, no orphan, no finished
+
+- [ ] **Verified by R7's Vega render error scenario above.**
+
+### AE4 — Read-mode migration: no persist, in-memory remap, lifecycle closes
+
+- [ ] **Verified by R10 scenario above.** Additionally, verify right-click on the visual produces the expected context menu (the in-memory remap fixed the pre-1.10 `enableContextMenu: false` to `true`).
+
+### AE5 — Edit-mode migration: persist + synchronous close
+
+- [ ] **Verified by R5 scenario above.**
+
+### AE6 — `closeCurrent` twice → second ignored (exactly-once guard)
+
+Already pinned at the unit-test level in 32 coordinator tests. Additionally:
+
+- [ ] **Scenario:** rapid update storm. Tally shows balanced `opens === closes.total + fails.total` even when individual updates fire close paths concurrently (race-resistant by the coordinator's internal exactly-once guard).
+
+### AE7 — Coalesced updates: one terminal per id, supersede emits failed
+
+- [ ] **Verified by R6 scenario above.** Additionally, the resize storm should NOT produce inflated `closes.asyncPendingRender` counts (each supersede counts as a `fail`, not a `close`).
+
+---
+
+## Phase 3 — Segmented-fetch four-quirk regression
+
+The four scenarios the U7-U10 chain was explicitly designed to preserve. From `docs/solutions/logic-errors/segmented-fetch-viewer-editor-transition-quirks-2026-05-27.md`.
+
+### Quirk 1 — Cross-filter mid-fetch
+
+- [ ] **Scenario:** bind a 50K dataset to Deneb. Start fetch. Before completion, click a data point in another visual to apply a cross-filter. Tally:
+  - Multiple `opens`.
+  - The interrupting update closes `via=sync-current` (recover handler).
+  - No safety-net fires.
+- [ ] Dataset eventually shows the filtered subset.
+
+### Quirk 2 — Viewer↔editor transition mid-fetch
+
+- [ ] **Scenario:** bind a 50K dataset. Click "Edit" while still fetching. Tally: recover handler fires; `closes.syncCurrent` increments for the interrupting update.
+- [ ] Dataset slice preserved (Math.max `rowsLoaded` — verify no row-count regression by checking the visual's count display if any).
+
+### Quirk 3 — Reduced-restart payload preservation
+
+- [ ] **Scenario:** within Quirk 2's setup, observe that the visual doesn't blank out into a "0 rows" state after the transition — the previously-loaded data slice is preserved.
+
+### Quirk 4 — Initial-segment-while-fetching detection
+
+- [ ] **Scenario:** bind 50K dataset; let it complete one or two segments; switch to a different page in the report; switch back. Tally: recover handler fires; `closes.syncCurrent` increments.
+
+---
+
+## Phase 4 — Export / print-to-PDF correctness
+
+The end-state cert deliverable. Snapshot service relies on accurate `renderingFinished` to capture visual state.
+
+- [ ] **Scenario A** (small dataset): print a report page containing a Deneb visual with a ≤5K row dataset to PDF. The visual renders completely in the PDF (no blank canvas, no truncation).
+- [ ] **Scenario B** (large dataset): repeat with a ~25K row dataset (single-window now, post-U6). The visual renders completely.
+- [ ] **Scenario C** (segmented fetch): repeat with a 50K row dataset. The visual renders completely after the fetch chain completes — no partial captures, no timeouts.
+- [ ] **Scenario D** (multiple visuals): print a page containing 3+ Deneb visuals with different specs. All capture completely.
+
+---
+
+## Phase 5 — CodeScene re-scan
+
+The CodeScene flag on `resolveDataset` was a contributing motivation for the plan.
+
+- [ ] **Open CodeScene** (or the relevant complexity-analysis tool) and re-scan `src/index.ts`.
+- [ ] **Verify:** `resolveDataset` no longer flags as a high-complexity hotspot, OR the residual complexity is the irreducible dispatcher shape (action.kind switch + handler dispatch + exhaustive `never` default).
+- [ ] Note the before/after complexity score in this checklist's commit message when closing out.
+
+---
+
+## Phase 6 — Wrap-up
+
+Once every checkbox above passes:
+
+- [ ] Update the plan document (`2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md`) frontmatter: `status: active` → `status: completed`.
+- [ ] Append a "Verified" note to the plan body with a link to this checklist's commit SHA.
+- [ ] Update this checklist's frontmatter: `status: ready-for-uat` → `status: passed` (or `failed` with notes if scenarios broke).
+- [ ] Consider a `docs/solutions/` learning capture for any non-obvious behaviours observed during UAT.
+
+---
+
+## What "pass" looks like in one sentence
+
+Every update during normal interactive use produces exactly one host terminal with the correct attribution (`sync-current`, `async-pending-render`, or `safety-net` for true orphans only); the tally's `pending` count never sustains above 1; the recent-failures panel surfaces meaningful error context for any deliberate error scenario; export captures complete without truncation.
+
+## If a scenario fails
+
+1. Capture the tally state at the moment of failure (screenshot the overlay).
+2. Capture the console log lines around the failure (`[lifecycle]` and `[read-mode-gate]` prefixes).
+3. Note which scenario failed and what was observed vs expected.
+4. File as a follow-up issue with the U-unit suspected. The U11 tally's `via` discriminator usually points at the failing closer.

--- a/docs/plans/2026-06-10-001-u12-lifecycle-compliance-verification.md
+++ b/docs/plans/2026-06-10-001-u12-lifecycle-compliance-verification.md
@@ -123,6 +123,13 @@ The umbrella requirement. Verified by Phase 1's collective tally observations.
 - [ ] **Sustained session:** open the visual, interact with it normally for 5 minutes (changes, resizes, filters). At the end, `opens === closes.total + fails.total` exactly.
 - [ ] **Pending count returns to 0** during idle moments — sustained `pending > 1` indicates an undiagnosed orphan path.
 
+### R11 — Coordinated single effort
+
+Process/meta requirement from the plan (this work landed as a single
+coordinated sequence rather than as ad-hoc fixes), satisfied by the
+plan structure itself and by U5-U12's linked commit history. **No
+standalone UAT scenario.**
+
 ### R13 / R14 — Dev-overlay tally available
 
 - [ ] **Scenario:** with `PBIVIZ_DEV_OVERLAY=true`, the lifecycle + history overlay appears top-left; the tally updates live across all scenarios above. Minimize/restore works. History section can be expanded for forensic detail.

--- a/docs/solutions/architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md
+++ b/docs/solutions/architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md
@@ -28,8 +28,14 @@ tags:
     - observability
     - power-bi-host
 related_components:
-    - development_workflow
-    - documentation
+    - src/lib/rendering-lifecycle/coordinator.ts
+    - src/lib/rendering-lifecycle/types.ts
+    - src/index.ts
+    - src/app/app.tsx
+    - packages/app-core/src/features/visual-viewer/components/vega-embed.tsx
+    - packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
+    - src/features/visual-update-history-overlay
+    - src/features/dev-overlay-shell
 ---
 
 # Rendering Lifecycle Coordinator — single-owner host-event pattern for Power BI custom visuals

--- a/docs/solutions/architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md
+++ b/docs/solutions/architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md
@@ -1,0 +1,286 @@
+---
+title: 'Rendering Lifecycle Coordinator — single-owner host-event pattern for Power BI custom visuals'
+date: 2026-07-03
+category: architecture-patterns
+module: rendering-lifecycle
+problem_type: architecture_pattern
+component: tooling
+severity: critical
+applies_when:
+    - 'Building a Power BI custom visual that must emit strict 1:1 host.eventService.rendering* events for Microsoft certification'
+    - 'Any host-driven visual where update() may or may not produce a paint (skip / fetch-more / persist-only / incremental-data / renderless paths)'
+    - 'Coordinating async render callbacks with a synchronous update() entry point under coalesced updates'
+    - 'A host lifecycle event has multiple candidate closers (async render callback, sync dispatch path, error catch, safety-net) and attribution must be correct'
+    - 'Certified builds forbid console.error and the host reason string is a write-only sink — error observability requires a dedicated in-app channel'
+tags:
+    - power-bi
+    - rendering-lifecycle
+    - certification
+    - coordinator-pattern
+    - single-owner
+    - single-writer
+    - update-identity
+    - exactly-once
+    - safety-net
+    - supersede
+    - dependency-injection
+    - dev-overlay
+    - observability
+    - power-bi-host
+related_components:
+    - development_workflow
+    - documentation
+---
+
+# Rendering Lifecycle Coordinator — single-owner host-event pattern for Power BI custom visuals
+
+## Context
+
+Power BI custom visuals get a single lifecycle contract from the host: for every `update(options)` the visual receives, the host expects exactly one matching terminal — `renderingFinished(options)` or `renderingFailed(options, reason)`. That contract underpins the snapshot/export service: PDF export and image snapshots are captured on `renderingFinished`. An orphaned `renderingStarted` breaks export in ways that are cert-blocking during Microsoft's AppSource review.
+
+Deneb's `update()` has more than one dispatch shape:
+
+- **Non-rendering paths** — skip (no data change), fetch-more (host accepted the segment; the next segment will arrive as its own `update()`), recover-interrupted-fetch (viewer↔editor transition aborted a segmented fetch).
+- **Rendering paths** — normal finalise, fetch-more where the host declined further segments. React re-renders, Vega embeds, and the completion signal arrives async through `vega-embed`'s `onRendering*` callbacks.
+- **Renderless modes** — landing, no-project, initializing, fetching, viewer↔editor transitions. React mounts a status component; Vega never embeds; `vega-embed`'s callbacks never fire.
+- **Rendering-mode-without-Vega-change** — a formatting property (editor theme, log level) changes; `handleNormalFinalise` runs but Vega's input deps are unchanged, so `vega-embed`'s effect never re-fires.
+- **Incremental data-update path** — Vega view is patched in place via `view.data()`; `vega-embed`'s `onRendering*` callbacks are tied to a full embed, not to in-place updates, so they never fire.
+
+Before this pattern, `renderingStarted` was fired eagerly at the top of `update()` and the terminal was scattered — some paths hit `renderingFinished` via `vega-embed`'s callback, several never did. Attribution was also broken: the async React callback that eventually did close would capture the wrong `visualUpdateOptions` if a newer `update()` had arrived in the meantime.
+
+There is a second constraint that shapes the design: in certified builds `console.error` is forbidden, and the host's `renderingFailed` `reason` parameter is write-only from the visual's perspective. There is no cert-permitted channel for surfacing error context to a developer during a certified build unless the visual builds its own.
+
+## Guidance
+
+The pattern is a **single-owner lifecycle coordinator** — one module owns every `host.eventService.rendering*` call, and everything else in the visual routes through its API. In Deneb it lives at `src/lib/rendering-lifecycle/coordinator.ts` with types at `src/lib/rendering-lifecycle/types.ts`, and it holds seven properties:
+
+### 1. Per-update identity, exactly-once terminal
+
+Every `open()` mints an opaque branded id and records it in a `Map<Id, OpenIdState>`. Terminal paths **delete the entry from the map before emitting to the host**. Map presence _is_ the exactly-once guard — no separate `closed` flag:
+
+```ts
+const closeInternal = (id, via) => {
+    const state = openIds.get(id);
+    if (!state) return; // exactly-once: no-op if already closed
+    if (state.safetyNet) state.safetyNet.cancel();
+    openIds.delete(id); // delete BEFORE host emission
+    observe({ kind: 'closed', id, via });
+    emitter.renderingFinished(state.options);
+};
+```
+
+Ordering matters: if the host throws on emission, the id is already gone. Any follow-up attempt (`update()`'s catch routing to `failCurrent`) finds nothing and no-ops — no half-closed limbo. The doc-comment calls this the "truthful-or-loud" invariant.
+
+### 2. At-most-one open id — supersede as failed
+
+A new `open()` walks the map first and supersede-fails any prior open id with a synthetic `SUPERSEDED_FAILURE_REASON = 'superseded'` marker before minting the new id. Every prior id has a terminal; the marker is distinct from a real render error so diagnostics can separate the two.
+
+### 3. Two dispatch surfaces: `*Current` (sync) vs `*PendingRender` (async)
+
+Synchronous dispatch handlers in `update()` don't know the minted id — it's created inside `update()`'s `try` after `open()`. Threading it through `resolveUpdateOptions → resolveDataset → each handler` would require an optional-id parameter chain. Instead the coordinator exposes **no-arg variants that look up "the currently open id"** (invariant #1 guarantees at most one):
+
+```ts
+const closeCurrent = () => {
+    const id = currentOpenId();
+    if (id === null) return;
+    closeInternal(id, 'sync-current');
+};
+```
+
+Async React callbacks route to `*PendingRender` variants. Dispatch handlers that will render bind the current open id to `pendingRenderId` **synchronously before returning**:
+
+```ts
+// handleNormalFinalise, at the end:
+this.#coordinator.bindPendingRenderCurrent();
+```
+
+By the time React's callback fires, `pendingRenderId` already targets the right id — the async callback needs no arguments and cannot mis-attribute.
+
+### 4. Split type: production API vs test surface
+
+The factory returns a `RenderingLifecycleCoordinatorTestSurface` that adds id-bearing variants (`close(id)`, `fail(id, error)`, `markRenderStarted(id)`) for deterministic test orderings. Production callers narrow at the field declaration:
+
+```ts
+#coordinator: RenderingLifecycleCoordinator;
+```
+
+The narrower type omits the id-bearing methods, so the type system rejects production code that would hard-code a misleading `via: 'sync-current'` discriminator. Test determinism is preserved without polluting the production API.
+
+### 5. Bounded safety-net — cert ceiling, not a tuning knob
+
+The coordinator can arm a bounded timer per id. When it fires:
+
+- If the id already closed normally, the map lookup misses — inert.
+- If `renderStarted === false`, the render never began — close it as an orphan.
+- If `renderStarted === true`, the render is in-flight — trust it, don't close.
+
+The bound in `src/index.ts` is `SAFETY_NET_BOUND_MS = 10_000`. **This is the Power BI certification ceiling, not a tunable.** If a legitimate path is exceeding the bound, the fix is to wire that path through the coordinator, not to raise the constant.
+
+### 6. Dependency injection at the seams
+
+The factory takes `{ emitter, scheduler, logger?, observer? }`. Production wires the real host event service and `setTimeout`; unit tests inject a synthetic scheduler that exposes the pending callback for deterministic ticks and a plain mock emitter — no need to instantiate a full `IVisualHost`.
+
+### 7. Observer as the cert-permitted diagnostic channel
+
+Every state transition emits a structured event into an optional observer:
+
+```ts
+type RenderingLifecycleEvent =
+    | { kind: 'opened'; id; options }
+    | { kind: 'render-started'; id }
+    | {
+          kind: 'closed';
+          id;
+          via: 'sync-current' | 'async-pending-render' | 'safety-net';
+      }
+    | {
+          kind: 'failed';
+          id;
+          reason;
+          error?;
+          via: 'sync-current' | 'async-pending-render' | 'superseded';
+      }
+    | { kind: 'safety-net-armed'; id }
+    | {
+          kind: 'safety-net-tick';
+          id;
+          result: 'closed' | 'deferred' | 'inert';
+      };
+```
+
+In production `PBIVIZ_DEV_OVERLAY=true` wires the observer to a bounded ring in the visual's Zustand store; a dev overlay computes a live start-vs-close tally by `via` discriminator. Because the event carries the _original_ error value (not just the stringified `reason` the host receives), it's the only channel that can surface real error context in certified builds where `console.error` is banned.
+
+### Visual `update()` wiring
+
+`open()` is the first statement in the `try`; the `finally` arms the safety-net for whichever id was minted:
+
+```ts
+public update(options: VisualUpdateOptions) {
+    let openId: RenderingLifecycleId | undefined;
+    try {
+        openId = this.#coordinator.open(options);
+        // ... resolveUpdateOptions runs; dispatch handlers call
+        // closeCurrent() (non-rendering) or bindPendingRenderCurrent()
+        // (rendering)
+    } catch (e) {
+        this.#coordinator.failCurrent(e);
+    } finally {
+        if (openId !== undefined) this.#coordinator.armSafetyNet(openId);
+    }
+}
+```
+
+If `open()` itself throws (host rejected the `renderingStarted` emission), `openId` stays `undefined` — the safety-net is never armed for a never-opened id, and `failCurrent()` in the catch finds nothing and no-ops.
+
+### App-side adapters
+
+The React app never imports the coordinator. `src/index.ts` builds three no-arg / one-arg adapters in the constructor and hands them to `<App>` as props:
+
+```ts
+this.#onRenderingStartedAdapter = () =>
+    this.#coordinator.markPendingRenderStarted();
+this.#onRenderingFinishedAdapter = () => this.#coordinator.closePendingRender();
+this.#onRenderingErrorAdapter = (error) =>
+    this.#coordinator.failPendingRender(error);
+```
+
+`app.tsx` threads these unchanged through the platform provider's `onRendering*` slots. There's no `visualUpdateOptions` capture and no risk of stale attribution — the id was bound before `update()` returned.
+
+A companion `useEffect` in `app.tsx` handles the two paths Vega's callbacks can't cover:
+
+- **Renderless modes** close synchronously when the effect runs.
+- **Rendering modes with no Vega-affecting change** get a 500 ms settle timer that closes via `onRenderingFinished()`. React's built-in effect cleanup caps in-flight timers at one regardless of update storm size. When Vega does close first, the timer eventually fires against a coordinator that already deleted the id — the exactly-once guard makes it a no-op.
+
+## Why This Matters
+
+Each property protects against a specific failure mode observed in Deneb:
+
+| Property | Failure mode when absent |
+|---|---|
+| Single owner of `rendering*` | Modules drift; some paths emit `renderingStarted` without any matching terminal. PDF export breaks. |
+| Delete before host emission | Host throws on emission → visual believes id is still open → follow-up `failCurrent` also emits → host contract violated twice. |
+| Supersede as failed | Prior orphan never closes; a burst of resize updates leaves one dangling `renderingStarted` per burst. |
+| `*Current` no-arg surface | Handlers need the id threaded through every call site; refactor pressure to route the id via globals or captured locals; attribution drift. |
+| `*PendingRender` no-arg surface | React callback captures a `visualUpdateOptions` from N updates ago and emits `renderingFinished(stale)`. Host sees terminal for the wrong id. |
+| Split test-surface type | Production code hard-codes `via: 'sync-current'` observer events from an async context; dev-overlay tally becomes actively misleading. |
+| Dep injection | Unit tests can't drive supersede/race/safety-net orderings deterministically; test complexity forces the coordinator to grow test-only branches. |
+| Safety-net at cert ceiling | If bound > 10s, cert reviewers observe an orphan window; if the bound is tuned per-path, the "raise the number" fix hides genuine wiring bugs. |
+| Observer | No cert-permitted way to surface `renderingFailed` error context during a certified build (host `reason` is write-only; `console.error` forbidden). |
+
+## When to Apply
+
+- Any Power BI custom visual whose `update()` has more than one dispatch shape (skip, fetch-more, incremental, renderless landing, transition modes).
+- React-in-async-host situations where a synchronous host call triggers async work (embed, fetch, render) whose completion the host cares about, and the async completion callback needs to identify _which_ prior host call it terminates.
+- Any visual where certified builds forbid `console.error` and error-context observability requires a dedicated in-app channel.
+
+The pattern is more general than Power BI: read `rendering*` as "host-facing lifecycle events" and it applies to any embedded-widget host contract with the same shape (Office add-ins, Looker Custom Vis, Tableau Extensions).
+
+## Examples
+
+### (a) Old direct-emission (broken attribution) vs coordinator adapters
+
+Before — `app.tsx` captured `visualUpdateOptions` from the store to satisfy the `renderingFinished(options)` signature. By the time the async render callback fired, `visualUpdateOptions` had rolled forward to a newer update and the host received a terminal for the wrong id:
+
+```tsx
+// Antipattern (representative of pre-coordinator code)
+const options = useDenebVisualState((s) => s.updates.options);
+// ... passed down to vega-embed:
+onRenderingFinished={() => host.eventService.renderingFinished(options)}
+// options may already reference a later update()
+```
+
+After — no options capture; the coordinator remembers the id:
+
+```tsx
+// src/index.ts constructor
+this.#onRenderingFinishedAdapter = () =>
+    this.#coordinator.closePendingRender();
+// app.tsx: passed as prop, threaded through provider unchanged
+```
+
+### (b) Skip-close on a non-rendering dispatch
+
+```ts
+if (action.kind === 'skip') {
+    logDebug('Visual dataset has not changed. No need to process.');
+    // Skip is non-rendering — no async callback will follow.
+    // Close synchronously so the host sees a balanced pair.
+    this.#coordinator.closeCurrent();
+    return;
+}
+```
+
+### (c) Observer-fed dev-overlay tally
+
+```ts
+// src/index.ts constructor — observer wired only when the env gate is on
+this.#coordinator = createRenderingLifecycleCoordinator({
+    emitter: host.eventService,
+    scheduler: renderingLifecycleScheduler,
+    logger: logHost,
+    observer: IS_LIFECYCLE_OBSERVER_ENABLED
+        ? useDenebVisualState.getState().updates.recordLifecycleEvent
+        : undefined
+});
+```
+
+The observer receives events tagged with `via: 'sync-current' | 'async-pending-render' | 'safety-net' | 'superseded'`; the `VisualUpdateHistoryOverlay` reads the ring and tallies close paths per discriminator. Failed events carry the original `error` object, not just the stringified `reason`, so a developer running a certified build can still see the actual error context that the host's write-only `reason` slot swallows.
+
+## Related
+
+- [freeze-on-viewer-editor-transition-2026-05-01.md](../ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md) — the deferred `renderingStarted`/`renderingFinished` contract mismatch flagged as a "Known follow-up" is **resolved by the pattern in this doc**. The follow-up bullet in that doc can be struck through and replaced with a link here.
+- [lifecycle-owns-effect-rebind-identity-token-2026-04-28.md](../best-practices/lifecycle-owns-effect-rebind-identity-token-2026-04-28.md) — the React-side sibling: single-owner identity token for effect rebinds. Same "single-writer of a lifecycle-scoped identity" pattern shape applied to a different scope.
+- [segmented-fetch-viewer-editor-transition-quirks-2026-05-27.md](../logic-errors/segmented-fetch-viewer-editor-transition-quirks-2026-05-27.md) — the dataset-lifecycle counterpart. The dispatch actions (`fetch-more`, `recover-interrupted-fetch`) that this coordinator's `closeCurrent()` binds to are defined and defended in that doc.
+- [dedup-synthetic-identity-token-rebind-trigger-2026-04-28.md](../best-practices/dedup-synthetic-identity-token-rebind-trigger-2026-04-28.md) — sibling "don't-saturate-downstream" pattern; different mechanism (dedup guard) but same target (prevent multi-writer noise on a lifecycle-owned signal).
+- Originating plan: [`docs/plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md`](../../plans/2026-05-28-001-refactor-simplify-deneb-resolve-dataset-plan.md) — U5–U12 with per-unit rationale.
+- Verification checklist: [`docs/plans/2026-06-10-001-u12-lifecycle-compliance-verification.md`](../../plans/2026-06-10-001-u12-lifecycle-compliance-verification.md).
+- GitHub issue: [deneb-viz/deneb#553](https://github.com/deneb-viz/deneb/issues/553) — the PDF-export-blank symptom class the coordinator addresses.
+
+**Primary source files:**
+
+- `src/lib/rendering-lifecycle/coordinator.ts` — implementation
+- `src/lib/rendering-lifecycle/types.ts` — public API contract, split test-surface type, `RenderingLifecycleEvent` union
+- `src/index.ts` — `Deneb.update()` wiring, adapter construction, `SAFETY_NET_BOUND_MS` rationale
+- `src/app/app.tsx` — adapter forwarding, renderless-mode close, 500 ms settle timer
+- `src/features/visual-update-history-overlay/` — observer consumer + tally
+- `src/features/dev-overlay-shell/` — shared shell for dev overlays


### PR DESCRIPTION
Two docs closing out the U5–U12 lifecycle work:

- `docs/plans/2026-06-10-001-u12-lifecycle-compliance-verification.md` —
  the U12 manual UAT checklist. Six phases: automated gate,
  per-requirement, per-AE, four-quirk regression, export, CodeScene.
  Statuses flip once the sweep runs.

- `docs/solutions/architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md` —
  the durable architecture-pattern learning captured from the plan.
  Seven properties of the pattern, cross-linked to the sibling
  React-side single-owner pattern and the segmented-fetch quirks doc.
  First doc in a new `architecture-patterns/` category — CLAUDE.md
  already points at `docs/solutions/` so no discoverability edit needed.