### PR TITLE
feat(visual): versioned stateManagement migration epoch with ordered registry (U2)

### DIFF
--- a/src/lib/dataset/support-field-migration.ts
+++ b/src/lib/dataset/support-field-migration.ts
@@ -1,4 +1,4 @@
-import { PROJECT_DEFAULTS } from '@deneb-viz/configuration';
+import { isSupportFieldMigrationPending } from '../persistence/state-management-migration';
 
 /**
  * Determine if a spec is a legacy (pre-2.0) spec that predates the support
@@ -10,11 +10,16 @@ import { PROJECT_DEFAULTS } from '@deneb-viz/configuration';
  * - The persisted denebMetaVersion is < 2 (pre-2.0 or never set)
  *
  * A brand new spec (default template) is NOT legacy — it gets new defaults.
+ *
+ * This is a thin delegate: the WHETHER decision (version comparison and
+ * the cross-GUID/fresh-visual applicability check) is owned by the ordered
+ * migration registry in
+ * `src/lib/persistence/state-management-migration.ts`. The execution point
+ * (the stamping block in `./processing.ts`) supplies its own trigger —
+ * this is a class `'first-dataview'` migration that needs DataView columns
+ * unavailable at load time.
  */
 export const isLegacySpec = (
     jsonSpec: string,
     denebMetaVersion: number
-): boolean => {
-    const hasProject = jsonSpec !== PROJECT_DEFAULTS.spec;
-    return hasProject && denebMetaVersion < 2;
-};
+): boolean => isSupportFieldMigrationPending(jsonSpec, denebMetaVersion);

--- a/src/lib/persistence/__test__/fixtures/corrupt-meta-version.json
+++ b/src/lib/persistence/__test__/fixtures/corrupt-meta-version.json
@@ -1,0 +1,20 @@
+{
+    "description": "Corrupt version stamp: denebMetaVersion holds a non-numeric value. The payload version is indeterminate, so the pipeline fails safe — it runs NOTHING (re-running migrations against possibly-already-migrated state risks double application), surfaces the typed corrupt-key signal, and leaves the payload untouched.",
+    "jsonSpec": "{\"data\":{\"name\":\"dataset\"},\"mark\":\"bar\",\"encoding\":{\"x\":{\"field\":\"Category\",\"type\":\"nominal\"},\"y\":{\"field\":\"Sales\",\"type\":\"quantitative\"}}}",
+    "stateManagement": {
+        "supportFieldConfiguration": "{\"Sales\":{\"highlight\":true,\"highlightStatus\":true,\"highlightComparator\":true,\"format\":true,\"formatted\":true}}",
+        "denebMetaVersion": "not-a-version",
+        "consolidateFieldParameters": true
+    },
+    "expected": {
+        "classification": "indeterminate",
+        "applied": [],
+        "pendingFirstDataview": [],
+        "corruptKeys": ["denebMetaVersion"],
+        "payload": {
+            "supportFieldConfiguration": "{\"Sales\":{\"highlight\":true,\"highlightStatus\":true,\"highlightComparator\":true,\"format\":true,\"formatted\":true}}",
+            "denebMetaVersion": "not-a-version",
+            "consolidateFieldParameters": true
+        }
+    }
+}

--- a/src/lib/persistence/__test__/fixtures/corrupt-support-field-config.json
+++ b/src/lib/persistence/__test__/fixtures/corrupt-support-field-config.json
@@ -1,0 +1,20 @@
+{
+    "description": "Corrupt JSON in a persisted key: supportFieldConfiguration was truncated mid-write. The pipeline surfaces a typed corrupt-key signal for the caller to act on and leaves the raw value in place — NOT a silent reset. The version stamp is intact so classification is otherwise normal.",
+    "jsonSpec": "{\"data\":{\"name\":\"dataset\"},\"mark\":\"point\",\"encoding\":{\"x\":{\"field\":\"Region\",\"type\":\"nominal\"},\"y\":{\"field\":\"Margin\",\"type\":\"quantitative\"}}}",
+    "stateManagement": {
+        "supportFieldConfiguration": "{\"Margin\":{\"highlight\":true,\"highlightStatus\":tr",
+        "denebMetaVersion": "2",
+        "scaleToZoom": false
+    },
+    "expected": {
+        "classification": "current",
+        "applied": [],
+        "pendingFirstDataview": [],
+        "corruptKeys": ["supportFieldConfiguration"],
+        "payload": {
+            "supportFieldConfiguration": "{\"Margin\":{\"highlight\":true,\"highlightStatus\":tr",
+            "denebMetaVersion": "2",
+            "scaleToZoom": false
+        }
+    }
+}

--- a/src/lib/persistence/__test__/fixtures/current-version.json
+++ b/src/lib/persistence/__test__/fixtures/current-version.json
@@ -1,0 +1,26 @@
+{
+    "description": "Visual already at the current schema version (denebMetaVersion 2, fully-populated payload). Everything is a no-op: no entries apply, nothing is pending, and the output payload deep-equals the input.",
+    "jsonSpec": "{\"data\":{\"name\":\"dataset\"},\"mark\":\"line\",\"encoding\":{\"x\":{\"field\":\"Date\",\"type\":\"temporal\"},\"y\":{\"field\":\"Sales\",\"type\":\"quantitative\"}}}",
+    "stateManagement": {
+        "viewportHeight": "480",
+        "viewportWidth": "640",
+        "supportFieldConfiguration": "{\"Sales\":{\"highlight\":true,\"highlightStatus\":true,\"highlightComparator\":true,\"format\":true,\"formatted\":true},\"Category\":{\"highlight\":true,\"highlightStatus\":false,\"highlightComparator\":false,\"format\":false,\"formatted\":false}}",
+        "denebMetaVersion": "2",
+        "scaleToZoom": true,
+        "consolidateFieldParameters": false
+    },
+    "expected": {
+        "classification": "current",
+        "applied": [],
+        "pendingFirstDataview": [],
+        "corruptKeys": [],
+        "payload": {
+            "viewportHeight": "480",
+            "viewportWidth": "640",
+            "supportFieldConfiguration": "{\"Sales\":{\"highlight\":true,\"highlightStatus\":true,\"highlightComparator\":true,\"format\":true,\"formatted\":true},\"Category\":{\"highlight\":true,\"highlightStatus\":false,\"highlightComparator\":false,\"format\":false,\"formatted\":false}}",
+            "denebMetaVersion": "2",
+            "scaleToZoom": true,
+            "consolidateFieldParameters": false
+        }
+    }
+}

--- a/src/lib/persistence/__test__/fixtures/empty-cross-guid.json
+++ b/src/lib/persistence/__test__/fixtures/empty-cross-guid.json
@@ -1,0 +1,12 @@
+{
+    "description": "Empty objects payload: a fresh visual, or a .pbix opened under a different packaging-channel GUID (persisted formatting properties do not carry across visual GUIDs, so EVERYTHING — including vega.jsonSpec — reverts to defaults). jsonSpec null means 'the factory default template'. This must be distinguishable from a genuinely unversioned legacy payload: it is NOT legacy and no migration runs or pends.",
+    "jsonSpec": null,
+    "stateManagement": {},
+    "expected": {
+        "classification": "empty-or-cross-guid",
+        "applied": [],
+        "pendingFirstDataview": [],
+        "corruptKeys": [],
+        "payload": {}
+    }
+}

--- a/src/lib/persistence/__test__/fixtures/partial-config-no-meta-version.json
+++ b/src/lib/persistence/__test__/fixtures/partial-config-no-meta-version.json
@@ -1,0 +1,18 @@
+{
+    "description": "Partially-populated payload — the split the audit's M10 finding describes: supportFieldConfiguration (and other keys) persisted, but denebMetaVersion absent because the stamps were persisted piecemeal and one write was lost. The payload classifies as unversioned-legacy (project content present, no stamp), the first-dataview migration is pending, and CRITICALLY the present keys must survive untouched — merged, never wiped.",
+    "jsonSpec": "{\"data\":{\"name\":\"dataset\"},\"mark\":\"area\",\"encoding\":{\"x\":{\"field\":\"Month\",\"type\":\"ordinal\"},\"y\":{\"field\":\"Units\",\"type\":\"quantitative\"}}}",
+    "stateManagement": {
+        "supportFieldConfiguration": "{\"Units\":{\"highlight\":false,\"highlightStatus\":false,\"highlightComparator\":false,\"format\":true,\"formatted\":true}}",
+        "scaleToZoom": true
+    },
+    "expected": {
+        "classification": "unversioned-legacy",
+        "applied": [],
+        "pendingFirstDataview": ["support-field-legacy-defaults"],
+        "corruptKeys": [],
+        "payload": {
+            "supportFieldConfiguration": "{\"Units\":{\"highlight\":false,\"highlightStatus\":false,\"highlightComparator\":false,\"format\":true,\"formatted\":true}}",
+            "scaleToZoom": true
+        }
+    }
+}

--- a/src/lib/persistence/__test__/fixtures/unversioned-legacy.json
+++ b/src/lib/persistence/__test__/fixtures/unversioned-legacy.json
@@ -1,0 +1,12 @@
+{
+    "description": "Genuine pre-2.0 visual: real project content persisted in vega.jsonSpec, but the stateManagement object was never written (the payload's keys did not exist before 2.0). This is the genuinely-unversioned legacy case — the support-field first-dataview migration is pending; the load-time pipeline itself applies nothing.",
+    "jsonSpec": "{\"data\":{\"name\":\"dataset\"},\"mark\":\"bar\",\"encoding\":{\"x\":{\"field\":\"Category\",\"type\":\"nominal\"},\"y\":{\"field\":\"Sales\",\"type\":\"quantitative\"}}}",
+    "stateManagement": {},
+    "expected": {
+        "classification": "unversioned-legacy",
+        "applied": [],
+        "pendingFirstDataview": ["support-field-legacy-defaults"],
+        "corruptKeys": [],
+        "payload": {}
+    }
+}

--- a/src/lib/persistence/__test__/migration.test.ts
+++ b/src/lib/persistence/__test__/migration.test.ts
@@ -66,7 +66,13 @@ vi.mock('../../host', () => ({
     }))
 }));
 
-import { handlePropertyMigration } from '../migration';
+import {
+    applyStateManagementPayloadToSettings,
+    getStateManagementPayloadFromSettings,
+    handlePropertyMigration,
+    runStateManagementSchemaMigrations
+} from '../migration';
+import { SUPPORT_FIELD_LEGACY_MIGRATION_ID } from '../state-management-migration';
 import { setReadModePersistSuppressed } from '../read-mode-gate';
 
 // ─── Test fixture types ──────────────────────────────────────────────────────
@@ -79,6 +85,18 @@ import { setReadModePersistSuppressed } from '../read-mode-gate';
  * is enough for these tests.
  */
 type TestField<T> = { value: T };
+type TestStateManagement = {
+    viewport: {
+        viewportHeight: TestField<string | null>;
+        viewportWidth: TestField<string | null>;
+    };
+    projectMetadata: {
+        supportFieldConfiguration: TestField<string>;
+        denebMetaVersion: TestField<string>;
+        scaleToZoom: TestField<boolean>;
+        consolidateFieldParameters: TestField<boolean>;
+    };
+};
 type TestSettings = {
     developer: { versioning: { version: TestField<string> } };
     vega: {
@@ -93,6 +111,7 @@ type TestSettings = {
             enableContextMenuSelector: TestField<boolean>;
         };
     };
+    stateManagement?: TestStateManagement;
 };
 
 const buildSettings = (overrides: {
@@ -120,6 +139,32 @@ const buildSettings = (overrides: {
             enableContextMenuSelector: {
                 value: overrides.enableContextMenuSelector ?? true
             }
+        }
+    }
+});
+
+const buildStateManagement = (
+    overrides: {
+        viewportHeight?: string | null;
+        viewportWidth?: string | null;
+        supportFieldConfiguration?: string;
+        denebMetaVersion?: string;
+        scaleToZoom?: boolean;
+        consolidateFieldParameters?: boolean;
+    } = {}
+): TestStateManagement => ({
+    viewport: {
+        viewportHeight: { value: overrides.viewportHeight ?? null },
+        viewportWidth: { value: overrides.viewportWidth ?? null }
+    },
+    projectMetadata: {
+        supportFieldConfiguration: {
+            value: overrides.supportFieldConfiguration ?? ''
+        },
+        denebMetaVersion: { value: overrides.denebMetaVersion ?? '' },
+        scaleToZoom: { value: overrides.scaleToZoom ?? false },
+        consolidateFieldParameters: {
+            value: overrides.consolidateFieldParameters ?? true
         }
     }
 });
@@ -280,5 +325,121 @@ describe('handlePropertyMigration — read mode', () => {
         ).toBe(false);
         // And the flag stayed where it was — read mode never touches it.
         expect(mockUpdateMigrationDetails).not.toHaveBeenCalled();
+    });
+});
+
+describe('stateManagement schema migrations — load-time wiring', () => {
+    it('reports the pending first-dataview support-field migration for a legacy visual', () => {
+        const settings = {
+            ...buildSettings({ denebVersion: '1.9.0' }),
+            stateManagement: buildStateManagement()
+        };
+        const result = runStateManagementSchemaMigrations(settings as never);
+        expect(result.classification).toBe('unversioned-legacy');
+        expect(result.pendingFirstDataview).toEqual([
+            SUPPORT_FIELD_LEGACY_MIGRATION_ID
+        ]);
+        expect(result.applied).toEqual([]);
+        // Nothing applied → the settings model is untouched.
+        expect(
+            settings.stateManagement.projectMetadata.denebMetaVersion.value
+        ).toBe('');
+    });
+
+    it('classifies a factory-default spec as empty/cross-GUID, not legacy', () => {
+        const settings = {
+            ...buildSettings({ jsonSpec: '__default_spec__' }),
+            stateManagement: buildStateManagement()
+        };
+        const result = runStateManagementSchemaMigrations(settings as never);
+        expect(result.classification).toBe('empty-or-cross-guid');
+        expect(result.pendingFirstDataview).toEqual([]);
+    });
+
+    it('surfaces corrupt persisted JSON as a typed signal and leaves the raw value in place', () => {
+        const corruptRaw = '{"Sales":{"highlight":tru';
+        const settings = {
+            ...buildSettings({}),
+            stateManagement: buildStateManagement({
+                supportFieldConfiguration: corruptRaw,
+                denebMetaVersion: '2'
+            })
+        };
+        const result = runStateManagementSchemaMigrations(settings as never);
+        expect(result.corruptKeys).toHaveLength(1);
+        expect(result.corruptKeys[0]).toMatchObject({
+            key: 'supportFieldConfiguration',
+            rawValue: corruptRaw
+        });
+        // NOT a silent reset — the raw value stays put.
+        expect(
+            settings.stateManagement.projectMetadata.supportFieldConfiguration
+                .value
+        ).toBe(corruptRaw);
+    });
+
+    it('tolerates a settings model without the stateManagement card', () => {
+        mockVisualSettings = buildSettings({});
+        expect(() =>
+            runStateManagementSchemaMigrations(mockVisualSettings as never)
+        ).not.toThrow();
+    });
+
+    it('handlePropertyMigration invokes the schema pipeline without throwing on legacy settings', () => {
+        mockVisualSettings = {
+            ...buildSettings({ denebVersion: '', providerVersion: '' }),
+            stateManagement: buildStateManagement()
+        };
+        expect(() =>
+            handlePropertyMigration(mockVisualSettings as never, false)
+        ).not.toThrow();
+    });
+
+    it('getStateManagementPayloadFromSettings extracts raw persisted values', () => {
+        const settings = {
+            ...buildSettings({}),
+            stateManagement: buildStateManagement({
+                viewportHeight: '480',
+                viewportWidth: '640',
+                supportFieldConfiguration: '{"Sales":{"highlight":true}}',
+                denebMetaVersion: '2',
+                scaleToZoom: true,
+                consolidateFieldParameters: false
+            })
+        };
+        expect(
+            getStateManagementPayloadFromSettings(settings as never)
+        ).toEqual({
+            viewportHeight: '480',
+            viewportWidth: '640',
+            supportFieldConfiguration: '{"Sales":{"highlight":true}}',
+            denebMetaVersion: '2',
+            scaleToZoom: true,
+            consolidateFieldParameters: false
+        });
+    });
+
+    it('applyStateManagementPayloadToSettings writes only the keys present on the payload (merge, never replace)', () => {
+        const stateManagement = buildStateManagement({
+            supportFieldConfiguration: '{"Sales":{"highlight":true}}',
+            scaleToZoom: false
+        });
+        const settings = { ...buildSettings({}), stateManagement };
+        applyStateManagementPayloadToSettings(settings as never, {
+            denebMetaVersion: '2',
+            scaleToZoom: true
+        });
+        expect(stateManagement.projectMetadata.denebMetaVersion.value).toBe(
+            '2'
+        );
+        expect(stateManagement.projectMetadata.scaleToZoom.value).toBe(true);
+        // Keys absent from the payload are untouched.
+        expect(
+            stateManagement.projectMetadata.supportFieldConfiguration.value
+        ).toBe('{"Sales":{"highlight":true}}');
+        expect(stateManagement.viewport.viewportHeight.value).toBeNull();
+        expect(
+            stateManagement.projectMetadata.consolidateFieldParameters.value
+        ).toBe(true);
     });
 });

--- a/src/lib/persistence/__test__/state-management-migration.test.ts
+++ b/src/lib/persistence/__test__/state-management-migration.test.ts
@@ -1,0 +1,538 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+// The registry consults `PROJECT_DEFAULTS.spec` to distinguish "genuinely
+// unversioned legacy payload" from "empty because fresh visual /
+// cross-GUID import". A deterministic sentinel keeps the fixtures
+// independent of the real default template.
+vi.mock('@deneb-viz/configuration', () => ({
+    PROJECT_DEFAULTS: {
+        spec: '__default_spec__',
+        config: '__default_config__'
+    }
+}));
+
+import {
+    assertStateManagementRegistryIntegrity,
+    getCurrentStateManagementVersion,
+    getStateManagementVersionToStamp,
+    hasProjectContent,
+    inspectStateManagementPayload,
+    isStateManagementMigrationPending,
+    isSupportFieldMigrationPending,
+    parseDenebMetaVersion,
+    runStateManagementLoadTimeMigrations,
+    StateManagementRegistryError,
+    SUPPORT_FIELD_LEGACY_MIGRATION_ID,
+    type StateManagementLoadTimeMigrationEntry,
+    type StateManagementMigrationEntry,
+    type StateManagementPayload,
+    type StateManagementPayloadClassification
+} from '../state-management-migration';
+
+const DEFAULT_SPEC = '__default_spec__';
+const CUSTOM_SPEC = '{"mark":"bar","encoding":{}}';
+const WITH_PROJECT = { hasProjectContent: true };
+const WITHOUT_PROJECT = { hasProjectContent: false };
+
+// ─── Synthetic registry helpers ──────────────────────────────────────────────
+
+const loadTimeEntry = (
+    id: string,
+    fromVersion: number,
+    toVersion: number,
+    migrate: StateManagementLoadTimeMigrationEntry['migrate'] = () => ({})
+): StateManagementMigrationEntry => ({
+    id,
+    fromVersion,
+    toVersion,
+    migrationClass: 'load-time',
+    requiresProjectContent: false,
+    description: `synthetic load-time ${id}`,
+    migrate
+});
+
+const firstDataviewEntry = (
+    id: string,
+    fromVersion: number,
+    toVersion: number
+): StateManagementMigrationEntry => ({
+    id,
+    fromVersion,
+    toVersion,
+    migrationClass: 'first-dataview',
+    requiresProjectContent: true,
+    description: `synthetic first-dataview ${id}`
+});
+
+// ─── Registry contract ───────────────────────────────────────────────────────
+
+describe('registry integrity', () => {
+    it('the REAL registry is valid and its current version is 2', () => {
+        // 2 is the first stamped version (2.0 is the last unversioned
+        // shape). It deliberately coincides with the value the mapping
+        // pass currently stamps via TEMPLATE_USERMETA_VERSION — U3 routes
+        // that stamp through getStateManagementVersionToStamp.
+        expect(getCurrentStateManagementVersion()).toBe(2);
+    });
+
+    it('rejects an empty registry', () => {
+        expect(() => assertStateManagementRegistryIntegrity([])).toThrow(
+            StateManagementRegistryError
+        );
+    });
+
+    it('rejects a chain that does not start at version 0', () => {
+        expect(() =>
+            assertStateManagementRegistryIntegrity([loadTimeEntry('a', 1, 2)])
+        ).toThrow(/expected fromVersion 0/);
+    });
+
+    it('rejects a gap in the chain as a hard error', () => {
+        expect(() =>
+            assertStateManagementRegistryIntegrity([
+                loadTimeEntry('a', 0, 2),
+                loadTimeEntry('b', 3, 4)
+            ])
+        ).toThrow(/out of order or leaves a gap/);
+    });
+
+    it('rejects out-of-order registration as a hard error', () => {
+        expect(() =>
+            assertStateManagementRegistryIntegrity([
+                loadTimeEntry('b', 2, 3),
+                loadTimeEntry('a', 0, 2)
+            ])
+        ).toThrow(StateManagementRegistryError);
+    });
+
+    it('rejects duplicate registration of the same range', () => {
+        expect(() =>
+            assertStateManagementRegistryIntegrity([
+                loadTimeEntry('a', 0, 2),
+                loadTimeEntry('b', 0, 2)
+            ])
+        ).toThrow(StateManagementRegistryError);
+    });
+
+    it('rejects duplicate migration ids', () => {
+        expect(() =>
+            assertStateManagementRegistryIntegrity([
+                loadTimeEntry('a', 0, 1),
+                loadTimeEntry('a', 1, 2)
+            ])
+        ).toThrow(/registered more than once/);
+    });
+
+    it('rejects an entry that does not advance the version', () => {
+        expect(() =>
+            assertStateManagementRegistryIntegrity([loadTimeEntry('a', 0, 0)])
+        ).toThrow(/does not advance/);
+    });
+
+    it('rejects a load-time entry without a migrate function', () => {
+        const entry = {
+            ...loadTimeEntry('a', 0, 1),
+            migrate: undefined
+        } as unknown as StateManagementMigrationEntry;
+        expect(() => assertStateManagementRegistryIntegrity([entry])).toThrow(
+            /must supply a migrate/
+        );
+    });
+
+    it('rejects a first-dataview entry that supplies a migrate function', () => {
+        const entry = {
+            ...firstDataviewEntry('a', 0, 1),
+            migrate: () => ({})
+        } as unknown as StateManagementMigrationEntry;
+        expect(() => assertStateManagementRegistryIntegrity([entry])).toThrow(
+            /must not supply a migrate/
+        );
+    });
+
+    it('throws on queries for unknown migration ids', () => {
+        expect(() =>
+            isStateManagementMigrationPending('nope', 0, WITH_PROJECT)
+        ).toThrow(StateManagementRegistryError);
+        expect(() => getStateManagementVersionToStamp('nope')).toThrow(
+            StateManagementRegistryError
+        );
+    });
+});
+
+// ─── Version stamp parsing ───────────────────────────────────────────────────
+
+describe('parseDenebMetaVersion', () => {
+    it('treats absent/empty as unversioned (0)', () => {
+        expect(parseDenebMetaVersion(undefined).version).toBe(0);
+        expect(parseDenebMetaVersion(null).version).toBe(0);
+        expect(parseDenebMetaVersion('').version).toBe(0);
+    });
+
+    it('parses a numeric stamp', () => {
+        expect(parseDenebMetaVersion('2')).toEqual({ version: 2 });
+    });
+
+    it('flags a non-numeric stamp as corrupt with a null version', () => {
+        const result = parseDenebMetaVersion('banana');
+        expect(result.version).toBeNull();
+        expect(result.corrupt).toMatchObject({
+            key: 'denebMetaVersion',
+            rawValue: 'banana'
+        });
+    });
+});
+
+// ─── Load-time pipeline behaviour (synthetic registries) ─────────────────────
+
+describe('runStateManagementLoadTimeMigrations — ordering & merge', () => {
+    it('applies pending entries in fromVersion order and stamps the final version', () => {
+        const order: string[] = [];
+        const entries = [
+            loadTimeEntry('zero-to-one', 0, 1, () => {
+                order.push('zero-to-one');
+                return { scaleToZoom: true };
+            }),
+            loadTimeEntry('one-to-two', 1, 2, () => {
+                order.push('one-to-two');
+                return { consolidateFieldParameters: false };
+            })
+        ];
+        const result = runStateManagementLoadTimeMigrations(
+            { supportFieldConfiguration: '{"a":{}}' },
+            WITH_PROJECT,
+            entries
+        );
+        expect(order).toEqual(['zero-to-one', 'one-to-two']);
+        expect(result.applied).toEqual(['zero-to-one', 'one-to-two']);
+        expect(result.version).toBe(2);
+        expect(result.payload).toEqual({
+            // Present keys survive — merged, never replaced.
+            supportFieldConfiguration: '{"a":{}}',
+            scaleToZoom: true,
+            consolidateFieldParameters: false,
+            denebMetaVersion: '2'
+        });
+    });
+
+    it('starts mid-chain for a partially-migrated payload', () => {
+        const order: string[] = [];
+        const entries = [
+            loadTimeEntry('zero-to-one', 0, 1, () => {
+                order.push('zero-to-one');
+                return {};
+            }),
+            loadTimeEntry('one-to-two', 1, 2, () => {
+                order.push('one-to-two');
+                return {};
+            })
+        ];
+        const result = runStateManagementLoadTimeMigrations(
+            { denebMetaVersion: '1' },
+            WITH_PROJECT,
+            entries
+        );
+        expect(order).toEqual(['one-to-two']);
+        expect(result.version).toBe(2);
+        expect(result.payload.denebMetaVersion).toBe('2');
+    });
+
+    it('re-running on its own output is a no-op (stale-echo idempotency)', () => {
+        const migrate = vi.fn(() => ({ scaleToZoom: true }));
+        const entries = [loadTimeEntry('zero-to-two', 0, 2, migrate)];
+        const first = runStateManagementLoadTimeMigrations(
+            {},
+            WITH_PROJECT,
+            entries
+        );
+        expect(first.applied).toEqual(['zero-to-two']);
+        // The sync layer can replay the migration's own persisted output
+        // back ~5s later — this must not double-apply.
+        const echo = runStateManagementLoadTimeMigrations(
+            first.payload,
+            WITH_PROJECT,
+            entries
+        );
+        expect(migrate).toHaveBeenCalledTimes(1);
+        expect(echo.applied).toEqual([]);
+        expect(echo.classification).toBe('current');
+        expect(echo.payload).toEqual(first.payload);
+    });
+
+    it('a pending first-dataview entry blocks later entries', () => {
+        const migrate = vi.fn(() => ({}));
+        const entries = [
+            firstDataviewEntry('data-dependent', 0, 2),
+            loadTimeEntry('two-to-three', 2, 3, migrate)
+        ];
+        const result = runStateManagementLoadTimeMigrations(
+            {},
+            WITH_PROJECT,
+            entries
+        );
+        expect(result.pendingFirstDataview).toEqual(['data-dependent']);
+        expect(result.applied).toEqual([]);
+        expect(migrate).not.toHaveBeenCalled();
+        // No stamp is written — the first-dataview execution point owns it.
+        expect(result.payload).toEqual({});
+        expect(result.version).toBe(0);
+    });
+
+    it('runs load-time entries beyond a COMPLETED first-dataview entry', () => {
+        const entries = [
+            firstDataviewEntry('data-dependent', 0, 2),
+            loadTimeEntry('two-to-three', 2, 3, () => ({ scaleToZoom: true }))
+        ];
+        // The mapping pass has executed the data-dependent entry and
+        // stamped 2; the next load picks up the chain from there.
+        const result = runStateManagementLoadTimeMigrations(
+            { denebMetaVersion: '2' },
+            WITH_PROJECT,
+            entries
+        );
+        expect(result.pendingFirstDataview).toEqual([]);
+        expect(result.applied).toEqual(['two-to-three']);
+        expect(result.payload.denebMetaVersion).toBe('3');
+    });
+
+    it('never migrates a payload stamped ABOVE the current version downwards', () => {
+        const migrate = vi.fn(() => ({}));
+        const entries = [loadTimeEntry('zero-to-two', 0, 2, migrate)];
+        const input = { denebMetaVersion: '5', scaleToZoom: true };
+        const result = runStateManagementLoadTimeMigrations(
+            input,
+            WITH_PROJECT,
+            entries
+        );
+        expect(result.classification).toBe('current');
+        expect(migrate).not.toHaveBeenCalled();
+        expect(result.payload).toEqual(input);
+    });
+});
+
+describe('runStateManagementLoadTimeMigrations — classification guards', () => {
+    it('does not treat an empty payload without project content as legacy (cross-GUID / fresh visual)', () => {
+        const result = runStateManagementLoadTimeMigrations(
+            {},
+            WITHOUT_PROJECT
+        );
+        expect(result.classification).toBe('empty-or-cross-guid');
+        expect(result.applied).toEqual([]);
+        expect(result.pendingFirstDataview).toEqual([]);
+        expect(result.payload).toEqual({});
+    });
+
+    it('treats the same empty payload WITH project content as genuinely legacy', () => {
+        const result = runStateManagementLoadTimeMigrations({}, WITH_PROJECT);
+        expect(result.classification).toBe('unversioned-legacy');
+        expect(result.pendingFirstDataview).toEqual([
+            SUPPORT_FIELD_LEGACY_MIGRATION_ID
+        ]);
+    });
+
+    it('completes a partial payload without wiping present keys', () => {
+        const input: StateManagementPayload = {
+            supportFieldConfiguration: '{"Units":{"highlight":false}}',
+            scaleToZoom: true
+        };
+        const result = runStateManagementLoadTimeMigrations(
+            input,
+            WITH_PROJECT
+        );
+        expect(result.classification).toBe('unversioned-legacy');
+        expect(result.payload).toEqual(input);
+    });
+
+    it('surfaces corrupt JSON in a persisted key as a typed signal, not a silent reset', () => {
+        const input: StateManagementPayload = {
+            supportFieldConfiguration: '{"broken": tru',
+            denebMetaVersion: '2'
+        };
+        const result = runStateManagementLoadTimeMigrations(
+            input,
+            WITH_PROJECT
+        );
+        expect(result.corruptKeys).toHaveLength(1);
+        expect(result.corruptKeys[0]).toMatchObject({
+            key: 'supportFieldConfiguration',
+            rawValue: '{"broken": tru'
+        });
+        expect(result.corruptKeys[0].error).toBeTruthy();
+        // Raw value left in place.
+        expect(result.payload).toEqual(input);
+    });
+
+    it('fails safe on an unreadable version stamp: runs nothing, surfaces the signal', () => {
+        const migrate = vi.fn(() => ({}));
+        const entries = [loadTimeEntry('zero-to-two', 0, 2, migrate)];
+        const input: StateManagementPayload = {
+            denebMetaVersion: '###',
+            scaleToZoom: true
+        };
+        const result = runStateManagementLoadTimeMigrations(
+            input,
+            WITH_PROJECT,
+            entries
+        );
+        expect(result.classification).toBe('indeterminate');
+        expect(migrate).not.toHaveBeenCalled();
+        expect(result.corruptKeys[0].key).toBe('denebMetaVersion');
+        expect(result.payload).toEqual(input);
+    });
+});
+
+// ─── First-dataview (class b) registration seam ──────────────────────────────
+
+describe('isSupportFieldMigrationPending (registry-owned isLegacySpec)', () => {
+    it('matches the legacy decision table exactly', () => {
+        // Existing project, never stamped → pending.
+        expect(isSupportFieldMigrationPending(CUSTOM_SPEC, 0)).toBe(true);
+        // Existing project, pre-2.0 stamp → pending.
+        expect(isSupportFieldMigrationPending(CUSTOM_SPEC, 1)).toBe(true);
+        // Already stamped at 2 → not pending.
+        expect(isSupportFieldMigrationPending(CUSTOM_SPEC, 2)).toBe(false);
+        // Brand-new / cross-GUID (default template) → never pending.
+        expect(isSupportFieldMigrationPending(DEFAULT_SPEC, 0)).toBe(false);
+        // Future stamps → not pending (never migrate downwards).
+        expect(isSupportFieldMigrationPending(CUSTOM_SPEC, 3)).toBe(false);
+    });
+
+    it('is a no-op against a stale echo of its own persisted output', () => {
+        // The mapping pass stamps toVersion on completion; when the sync
+        // layer echoes that persisted output back, the decision must flip
+        // to false — no double application.
+        const stamped = getStateManagementVersionToStamp(
+            SUPPORT_FIELD_LEGACY_MIGRATION_ID
+        );
+        expect(isSupportFieldMigrationPending(CUSTOM_SPEC, stamped)).toBe(
+            false
+        );
+    });
+
+    it('exposes the version the mapping pass must stamp on completion', () => {
+        expect(
+            getStateManagementVersionToStamp(SUPPORT_FIELD_LEGACY_MIGRATION_ID)
+        ).toBe(2);
+    });
+
+    it('hasProjectContent discriminates factory-default from real specs', () => {
+        expect(hasProjectContent(DEFAULT_SPEC)).toBe(false);
+        expect(hasProjectContent(CUSTOM_SPEC)).toBe(true);
+    });
+});
+
+// ─── Fixture corpus replay ───────────────────────────────────────────────────
+
+interface FixtureFile {
+    description: string;
+    jsonSpec: string | null;
+    stateManagement: StateManagementPayload;
+    expected: {
+        classification: StateManagementPayloadClassification;
+        applied: string[];
+        pendingFirstDataview: string[];
+        corruptKeys: string[];
+        payload: StateManagementPayload;
+    };
+}
+
+// jsdom rewrites `import.meta.url` to an http scheme, so resolve from the
+// repo root (vitest's cwd) instead.
+const FIXTURES_DIR = resolve(
+    process.cwd(),
+    'src/lib/persistence/__test__/fixtures'
+);
+const FIXTURE_FILES = readdirSync(FIXTURES_DIR).filter((f) =>
+    f.endsWith('.json')
+);
+
+describe('fixture corpus replay', () => {
+    it('the corpus is present (guards against a vacuous replay)', () => {
+        expect(FIXTURE_FILES.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it.each(FIXTURE_FILES)('%s replays to the expected final shape', (file) => {
+        const fixture: FixtureFile = JSON.parse(
+            readFileSync(join(FIXTURES_DIR, file), 'utf-8')
+        );
+        // `jsonSpec: null` in a fixture means "the factory default
+        // template" (fresh visual / cross-GUID import).
+        const jsonSpec = fixture.jsonSpec ?? DEFAULT_SPEC;
+        const context = { hasProjectContent: hasProjectContent(jsonSpec) };
+        const result = runStateManagementLoadTimeMigrations(
+            fixture.stateManagement,
+            context
+        );
+        expect(result.classification).toBe(fixture.expected.classification);
+        expect(result.applied).toEqual(fixture.expected.applied);
+        expect(result.pendingFirstDataview).toEqual(
+            fixture.expected.pendingFirstDataview
+        );
+        expect(result.corruptKeys.map((c) => c.key)).toEqual(
+            fixture.expected.corruptKeys
+        );
+        expect(result.payload).toEqual(fixture.expected.payload);
+    });
+
+    it.each(FIXTURE_FILES)(
+        '%s is idempotent when its own output is replayed (stale echo)',
+        (file) => {
+            const fixture: FixtureFile = JSON.parse(
+                readFileSync(join(FIXTURES_DIR, file), 'utf-8')
+            );
+            const jsonSpec = fixture.jsonSpec ?? DEFAULT_SPEC;
+            const context = {
+                hasProjectContent: hasProjectContent(jsonSpec)
+            };
+            const first = runStateManagementLoadTimeMigrations(
+                fixture.stateManagement,
+                context
+            );
+            const echo = runStateManagementLoadTimeMigrations(
+                first.payload,
+                context
+            );
+            expect(echo.applied).toEqual([]);
+            expect(echo.payload).toEqual(first.payload);
+        }
+    );
+
+    it('classifications across the corpus cover the legacy/empty/current/corrupt space', () => {
+        const classifications = new Set(
+            FIXTURE_FILES.map((file) => {
+                const fixture: FixtureFile = JSON.parse(
+                    readFileSync(join(FIXTURES_DIR, file), 'utf-8')
+                );
+                return fixture.expected.classification;
+            })
+        );
+        expect(classifications).toContain('unversioned-legacy');
+        expect(classifications).toContain('empty-or-cross-guid');
+        expect(classifications).toContain('current');
+        expect(classifications).toContain('indeterminate');
+    });
+});
+
+// ─── inspectStateManagementPayload ───────────────────────────────────────────
+
+describe('inspectStateManagementPayload', () => {
+    it('classifies a stamped-but-outdated payload as versioned-outdated', () => {
+        const { classification } = inspectStateManagementPayload(
+            { denebMetaVersion: '1' },
+            WITH_PROJECT
+        );
+        expect(classification).toBe('versioned-outdated');
+    });
+
+    it('accepts a valid supportFieldConfiguration without signalling', () => {
+        const { corruptKeys } = inspectStateManagementPayload(
+            {
+                denebMetaVersion: '2',
+                supportFieldConfiguration: '{"Sales":{"highlight":true}}'
+            },
+            WITH_PROJECT
+        );
+        expect(corruptKeys).toEqual([]);
+    });
+});

--- a/src/lib/persistence/index.ts
+++ b/src/lib/persistence/index.ts
@@ -1,4 +1,31 @@
-export { handlePropertyMigration } from './migration';
+export {
+    applyStateManagementPayloadToSettings,
+    getStateManagementPayloadFromSettings,
+    handlePropertyMigration,
+    runStateManagementSchemaMigrations
+} from './migration';
+export {
+    assertStateManagementRegistryIntegrity,
+    getCurrentStateManagementVersion,
+    getStateManagementVersionToStamp,
+    hasProjectContent,
+    inspectStateManagementPayload,
+    isStateManagementMigrationPending,
+    isSupportFieldMigrationPending,
+    parseDenebMetaVersion,
+    runStateManagementLoadTimeMigrations,
+    StateManagementRegistryError,
+    SUPPORT_FIELD_LEGACY_MIGRATION_ID,
+    type StateManagementCorruptKey,
+    type StateManagementFirstDataviewMigrationEntry,
+    type StateManagementLoadMigrationResult,
+    type StateManagementLoadTimeMigrationEntry,
+    type StateManagementMigrationClass,
+    type StateManagementMigrationContext,
+    type StateManagementMigrationEntry,
+    type StateManagementPayload,
+    type StateManagementPayloadClassification
+} from './state-management-migration';
 export * from './model';
 export { persistProperties, resolveObjectProperties } from './persist';
 export {

--- a/src/lib/persistence/migration.ts
+++ b/src/lib/persistence/migration.ts
@@ -15,6 +15,12 @@ import { persistProperties, resolveObjectProperties } from './persist';
 import { getDenebState } from '@deneb-viz/app-core';
 import { getDenebVisualState } from '../../state';
 import { APPLICATION_VERSION } from '../application';
+import {
+    hasProjectContent,
+    runStateManagementLoadTimeMigrations,
+    type StateManagementLoadMigrationResult,
+    type StateManagementPayload
+} from './state-management-migration';
 
 /**
  * Current visual and provider information
@@ -129,6 +135,12 @@ export const handlePropertyMigration = (
     visualSettings: VisualFormattingSettingsModel,
     isReadMode: boolean
 ) => {
+    // Schema-versioned `stateManagement` payload migrations run first, in
+    // BOTH modes, on every update: the settings model is rebuilt from the
+    // host data view each update, so in-memory application must re-run
+    // (mirroring the read-mode pattern below). With no registered
+    // load-time entries this is a cheap parse + classify.
+    runStateManagementSchemaMigrations(visualSettings);
     const {
         vega: {
             output: {
@@ -166,6 +178,108 @@ export const handlePropertyMigration = (
             }
             default:
                 break;
+        }
+    }
+};
+
+/**
+ * Execution point for class `'load-time'` (payload-shape) migrations of
+ * the persisted `stateManagement` payload — see
+ * `./state-management-migration.ts`, which owns the registry and ALL
+ * version comparison for that payload.
+ *
+ * Applies pending load-time entries in registry order to the in-memory
+ * settings model (merge semantics — present keys are never wiped). The
+ * returned result carries the typed corrupt-key signals and the ids of
+ * pending first-dataview (data-dependent) entries, which execute later
+ * from the dataset mapping pass.
+ *
+ * Persistence note: application here is in-memory only, matching the
+ * settings-model lifecycle (rebuilt every update). Durable persistence of
+ * migration output — batched into a single store update so the sync layer
+ * emits one persist — is wired by the data-dependent execution point
+ * (see U3 of the audit remediation program); durable UI surfacing of
+ * corrupt-key signals lands there too.
+ */
+export const runStateManagementSchemaMigrations = (
+    visualSettings: VisualFormattingSettingsModel
+): StateManagementLoadMigrationResult => {
+    const payload = getStateManagementPayloadFromSettings(visualSettings);
+    const jsonSpec = visualSettings.vega?.output?.jsonSpec?.value ?? '';
+    const result = runStateManagementLoadTimeMigrations(payload, {
+        hasProjectContent: hasProjectContent(jsonSpec)
+    });
+    if (result.corruptKeys.length > 0) {
+        logDebug(
+            'runStateManagementSchemaMigrations: corrupt persisted key(s) detected',
+            { corruptKeys: result.corruptKeys }
+        );
+    }
+    if (result.applied.length > 0) {
+        logDebug('runStateManagementSchemaMigrations: applied migrations', {
+            applied: result.applied,
+            version: result.version
+        });
+        applyStateManagementPayloadToSettings(visualSettings, result.payload);
+    }
+    return result;
+};
+
+/**
+ * Extract the raw persisted `stateManagement` payload from the settings
+ * model. Values stay in their persisted (serialized) form — parsing and
+ * corruption detection belong to the registry.
+ */
+export const getStateManagementPayloadFromSettings = (
+    visualSettings: VisualFormattingSettingsModel
+): StateManagementPayload => {
+    const projectMetadata = visualSettings.stateManagement?.projectMetadata;
+    const viewport = visualSettings.stateManagement?.viewport;
+    return {
+        viewportHeight: viewport?.viewportHeight?.value,
+        viewportWidth: viewport?.viewportWidth?.value,
+        supportFieldConfiguration:
+            projectMetadata?.supportFieldConfiguration?.value,
+        denebMetaVersion: projectMetadata?.denebMetaVersion?.value,
+        scaleToZoom: projectMetadata?.scaleToZoom?.value,
+        consolidateFieldParameters:
+            projectMetadata?.consolidateFieldParameters?.value
+    };
+};
+
+/**
+ * Write a migrated `stateManagement` payload back onto the in-memory
+ * settings model. Only keys present on the payload are written — absent
+ * keys leave the model untouched (merge, never replace).
+ */
+export const applyStateManagementPayloadToSettings = (
+    visualSettings: VisualFormattingSettingsModel,
+    payload: StateManagementPayload
+): void => {
+    const projectMetadata = visualSettings.stateManagement?.projectMetadata;
+    const viewport = visualSettings.stateManagement?.viewport;
+    if (viewport) {
+        if (payload.viewportHeight !== undefined) {
+            viewport.viewportHeight.value = payload.viewportHeight;
+        }
+        if (payload.viewportWidth !== undefined) {
+            viewport.viewportWidth.value = payload.viewportWidth;
+        }
+    }
+    if (projectMetadata) {
+        if (payload.supportFieldConfiguration !== undefined) {
+            projectMetadata.supportFieldConfiguration.value =
+                payload.supportFieldConfiguration;
+        }
+        if (payload.denebMetaVersion !== undefined) {
+            projectMetadata.denebMetaVersion.value = payload.denebMetaVersion;
+        }
+        if (payload.scaleToZoom !== undefined) {
+            projectMetadata.scaleToZoom.value = payload.scaleToZoom;
+        }
+        if (payload.consolidateFieldParameters !== undefined) {
+            projectMetadata.consolidateFieldParameters.value =
+                payload.consolidateFieldParameters;
         }
     }
 };

--- a/src/lib/persistence/model/settings-state-management.ts
+++ b/src/lib/persistence/model/settings-state-management.ts
@@ -22,6 +22,18 @@ class SettingsStateManagementGroupProjectMetadata
             'Objects_StateManagement_SupportFieldConfiguration_Description',
         value: DEFAULTS.stateManagement.supportFieldConfiguration
     });
+    /**
+     * Schema-version stamp for the persisted `stateManagement` payload.
+     *
+     * OWNED by the ordered migration registry in
+     * `src/lib/persistence/state-management-migration.ts` — all version
+     * comparison for this payload goes through that registry
+     * (`isStateManagementMigrationPending` /
+     * `runStateManagementLoadTimeMigrations`); never compare this value
+     * directly. Empty/absent means unversioned (pre-2.0 — the last shape
+     * that ever has to be sniffed); completed migrations stamp the
+     * registry's `toVersion` for the entry that ran.
+     */
     denebMetaVersion = new formattingSettings.ReadOnlyText({
         name: 'denebMetaVersion',
         displayNameKey: 'Objects_StateManagement_DenebMetaVersion',

--- a/src/lib/persistence/state-management-migration.ts
+++ b/src/lib/persistence/state-management-migration.ts
@@ -113,6 +113,17 @@ interface StateManagementMigrationEntryBase {
      * When `true`, the entry only applies to payloads belonging to a real
      * project (see `StateManagementMigrationContext.hasProjectContent`).
      * Fresh visuals and cross-GUID imports skip it — they are not legacy.
+     *
+     * IMPORTANT — this flag is ADDITIVE on top of payload classification,
+     * not an independent gate. A project-less payload below the current
+     * version classifies as `'empty-or-cross-guid'` and returns before the
+     * load-time loop runs (see `runStateManagementLoadTimeMigrations`), so a
+     * `'load-time'` entry with `requiresProjectContent: false` still does
+     * NOT run for such payloads — the classification guard is the primary
+     * gate and this flag only tightens it further when project content IS
+     * present. A migration that must run for ALL payloads regardless of
+     * project content (e.g. a viewport-dimension schema change) would need
+     * the classification step revisited, not just this flag cleared.
      */
     requiresProjectContent: boolean;
 }
@@ -315,6 +326,15 @@ export const assertStateManagementRegistryIntegrity = (
 };
 
 /**
+ * Validate the canonical registry ONCE at import. It is a module-level
+ * `const` and cannot change between calls, so query paths that default to
+ * it (`getEntryById`) skip the per-call O(n) re-scan — the check has already
+ * fired here. Custom registries passed explicitly (by tests) are still
+ * validated on use. Throws at import if the shipped registry is malformed.
+ */
+assertStateManagementRegistryIntegrity(STATE_MANAGEMENT_MIGRATIONS);
+
+/**
  * The current `stateManagement` schema version — the last registry entry's
  * `toVersion`. This is the value newly-completed migrations stamp.
  */
@@ -412,7 +432,11 @@ const getEntryById = (
     id: string,
     entries: readonly StateManagementMigrationEntry[]
 ): StateManagementMigrationEntry => {
-    assertStateManagementRegistryIntegrity(entries);
+    // The canonical registry is validated once at import; only re-validate a
+    // caller-supplied (test) registry, which may be malformed by design.
+    if (entries !== STATE_MANAGEMENT_MIGRATIONS) {
+        assertStateManagementRegistryIntegrity(entries);
+    }
     const entry = entries.find((e) => e.id === id);
     if (!entry) {
         throw new StateManagementRegistryError(`Unknown migration id '${id}'.`);
@@ -516,9 +540,15 @@ export const runStateManagementLoadTimeMigrations = (
             // Already migrated past this entry (idempotency / stale echo).
             continue;
         }
-        // Note: `requiresProjectContent` needs no per-entry check here —
-        // every payload without project content classifies as
-        // `'empty-or-cross-guid'` above and never reaches this loop.
+        // `requiresProjectContent` is primarily enforced by classification:
+        // a project-less payload below the current version is
+        // `'empty-or-cross-guid'` above and never reaches this loop. This
+        // per-entry guard is the defensive backstop — it keeps the loop
+        // honouring the flag if a future entry is ever reached with it set,
+        // rather than relying solely on the earlier classification return.
+        if (entry.requiresProjectContent && !context.hasProjectContent) {
+            continue;
+        }
         if (entry.migrationClass === 'first-dataview') {
             // Data-dependent: executes later from the mapping pass. Later
             // entries assume its output shape, so stop here.

--- a/src/lib/persistence/state-management-migration.ts
+++ b/src/lib/persistence/state-management-migration.ts
@@ -1,0 +1,551 @@
+import { PROJECT_DEFAULTS } from '@deneb-viz/configuration';
+
+/**
+ * Ordered migration registry for the persisted `stateManagement` payload.
+ *
+ * This module is the SINGLE OWNER of version comparison for the
+ * `stateManagement` persisted-property payload (the `denebMetaVersion`
+ * stamp defined in `model/settings-state-management.ts` and mapped through
+ * `src/lib/state/project-sync-mappings.ts`). Every future change to the
+ * payload's shape registers an entry here; no other code may compare the
+ * stamp directly.
+ *
+ * Two migration classes share the one version stamp:
+ *
+ *  - `'load-time'` — payload-shape migrations that need nothing beyond the
+ *    persisted payload itself. Applied in sequence on load via
+ *    `runStateManagementLoadTimeMigrations` (invoked from
+ *    `migration.ts#handlePropertyMigration`).
+ *  - `'first-dataview'` — data-dependent migrations that need DataView
+ *    columns and/or `jsonSpec` context unavailable at load (the legacy
+ *    support-field stamping). The registry decides WHETHER such an entry
+ *    runs (`isStateManagementMigrationPending`); the entry's execution
+ *    point lives in the dataset mapping pass (`src/lib/dataset/`).
+ *
+ * Versioning model: `denebMetaVersion` is an integer. `0` (absent/empty)
+ * is the unversioned pre-2.0 state; `2` is the first stamped version
+ * (version `1` never shipped — the jump is intentional and encoded in the
+ * first entry's `fromVersion: 0, toVersion: 2`). 2.0 is the LAST
+ * unversioned shape the code ever has to sniff: any later shape change
+ * appends an entry `{ fromVersion: 2, toVersion: 3, ... }` and so on.
+ *
+ * Institutional constraints encoded here (and covered by
+ * `__test__/state-management-migration.test.ts`):
+ *
+ *  - Idempotency against the sync layer's ~5s stale-echo window: re-running
+ *    any entry on already-migrated state is a no-op
+ *    (docs/solutions/logic-errors/stale-echo-triple-render-on-apply-2026-04-10.md).
+ *  - Partial persisted states are MERGED, never replaced: migrations return
+ *    a patch which is spread over the input payload.
+ *  - Cross-GUID awareness: an empty payload (fresh visual, or a .pbix from
+ *    a different packaging-channel GUID, where NO persisted properties
+ *    carry over) is NOT legacy. The discriminator is project content
+ *    (`jsonSpec` differs from the factory default) — the `stateManagement`
+ *    object of a genuine pre-2.0 visual is also empty, but its `jsonSpec`
+ *    is not
+ *    (docs/solutions/best-practices/validate-migrations-on-matching-channel-builds-2026-06-03.md).
+ *  - Corrupt persisted values surface a typed signal
+ *    (`StateManagementCorruptKey`) and are never silently reset.
+ */
+
+/**
+ * When a registered migration executes:
+ *
+ *  - `'load-time'`: applied in sequence on load from
+ *    `migration.ts` — must carry a `migrate` function.
+ *  - `'first-dataview'`: executed from the dataset mapping pass, which
+ *    supplies its own execution point and stamps
+ *    `getStateManagementVersionToStamp(id)` on completion. The registry
+ *    only answers WHETHER it is pending.
+ */
+export type StateManagementMigrationClass = 'load-time' | 'first-dataview';
+
+/**
+ * The persisted `stateManagement` payload, as raw persisted values (JSON
+ * keys are still serialized strings at this level — parsing/validation is
+ * the registry's job so corrupt values can be surfaced, not swallowed).
+ * Add new keys here as the payload grows; any shape change to an EXISTING
+ * key requires a new registry entry.
+ */
+export interface StateManagementPayload {
+    viewportHeight?: string | null;
+    viewportWidth?: string | null;
+    supportFieldConfiguration?: string;
+    denebMetaVersion?: string;
+    scaleToZoom?: boolean;
+    consolidateFieldParameters?: boolean;
+}
+
+/**
+ * Context the registry needs to make applicability decisions that the
+ * payload alone cannot answer (the cross-GUID/fresh-visual distinction).
+ */
+export interface StateManagementMigrationContext {
+    /**
+     * `true` when the visual has real project content (persisted
+     * `jsonSpec` differs from the factory default). Compute via
+     * `hasProjectContent()`.
+     */
+    hasProjectContent: boolean;
+}
+
+interface StateManagementMigrationEntryBase {
+    /**
+     * Stable unique identifier — referenced by class `'first-dataview'`
+     * execution points and reported in migration results.
+     */
+    id: string;
+    /**
+     * The payload schema version this entry migrates FROM. Entries must
+     * form a contiguous ascending chain starting at 0.
+     */
+    fromVersion: number;
+    /**
+     * The payload schema version this entry produces. Must equal the next
+     * entry's `fromVersion` (or defines the current version if last).
+     */
+    toVersion: number;
+    /**
+     * Human-readable summary of what the migration does.
+     */
+    description: string;
+    /**
+     * When `true`, the entry only applies to payloads belonging to a real
+     * project (see `StateManagementMigrationContext.hasProjectContent`).
+     * Fresh visuals and cross-GUID imports skip it — they are not legacy.
+     */
+    requiresProjectContent: boolean;
+}
+
+export interface StateManagementLoadTimeMigrationEntry extends StateManagementMigrationEntryBase {
+    migrationClass: 'load-time';
+    /**
+     * Transform the payload. Returns a PATCH that is merged over the input
+     * (`{ ...payload, ...patch }`) — never a replacement, so keys the
+     * migration does not know about are preserved.
+     */
+    migrate: (
+        payload: Readonly<StateManagementPayload>
+    ) => Partial<StateManagementPayload>;
+}
+
+export interface StateManagementFirstDataviewMigrationEntry extends StateManagementMigrationEntryBase {
+    migrationClass: 'first-dataview';
+}
+
+export type StateManagementMigrationEntry =
+    | StateManagementLoadTimeMigrationEntry
+    | StateManagementFirstDataviewMigrationEntry;
+
+/**
+ * Thrown when the registry itself is malformed (gap, out-of-order or
+ * duplicate registration, non-advancing entry, wrong class shape) or when
+ * an unknown migration id is queried. This is a programming error and is
+ * intentionally loud — a broken registry must never ship.
+ */
+export class StateManagementRegistryError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'StateManagementRegistryError';
+    }
+}
+
+/**
+ * Typed signal for a persisted key whose value could not be parsed.
+ * Surfaced to the caller (NOT a silent reset — the raw value is left in
+ * place); U3 wires the durable UI surfacing.
+ */
+export interface StateManagementCorruptKey {
+    key: keyof StateManagementPayload;
+    rawValue: string;
+    error: string;
+}
+
+/**
+ * How the registry classifies a persisted payload before deciding what to
+ * run:
+ *
+ *  - `'empty-or-cross-guid'` — no project content: a fresh visual, or a
+ *    .pbix saved under a different packaging-channel GUID (persisted
+ *    properties do not carry across GUIDs). NOT legacy; migrations that
+ *    require project content do not run.
+ *  - `'unversioned-legacy'` — real project content with no version stamp:
+ *    a genuine pre-2.0 payload.
+ *  - `'versioned-outdated'` — stamped, but below the current version.
+ *  - `'current'` — stamped at (or above) the current version; everything
+ *    is a no-op. "Above" covers a report last saved by a newer visual
+ *    build — never migrate downwards.
+ *  - `'indeterminate'` — the version stamp itself is unreadable. Fail-safe:
+ *    run nothing (re-running migrations on possibly-migrated state risks
+ *    double application) and surface the corrupt-key signal.
+ */
+export type StateManagementPayloadClassification =
+    | 'empty-or-cross-guid'
+    | 'unversioned-legacy'
+    | 'versioned-outdated'
+    | 'current'
+    | 'indeterminate';
+
+/**
+ * Result of the load-time migration pipeline. `payload` is the (merged)
+ * migrated payload — deep-equal to the input when nothing applied.
+ */
+export interface StateManagementLoadMigrationResult {
+    payload: StateManagementPayload;
+    /**
+     * The schema version the returned payload reflects (unchanged when no
+     * entry applied).
+     */
+    version: number;
+    classification: StateManagementPayloadClassification;
+    /**
+     * Ids of `'load-time'` entries applied by this run, in order.
+     */
+    applied: string[];
+    /**
+     * Ids of pending `'first-dataview'` entries the load-time pipeline
+     * cannot run — they execute later from the dataset mapping pass.
+     * Entries registered after a pending first-dataview entry are blocked
+     * behind it (they assume its output shape).
+     */
+    pendingFirstDataview: string[];
+    corruptKeys: StateManagementCorruptKey[];
+}
+
+/**
+ * Id of the legacy support-field stamping migration (class
+ * `'first-dataview'`) — the dataset mapping pass queries the registry with
+ * this id.
+ */
+export const SUPPORT_FIELD_LEGACY_MIGRATION_ID =
+    'support-field-legacy-defaults';
+
+/**
+ * THE registry. Ordered, contiguous chain of every shape change to the
+ * `stateManagement` payload. Append new entries at the end with
+ * `fromVersion` equal to the previous entry's `toVersion`; integrity is
+ * asserted on every pipeline/query call and contract-tested.
+ */
+const STATE_MANAGEMENT_MIGRATIONS: readonly StateManagementMigrationEntry[] = [
+    {
+        id: SUPPORT_FIELD_LEGACY_MIGRATION_ID,
+        fromVersion: 0,
+        toVersion: 2,
+        migrationClass: 'first-dataview',
+        requiresProjectContent: true,
+        description:
+            'Stamp resolved legacy support-field defaults (all support ' +
+            'fields enabled) into supportFieldConfiguration for pre-2.0 ' +
+            'projects, and pin consolidateFieldParameters off. Needs ' +
+            'DataView columns, so it executes from the dataset mapping ' +
+            'pass. toVersion 2 skips 1 deliberately: version 1 never ' +
+            'shipped.'
+    }
+];
+
+/**
+ * Validate a registry: entries must form a contiguous, ascending chain
+ * starting at version 0, each entry must advance the version, and each
+ * class must have the right shape. Throws `StateManagementRegistryError`
+ * on the first violation — a gap or out-of-order registration is a hard
+ * error, never a silent skip.
+ */
+export const assertStateManagementRegistryIntegrity = (
+    entries: readonly StateManagementMigrationEntry[]
+): void => {
+    if (entries.length === 0) {
+        throw new StateManagementRegistryError(
+            'Migration registry must contain at least one entry.'
+        );
+    }
+    const seenIds = new Set<string>();
+    let expectedFromVersion = 0;
+    for (const entry of entries) {
+        if (
+            !Number.isInteger(entry.fromVersion) ||
+            !Number.isInteger(entry.toVersion)
+        ) {
+            throw new StateManagementRegistryError(
+                `Migration '${entry.id}' has non-integer versions ` +
+                    `(${entry.fromVersion} -> ${entry.toVersion}).`
+            );
+        }
+        if (entry.fromVersion !== expectedFromVersion) {
+            throw new StateManagementRegistryError(
+                `Migration '${entry.id}' is out of order or leaves a gap: ` +
+                    `expected fromVersion ${expectedFromVersion}, got ` +
+                    `${entry.fromVersion}. Entries must form a contiguous ` +
+                    'ascending chain starting at 0.'
+            );
+        }
+        if (entry.toVersion <= entry.fromVersion) {
+            throw new StateManagementRegistryError(
+                `Migration '${entry.id}' does not advance the version ` +
+                    `(${entry.fromVersion} -> ${entry.toVersion}).`
+            );
+        }
+        if (seenIds.has(entry.id)) {
+            throw new StateManagementRegistryError(
+                `Migration id '${entry.id}' is registered more than once.`
+            );
+        }
+        if (
+            entry.migrationClass === 'load-time' &&
+            typeof entry.migrate !== 'function'
+        ) {
+            throw new StateManagementRegistryError(
+                `Load-time migration '${entry.id}' must supply a migrate ` +
+                    'function.'
+            );
+        }
+        if (
+            entry.migrationClass === 'first-dataview' &&
+            'migrate' in entry &&
+            (entry as { migrate?: unknown }).migrate !== undefined
+        ) {
+            throw new StateManagementRegistryError(
+                `First-dataview migration '${entry.id}' must not supply a ` +
+                    'migrate function — its execution point lives in the ' +
+                    'dataset mapping pass.'
+            );
+        }
+        seenIds.add(entry.id);
+        expectedFromVersion = entry.toVersion;
+    }
+};
+
+/**
+ * The current `stateManagement` schema version — the last registry entry's
+ * `toVersion`. This is the value newly-completed migrations stamp.
+ */
+export const getCurrentStateManagementVersion = (
+    entries: readonly StateManagementMigrationEntry[] = STATE_MANAGEMENT_MIGRATIONS
+): number => {
+    assertStateManagementRegistryIntegrity(entries);
+    return entries[entries.length - 1].toVersion;
+};
+
+/**
+ * `true` when the visual has real project content, i.e. its persisted
+ * `jsonSpec` differs from the factory default. This is the discriminator
+ * between "genuinely unversioned pre-2.0 payload" and "empty payload
+ * because fresh visual / cross-GUID import" — both have an empty
+ * `stateManagement` object, but only the former has a project.
+ */
+export const hasProjectContent = (jsonSpec: string): boolean =>
+    jsonSpec !== PROJECT_DEFAULTS.spec;
+
+const DENEB_META_VERSION_PATTERN = /^\d+$/;
+
+/**
+ * Parse the persisted version stamp. Absent/empty means unversioned (0).
+ * A non-numeric value is corrupt: surfaced as a signal, with the version
+ * reported as `null` so callers fail safe (run nothing) rather than
+ * re-running migrations against possibly-migrated state.
+ */
+export const parseDenebMetaVersion = (
+    raw: string | undefined | null
+): { version: number | null; corrupt?: StateManagementCorruptKey } => {
+    if (raw === undefined || raw === null || raw === '') {
+        return { version: 0 };
+    }
+    if (DENEB_META_VERSION_PATTERN.test(raw)) {
+        return { version: parseInt(raw, 10) };
+    }
+    return {
+        version: null,
+        corrupt: {
+            key: 'denebMetaVersion',
+            rawValue: raw,
+            error: `Expected an integer string, got '${raw}'.`
+        }
+    };
+};
+
+/**
+ * Inspect a payload without mutating it: parse the version stamp, detect
+ * corrupt persisted values (typed signals, never a reset), and classify.
+ */
+export const inspectStateManagementPayload = (
+    payload: Readonly<StateManagementPayload>,
+    context: StateManagementMigrationContext,
+    entries: readonly StateManagementMigrationEntry[] = STATE_MANAGEMENT_MIGRATIONS
+): {
+    version: number | null;
+    classification: StateManagementPayloadClassification;
+    corruptKeys: StateManagementCorruptKey[];
+} => {
+    const currentVersion = getCurrentStateManagementVersion(entries);
+    const corruptKeys: StateManagementCorruptKey[] = [];
+    const { version, corrupt } = parseDenebMetaVersion(
+        payload.denebMetaVersion
+    );
+    if (corrupt) {
+        corruptKeys.push(corrupt);
+    }
+    const supportFieldRaw = payload.supportFieldConfiguration;
+    if (supportFieldRaw !== undefined && supportFieldRaw !== '') {
+        try {
+            JSON.parse(supportFieldRaw);
+        } catch (e) {
+            corruptKeys.push({
+                key: 'supportFieldConfiguration',
+                rawValue: supportFieldRaw,
+                error: e instanceof Error ? e.message : String(e)
+            });
+        }
+    }
+    const classification: StateManagementPayloadClassification =
+        version === null
+            ? 'indeterminate'
+            : version >= currentVersion
+              ? 'current'
+              : !context.hasProjectContent
+                ? 'empty-or-cross-guid'
+                : version === 0
+                  ? 'unversioned-legacy'
+                  : 'versioned-outdated';
+    return { version, classification, corruptKeys };
+};
+
+const getEntryById = (
+    id: string,
+    entries: readonly StateManagementMigrationEntry[]
+): StateManagementMigrationEntry => {
+    assertStateManagementRegistryIntegrity(entries);
+    const entry = entries.find((e) => e.id === id);
+    if (!entry) {
+        throw new StateManagementRegistryError(`Unknown migration id '${id}'.`);
+    }
+    return entry;
+};
+
+/**
+ * The WHETHER decision for a single registered migration — the seam that
+ * class `'first-dataview'` execution points call. `true` when the payload
+ * predates the entry's output shape (and its applicability context is
+ * satisfied). Already-migrated payloads — including a stale echo of the
+ * migration's own persisted output — return `false`.
+ */
+export const isStateManagementMigrationPending = (
+    id: string,
+    payloadVersion: number,
+    context: StateManagementMigrationContext,
+    entries: readonly StateManagementMigrationEntry[] = STATE_MANAGEMENT_MIGRATIONS
+): boolean => {
+    const entry = getEntryById(id, entries);
+    if (entry.requiresProjectContent && !context.hasProjectContent) {
+        return false;
+    }
+    return payloadVersion < entry.toVersion;
+};
+
+/**
+ * The version a `'first-dataview'` execution point must stamp on
+ * completion of the given migration. Routing the stamp through this (U3)
+ * keeps the number owned by the registry.
+ */
+export const getStateManagementVersionToStamp = (
+    id: string,
+    entries: readonly StateManagementMigrationEntry[] = STATE_MANAGEMENT_MIGRATIONS
+): number => getEntryById(id, entries).toVersion;
+
+/**
+ * Registry-owned replacement for the legacy `isLegacySpec` version sniff:
+ * is the support-field legacy stamping still pending for this visual?
+ * Pre-2.0 payloads with real project content qualify; fresh visuals,
+ * cross-GUID imports and already-stamped payloads do not.
+ */
+export const isSupportFieldMigrationPending = (
+    jsonSpec: string,
+    denebMetaVersion: number
+): boolean =>
+    isStateManagementMigrationPending(
+        SUPPORT_FIELD_LEGACY_MIGRATION_ID,
+        denebMetaVersion,
+        { hasProjectContent: hasProjectContent(jsonSpec) }
+    );
+
+/**
+ * Apply all pending `'load-time'` migrations to a payload, in registry
+ * order, and return the merged result plus everything the caller needs to
+ * act on (pending data-dependent entries, corrupt-key signals).
+ *
+ * Guarantees:
+ *
+ *  - MERGE, never replace: each entry's patch is spread over the input;
+ *    keys an entry does not touch are preserved verbatim.
+ *  - Idempotent: running the pipeline on its own output (or on a stale
+ *    sync-layer echo of it) applies nothing and returns a deep-equal
+ *    payload.
+ *  - `'empty-or-cross-guid'`, `'current'` and `'indeterminate'` payloads
+ *    are no-ops.
+ *  - A pending `'first-dataview'` entry blocks all later entries — they
+ *    assume its output shape and run only after it has executed and
+ *    stamped from the mapping pass.
+ *  - The version stamp is only written when at least one entry applied.
+ */
+export const runStateManagementLoadTimeMigrations = (
+    payload: Readonly<StateManagementPayload>,
+    context: StateManagementMigrationContext,
+    entries: readonly StateManagementMigrationEntry[] = STATE_MANAGEMENT_MIGRATIONS
+): StateManagementLoadMigrationResult => {
+    const { version, classification, corruptKeys } =
+        inspectStateManagementPayload(payload, context, entries);
+    const noOp = (v: number | null): StateManagementLoadMigrationResult => ({
+        payload: { ...payload },
+        version: v ?? 0,
+        classification,
+        applied: [],
+        pendingFirstDataview: [],
+        corruptKeys
+    });
+    if (
+        classification === 'indeterminate' ||
+        classification === 'current' ||
+        classification === 'empty-or-cross-guid'
+    ) {
+        return noOp(version);
+    }
+    let migrated: StateManagementPayload = { ...payload };
+    let workingVersion = version as number;
+    const applied: string[] = [];
+    const pendingFirstDataview: string[] = [];
+    for (const entry of entries) {
+        if (workingVersion >= entry.toVersion) {
+            // Already migrated past this entry (idempotency / stale echo).
+            continue;
+        }
+        // Note: `requiresProjectContent` needs no per-entry check here —
+        // every payload without project content classifies as
+        // `'empty-or-cross-guid'` above and never reaches this loop.
+        if (entry.migrationClass === 'first-dataview') {
+            // Data-dependent: executes later from the mapping pass. Later
+            // entries assume its output shape, so stop here.
+            pendingFirstDataview.push(entry.id);
+            break;
+        }
+        migrated = { ...migrated, ...entry.migrate(migrated) };
+        workingVersion = entry.toVersion;
+        applied.push(entry.id);
+    }
+    if (applied.length === 0) {
+        return {
+            payload: { ...payload },
+            version: version as number,
+            classification,
+            applied,
+            pendingFirstDataview,
+            corruptKeys
+        };
+    }
+    migrated = { ...migrated, denebMetaVersion: String(workingVersion) };
+    return {
+        payload: migrated,
+        version: workingVersion,
+        classification,
+        applied,
+        pendingFirstDataview,
+        corruptKeys
+    };
+};


### PR DESCRIPTION
## What

Implements the **migration epoch** (plan U2, ideation idea #2): a schema-versioned, ordered `{fromVersion, migrate}` registry that owns ALL version comparison for the persisted `stateManagement` payload. 2.0 becomes the last unversioned shape the code ever has to sniff.

## Design

- **Version stamp = existing `denebMetaVersion`** — already persisted, already synced through `serializeForPersistence`, already what the only live migration checks. A second stamp could disagree with it. Registry current version: 2 (entry `0 → 2`; v1 never shipped).
- **Two migration classes, one stamp:**
  - *load-time* payload-shape entries, applied in order from `handlePropertyMigration` (edit + read mode);
  - *first-dataview* data-dependent entries — the support-field legacy stamping, which needs DataView/jsonSpec context — register here for the WHETHER decision but execute from the mapping pass. The stamping block itself is restructured in the stacked follow-up (U3), which routes it through `isStateManagementMigrationPending` / `getStateManagementVersionToStamp`.
- Registry integrity is a hard error: gaps, duplicates, out-of-order or non-advancing entries throw (tested).

## Safety properties (all tested)

- **Idempotent vs stale-echo**: re-running any entry on migrated state is a no-op — required because create-slice-sync can replay a migration's own persist ~5s later
- **Partial payloads merge, never replace** (the M10 config-present/metaVersion-absent split)
- **Empty ≠ legacy**: fresh-visual/cross-GUID empty payloads classify distinctly from genuinely-unversioned pre-2.0 payloads
- **Corrupt keys → typed signals** (`StateManagementCorruptKey`), never silent resets; unreadable stamp classifies `indeterminate` and fails safe
- **Fixture corpus replays the full pipeline in CI**: unversioned / current / partial / empty / corrupt ×2

## Verification

`npm run test:root`: 17 files, **268 tests green** (+52 new). tsc/eslint/prettier clean. Grep sweep: no `stateManagement` version-comparison sites remain outside the registry (`isLegacySpec` is now a one-line delegate). Unrelated gates (CONTEXT_MENU_SPLIT_VERSION remap, version-change modal) untouched by design.

**Known follow-up (owned by U3):** `project-sync-mappings.ts` deserializes the stamp with `parseInt(raw,10) || 0`, coercing a corrupt stamp to 0 store-side — pre-existing; U3's stamping-block restructure addresses it alongside merge/single-persist semantics.

Part of the 2026-07-03 audit remediation program (unit U2 of 18; U1 = #687).

🤖 Generated with [Claude Code](https://claude.com/claude-code)