### PR TITLE
feat(visual): fake-host lifecycle harness + root test CI wiring (U4)

### DIFF
--- a/src/__test__/harness/display-mode-quirks.test.ts
+++ b/src/__test__/harness/display-mode-quirks.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+// `powerbi-visuals-api` const enums have no runtime representation in
+// the test environment (the package's runtime export is only
+// `{ version, schemas }`), but `display-mode.ts`'s update-type helpers
+// read `powerbi.VisualUpdateType.*` at runtime. Provide the pinned
+// numeric values (they are `satisfies`-guarded in
+// src/__test__/harness/fixtures.ts, so API drift fails compilation).
+vi.mock('powerbi-visuals-api', () => ({
+    default: {
+        VisualUpdateType: {
+            Data: 2,
+            Resize: 4,
+            ViewMode: 8,
+            Style: 16,
+            ResizeEnd: 32
+        }
+    }
+}));
+
+import type powerbi from 'powerbi-visuals-api';
+
+import {
+    doesModeAllowEmbedViewportSet,
+    getUpdatedDisplayHistoryList,
+    type DisplayHistoryRecord,
+    type GetUpdatedHistoryListPayload
+} from '../../lib/state/display-mode';
+import {
+    buildCategorical,
+    buildDataView,
+    buildUpdateOptions,
+    buildViewportBeforeIframeResizeQuirk,
+    EDIT_MODE_ADVANCED,
+    EDIT_MODE_DEFAULT,
+    EDITOR_VIEWPORT,
+    FRACTIONAL_VIEWPORT,
+    UPDATE_TYPE_DATA,
+    UPDATE_TYPE_RESIZE,
+    UPDATE_TYPE_RESIZE_WITH_END
+} from './fixtures';
+
+/**
+ * Fake-host display-mode scenarios: drives the REAL
+ * `getUpdatedDisplayHistoryList` / `doesModeAllowEmbedViewportSet`
+ * against the documented host quirks:
+ *
+ *  - fractional viewport dimensions (Desktop, snap-to-grid off);
+ *  - `isInFocus: undefined` on the options envelope;
+ *  - host reports the new viewport before the iframe physically
+ *    resizes (freeze/bounce docs) — the embed-viewport commit gate
+ *    must block the premature value;
+ *  - segmented-fetch quirk #2 — a transition arriving mid-fetch keeps
+ *    the resolved mode pinned at `fetching`, which must remain
+ *    commit-unsafe.
+ */
+
+const buildSettingsStub = (): GetUpdatedHistoryListPayload['settings'] =>
+    ({
+        vega: {
+            output: { jsonSpec: { value: '{"mark": "bar"}' } }
+        }
+    }) as unknown as GetUpdatedHistoryListPayload['settings'];
+
+const pushHistory = (
+    history: DisplayHistoryRecord[],
+    options: powerbi.extensibility.visual.VisualUpdateOptions,
+    isFetchingAdditionalData = false
+): DisplayHistoryRecord[] =>
+    getUpdatedDisplayHistoryList(history, {
+        options,
+        settings: buildSettingsStub(),
+        isFetchingAdditionalData
+    });
+
+const viewerBaseline = () =>
+    pushHistory(
+        [],
+        buildUpdateOptions({
+            dataView: buildDataView({ categorical: buildCategorical(100) }),
+            type: UPDATE_TYPE_DATA,
+            editMode: EDIT_MODE_DEFAULT,
+            viewport: FRACTIONAL_VIEWPORT
+        })
+    );
+
+describe('display-mode quirks: fractional viewports (Desktop snap-to-grid off)', () => {
+    it('viewer→editor transition sequence resolves correctly with sub-pixel viewports throughout', () => {
+        // [initial] viewer at a fractional viewport.
+        let history = viewerBaseline();
+        expect(history[0].displayMode).toBe('viewer');
+        expect(history[0].viewport).toBe(FRACTIONAL_VIEWPORT);
+
+        // #1 — editMode Advanced, Resize+ResizeEnd, premature editor
+        // viewport (also fractional) → transition start.
+        history = pushHistory(
+            history,
+            buildUpdateOptions({
+                dataView: buildDataView({
+                    categorical: buildCategorical(100)
+                }),
+                type: UPDATE_TYPE_RESIZE_WITH_END,
+                editMode: EDIT_MODE_ADVANCED,
+                viewport: EDITOR_VIEWPORT
+            })
+        );
+        expect(history[0].displayMode).toBe('transition-viewer-editor');
+
+        // #2 — editMode Advanced, Resize only → transition confirmed.
+        history = pushHistory(
+            history,
+            buildUpdateOptions({
+                dataView: buildDataView({
+                    categorical: buildCategorical(100)
+                }),
+                type: UPDATE_TYPE_RESIZE,
+                editMode: EDIT_MODE_ADVANCED,
+                viewport: EDITOR_VIEWPORT
+            })
+        );
+        expect(history[0].displayMode).toBe('editor');
+    });
+});
+
+describe('display-mode quirks: isInFocus arrives as undefined', () => {
+    it('mode resolution tolerates the undefined flag and the history record preserves it verbatim', () => {
+        const options = buildUpdateOptions({
+            dataView: buildDataView({ categorical: buildCategorical(100) }),
+            type: UPDATE_TYPE_DATA,
+            editMode: EDIT_MODE_DEFAULT
+        });
+        expect((options as { isInFocus?: boolean }).isInFocus).toBeUndefined();
+        const history = pushHistory([], options);
+        expect(history[0].displayMode).toBe('viewer');
+        expect(history[0].isInFocus).toBeUndefined();
+    });
+});
+
+describe('display-mode quirks: host reports the new viewport before the iframe resizes', () => {
+    it('the transition mode resolved for the premature-viewport update is commit-unsafe, so the wrong dimensions never reach embedViewport', () => {
+        const quirk = buildViewportBeforeIframeResizeQuirk();
+        // The bounce doc's precision pitfall: the host-reported width is
+        // fractional while the iframe's innerWidth is an integer —
+        // strict equality between them can never confirm settlement.
+        expect(quirk.options.viewport.width).not.toBe(quirk.physicalInnerWidth);
+
+        const history = pushHistory(viewerBaseline(), quirk.options);
+        expect(history[0].displayMode).toBe('transition-viewer-editor');
+        expect(history[0].viewport).toBe(EDITOR_VIEWPORT);
+        // The commit gate blocks the premature host viewport.
+        expect(doesModeAllowEmbedViewportSet(history[0].displayMode)).toBe(
+            false
+        );
+    });
+});
+
+describe('display-mode quirks: transition arriving mid-fetch (segmented-fetch quirk #2)', () => {
+    it('the stuck fetching flag pins the resolved mode at fetching, which stays commit-unsafe', () => {
+        // Mid-fetch: a segment update lands while the fetching flag is
+        // set, so the latest history record resolves to `fetching`
+        // (not `viewer`) — this is what masks the transition detector.
+        const midFetch = pushHistory(
+            viewerBaseline(),
+            buildUpdateOptions({
+                dataView: buildDataView({
+                    categorical: buildCategorical(100),
+                    segment: true
+                }),
+                type: UPDATE_TYPE_DATA,
+                editMode: EDIT_MODE_DEFAULT
+            }),
+            true
+        );
+        expect(midFetch[0].displayMode).toBe('fetching');
+        // A transition-shaped update (editor viewport, Advanced edit
+        // mode) arrives while `isFetchingAdditional` is still true —
+        // the resolved mode stays pinned at `fetching` because the
+        // transition detector requires the prior record to be `viewer`.
+        const history = pushHistory(
+            midFetch,
+            buildUpdateOptions({
+                dataView: buildDataView({
+                    categorical: buildCategorical(100)
+                }),
+                type: UPDATE_TYPE_RESIZE_WITH_END,
+                editMode: EDIT_MODE_ADVANCED,
+                viewport: EDITOR_VIEWPORT
+            }),
+            true
+        );
+        expect(history[0].displayMode).toBe('fetching');
+        // Quirk #2's fix: `fetching` is excluded from the embed-
+        // viewport commit gate, so the editor-sized viewport reported
+        // during the masked transition cannot pollute embedViewport.
+        expect(doesModeAllowEmbedViewportSet('fetching')).toBe(false);
+    });
+});

--- a/src/__test__/harness/fake-visual-host.ts
+++ b/src/__test__/harness/fake-visual-host.ts
@@ -1,0 +1,125 @@
+import type powerbi from 'powerbi-visuals-api';
+
+/**
+ * One recorded emission the fake host's event service received. Ordered
+ * capture lets scenario tests assert both counts (exactly-once) and
+ * sequencing (supersede-before-new-start).
+ */
+export type FakeEmitterCall =
+    | {
+          method: 'renderingStarted';
+          options: powerbi.extensibility.visual.VisualUpdateOptions;
+      }
+    | {
+          method: 'renderingFinished';
+          options: powerbi.extensibility.visual.VisualUpdateOptions;
+      }
+    | {
+          method: 'renderingFailed';
+          options: powerbi.extensibility.visual.VisualUpdateOptions;
+          reason: string | undefined;
+      };
+
+/**
+ * Script for the fake host's `fetchMoreData`. Responses are consumed in
+ * order, one per call:
+ *  - `true`  — host accepted the segment request (an Append will follow
+ *    as its own `update()` in a real session; the scenario ships it).
+ *  - `false` — host declined (no more segments / limit reached).
+ *  - `Error` — host throws synchronously (the documented defensive-path
+ *    quirk in `Deneb.handleFetchMore`).
+ *
+ * When the script is exhausted the fake declines (`false`) — the safest
+ * default because it routes the driver into finalise-with-what-we-have
+ * rather than an unbounded fetch loop.
+ */
+export type FetchMoreResponse = boolean | Error;
+
+export type FakeVisualHostConfig = {
+    fetchMoreResponses?: FetchMoreResponse[];
+};
+
+/**
+ * Minimal structural subset of `powerbi.extensibility.visual.IVisualHost`
+ * that the update-cycle orchestration touches: the rendering event
+ * service (consumed by the rendering-lifecycle coordinator as its
+ * emitter) and `fetchMoreData` (consumed by the fetch-more dispatch
+ * branch). Everything else on the real host is irrelevant to lifecycle
+ * orchestration and intentionally absent, so a scenario that
+ * accidentally reaches for another host capability fails loudly at the
+ * type level instead of silently exercising an untested seam.
+ */
+export type FakeVisualHost = {
+    eventService: {
+        renderingStarted: (
+            options: powerbi.extensibility.visual.VisualUpdateOptions
+        ) => void;
+        renderingFinished: (
+            options: powerbi.extensibility.visual.VisualUpdateOptions
+        ) => void;
+        renderingFailed: (
+            options: powerbi.extensibility.visual.VisualUpdateOptions,
+            reason?: string
+        ) => void;
+    };
+    fetchMoreData: (aggregateSegments?: boolean) => boolean;
+};
+
+export type FakeVisualHostHandle = {
+    host: FakeVisualHost;
+    /** Ordered record of every rendering* emission the host saw. */
+    emitterCalls: FakeEmitterCall[];
+    /** Arguments of every `fetchMoreData` call, in order. */
+    fetchMoreCalls: Array<{ aggregateSegments: boolean | undefined }>;
+    /** Convenience count of emitter calls by method. */
+    countEmitterCalls: (method: FakeEmitterCall['method']) => number;
+};
+
+/**
+ * Build a scripted fake Power BI visual host. The event service records
+ * every emission (never throws — host-throw scenarios are covered by
+ * the coordinator's own unit suite); `fetchMoreData` consumes the
+ * configured response script.
+ */
+export const createFakeVisualHost = (
+    config: FakeVisualHostConfig = {}
+): FakeVisualHostHandle => {
+    const emitterCalls: FakeEmitterCall[] = [];
+    const fetchMoreCalls: Array<{ aggregateSegments: boolean | undefined }> =
+        [];
+    const responses = [...(config.fetchMoreResponses ?? [])];
+
+    const host: FakeVisualHost = {
+        eventService: {
+            renderingStarted: (options) => {
+                emitterCalls.push({ method: 'renderingStarted', options });
+            },
+            renderingFinished: (options) => {
+                emitterCalls.push({ method: 'renderingFinished', options });
+            },
+            renderingFailed: (options, reason) => {
+                emitterCalls.push({
+                    method: 'renderingFailed',
+                    options,
+                    reason
+                });
+            }
+        },
+        fetchMoreData: (aggregateSegments) => {
+            fetchMoreCalls.push({ aggregateSegments });
+            const next = responses.shift();
+            if (next instanceof Error) {
+                throw next;
+            }
+            return next ?? false;
+        }
+    };
+
+    return {
+        host,
+        emitterCalls,
+        fetchMoreCalls,
+        countEmitterCalls: (method) =>
+            emitterCalls.filter((c) => c.method === method).length
+    };
+};

--- a/src/__test__/harness/fixtures.ts
+++ b/src/__test__/harness/fixtures.ts
@@ -1,0 +1,216 @@
+import type powerbi from 'powerbi-visuals-api';
+
+/**
+ * Scenario fixture builders for the fake-host lifecycle harness,
+ * including the documented Power BI host quirks from:
+ *
+ *  - docs/solutions/logic-errors/segmented-fetch-viewer-editor-transition-quirks-2026-05-27.md
+ *  - docs/solutions/ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md
+ *  - docs/solutions/ui-bugs/viewer-bounce-on-editor-exit-2026-05-04.md
+ *
+ * Enum values are pinned as numeric literals with `satisfies` clauses
+ * (the pattern established in `src/lib/state/display-mode.ts`) because
+ * `powerbi-visuals-api` const enums have no runtime representation in
+ * the vitest environment — the namespace import resolves, but member
+ * lookups are `undefined`. The `satisfies` clause fails compilation if
+ * a future API upgrade reassigns the value.
+ */
+
+export const OPERATION_KIND_CREATE =
+    0 satisfies powerbi.VisualDataChangeOperationKind;
+export const OPERATION_KIND_APPEND =
+    1 satisfies powerbi.VisualDataChangeOperationKind;
+
+export const UPDATE_TYPE_DATA = 2 satisfies powerbi.VisualUpdateType;
+export const UPDATE_TYPE_RESIZE = 4 satisfies powerbi.VisualUpdateType;
+export const UPDATE_TYPE_VIEW_MODE = 8 satisfies powerbi.VisualUpdateType;
+export const UPDATE_TYPE_RESIZE_END = 32 satisfies powerbi.VisualUpdateType;
+/** `Resize | ResizeEnd` — the composite the host ships on transition updates. */
+export const UPDATE_TYPE_RESIZE_WITH_END = (UPDATE_TYPE_RESIZE |
+    UPDATE_TYPE_RESIZE_END) as powerbi.VisualUpdateType;
+
+export const EDIT_MODE_DEFAULT = 0 satisfies powerbi.EditMode;
+export const EDIT_MODE_ADVANCED = 1 satisfies powerbi.EditMode;
+
+export const VIEW_MODE_VIEW = 0 satisfies powerbi.ViewMode;
+export const VIEW_MODE_EDIT = 1 satisfies powerbi.ViewMode;
+
+/**
+ * Documented host quirk (viewer-bounce doc): with snap-to-grid off,
+ * Power BI Desktop reports FRACTIONAL viewport dimensions. Any harness
+ * logic that assumes integer viewports diverges from the real host, so
+ * the default scenario viewports deliberately carry sub-pixel values.
+ */
+export const FRACTIONAL_VIEWPORT: powerbi.IViewport = {
+    width: 286.4729,
+    height: 174.2331
+};
+
+/**
+ * A plausible editor-pane viewport, also fractional. Used with the
+ * "host reports the new viewport before the iframe physically resizes"
+ * quirk: during a viewer→editor transition the host ships this larger
+ * viewport while the iframe's `window.innerWidth` still reflects the
+ * old viewer size.
+ */
+export const EDITOR_VIEWPORT: powerbi.IViewport = {
+    width: 1280.5,
+    height: 720.25
+};
+
+/**
+ * Build a categorical data view slice with `rowCount` rows. Every call
+ * produces FRESH array references — the reference-based change
+ * detection in `hasDataViewChanged` treats each build as new data.
+ * Reuse the same returned object across updates to simulate the
+ * host's reference-equal DataView behaviour on transitions.
+ */
+export const buildCategorical = (
+    rowCount: number
+): powerbi.DataViewCategorical =>
+    ({
+        categories: [
+            {
+                source: {
+                    displayName: 'Category',
+                    queryName: 'Table.Category',
+                    index: 0,
+                    roles: { dataset: true }
+                },
+                values: Array.from({ length: rowCount }, (_, i) => `row-${i}`)
+            }
+        ],
+        values: []
+    }) as unknown as powerbi.DataViewCategorical;
+
+export type BuildDataViewConfig = {
+    categorical: powerbi.DataViewCategorical;
+    /**
+     * When true, `metadata.segment` is present — the host's signal that
+     * more data segments are available (`canFetchMoreFromDataview`
+     * reads this together with the data-limit override setting).
+     */
+    segment?: boolean;
+};
+
+export const buildDataView = (config: BuildDataViewConfig): powerbi.DataView =>
+    ({
+        metadata: {
+            columns: [
+                {
+                    displayName: 'Category',
+                    queryName: 'Table.Category',
+                    index: 0,
+                    roles: { dataset: true }
+                }
+            ],
+            ...(config.segment ? { segment: {} } : {})
+        },
+        categorical: config.categorical
+    }) as unknown as powerbi.DataView;
+
+export type BuildUpdateOptionsConfig = {
+    dataView?: powerbi.DataView;
+    /** Reuse a prior update's `dataViews` array verbatim (reference-equal quirk). */
+    dataViews?: powerbi.DataView[];
+    operationKind?: powerbi.VisualDataChangeOperationKind;
+    type?: powerbi.VisualUpdateType;
+    viewport?: powerbi.IViewport;
+    editMode?: powerbi.EditMode;
+    viewMode?: powerbi.ViewMode;
+    /**
+     * Documented host quirk: `isInFocus` arrives as `undefined` (not
+     * `false`) on many real host updates. The default here is
+     * deliberately `undefined` so every scenario exercises the quirk
+     * unless a test opts into an explicit value.
+     */
+    isInFocus?: boolean;
+};
+
+/**
+ * Build a `VisualUpdateOptions` payload for the driver. Only the
+ * properties the update-cycle orchestration reads are populated; the
+ * cast is the same pattern the existing root test-suites use for
+ * partial host payloads.
+ */
+export const buildUpdateOptions = (
+    config: BuildUpdateOptionsConfig = {}
+): powerbi.extensibility.visual.VisualUpdateOptions =>
+    ({
+        dataViews:
+            config.dataViews ??
+            (config.dataView ? [config.dataView] : undefined),
+        operationKind: config.operationKind,
+        type: config.type ?? UPDATE_TYPE_DATA,
+        viewport: config.viewport ?? FRACTIONAL_VIEWPORT,
+        editMode: config.editMode ?? EDIT_MODE_DEFAULT,
+        viewMode: config.viewMode ?? VIEW_MODE_EDIT,
+        isInFocus: config.isInFocus
+    }) as unknown as powerbi.extensibility.visual.VisualUpdateOptions;
+
+/**
+ * Documented host quirk (segmented-fetch doc, root cause #1): a
+ * viewer↔editor transition update re-ships the PREVIOUS update's
+ * DataView objects reference-equal — only the options envelope (type,
+ * viewport, editMode) changes. Reference-based change detection must
+ * report "no data change" for these.
+ */
+export const buildTransitionUpdateReusingDataView = (
+    previous: powerbi.extensibility.visual.VisualUpdateOptions,
+    overrides: Omit<BuildUpdateOptionsConfig, 'dataView' | 'dataViews'> = {}
+): powerbi.extensibility.visual.VisualUpdateOptions =>
+    buildUpdateOptions({
+        dataViews: previous.dataViews,
+        type: overrides.type ?? UPDATE_TYPE_RESIZE_WITH_END,
+        viewport: overrides.viewport ?? EDITOR_VIEWPORT,
+        editMode: overrides.editMode ?? EDIT_MODE_ADVANCED,
+        viewMode: overrides.viewMode,
+        isInFocus: overrides.isInFocus,
+        operationKind: overrides.operationKind
+    });
+
+/**
+ * Documented host quirk (segmented-fetch doc, root causes #3 + #4): on
+ * a viewer→editor transition of a fully-loaded multi-segment dataset,
+ * the host resets its segmented-fetch state and re-ships a REDUCED
+ * first segment as a fresh `Create` — while the visual's
+ * `isFetchingAdditional` flag from the interrupted chain is still set.
+ * The decision function must route this to recovery (preserve the
+ * fully-loaded slice; do NOT re-enter fetch-more).
+ */
+export const buildReducedRestartCreate = (
+    reducedRowCount: number
+): powerbi.extensibility.visual.VisualUpdateOptions =>
+    buildUpdateOptions({
+        dataView: buildDataView({
+            categorical: buildCategorical(reducedRowCount),
+            segment: true
+        }),
+        operationKind: OPERATION_KIND_CREATE,
+        type: UPDATE_TYPE_DATA
+    });
+
+/**
+ * Documented host quirk (freeze + bounce docs): the host reports the
+ * NEW viewport in `options.viewport` before the iframe has physically
+ * resized — `window.innerWidth` still holds the old width for tens to
+ * ~150ms. The fixture pairs the premature host-reported viewport with
+ * the stale physical width so display-mode tests can assert the
+ * embed-viewport commit gate blocks the premature value.
+ */
+export type ViewportBeforeIframeResizeFixture = {
+    options: powerbi.extensibility.visual.VisualUpdateOptions;
+    /** What `window.innerWidth` would still report at this instant. */
+    physicalInnerWidth: number;
+};
+
+export const buildViewportBeforeIframeResizeQuirk =
+    (): ViewportBeforeIframeResizeFixture => ({
+        options: buildUpdateOptions({
+            dataView: buildDataView({ categorical: buildCategorical(100) }),
+            type: UPDATE_TYPE_RESIZE_WITH_END,
+            editMode: EDIT_MODE_ADVANCED,
+            viewport: EDITOR_VIEWPORT
+        }),
+        physicalInnerWidth: Math.trunc(FRACTIONAL_VIEWPORT.width)
+    });

--- a/src/__test__/harness/mock-dataset-slice.ts
+++ b/src/__test__/harness/mock-dataset-slice.ts
@@ -1,0 +1,68 @@
+/**
+ * Recording stand-in for the visual store's `dataset` slice. The
+ * update-cycle driver mirrors `Deneb.resolveDataset`'s dispatch against
+ * this slice instead of the real Zustand store, per the U4 harness
+ * shape (mocked state slices + fake host + real decision function +
+ * real coordinator).
+ *
+ * Semantics mirrored from `src/state/dataset.ts`'s slice contract as
+ * consumed by `src/index.ts`:
+ *  - `setIsFetchingAdditional` updates BOTH the flag and `rowsLoaded`
+ *    (this is how the recover-interrupted-fetch branch preserves the
+ *    displayed row count via `Math.max` without touching `values`).
+ *  - `setDataset` replaces `values` and `rowsLoaded` together.
+ */
+
+export type MockDatasetState = {
+    isFetchingAdditional: boolean;
+    rowsLoaded: number;
+    values: unknown[];
+};
+
+export type SetIsFetchingAdditionalPayload = {
+    isFetchingAdditional: boolean;
+    rowsLoaded: number;
+};
+
+export type SetDatasetPayload = {
+    values: unknown[];
+    rowsLoaded: number;
+};
+
+export type MockDatasetSlice = {
+    state: MockDatasetState;
+    setIsFetchingAdditional: (payload: SetIsFetchingAdditionalPayload) => void;
+    setDataset: (payload: SetDatasetPayload) => void;
+    /** Ordered record of every `setIsFetchingAdditional` call. */
+    setIsFetchingAdditionalCalls: SetIsFetchingAdditionalPayload[];
+    /** Ordered record of every `setDataset` call. */
+    setDatasetCalls: SetDatasetPayload[];
+};
+
+export const createMockDatasetSlice = (
+    initial: Partial<MockDatasetState> = {}
+): MockDatasetSlice => {
+    const state: MockDatasetState = {
+        isFetchingAdditional: initial.isFetchingAdditional ?? false,
+        rowsLoaded: initial.rowsLoaded ?? 0,
+        values: initial.values ?? []
+    };
+    const setIsFetchingAdditionalCalls: SetIsFetchingAdditionalPayload[] = [];
+    const setDatasetCalls: SetDatasetPayload[] = [];
+
+    return {
+        state,
+        setIsFetchingAdditional: (payload) => {
+            setIsFetchingAdditionalCalls.push(payload);
+            state.isFetchingAdditional = payload.isFetchingAdditional;
+            state.rowsLoaded = payload.rowsLoaded;
+        },
+        setDataset: (payload) => {
+            setDatasetCalls.push(payload);
+            state.values = payload.values;
+            state.rowsLoaded = payload.rowsLoaded;
+        },
+        setIsFetchingAdditionalCalls,
+        setDatasetCalls
+    };
+};

--- a/src/__test__/harness/scenarios.test.ts
+++ b/src/__test__/harness/scenarios.test.ts
@@ -1,0 +1,501 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+//
+// The harness drives the REAL `resolveDatasetUpdateAction`, the REAL
+// `hasDataViewChanged` (reference-based change detection) and the REAL
+// rendering-lifecycle coordinator. `processing.ts` transitively imports
+// the full dataset-mapping chain (app-core store, data-core support
+// fields, interactivity), none of which participates in lifecycle
+// orchestration — the mocks below isolate `hasDataViewChanged` exactly
+// the way `src/lib/dataset/__test__/support-field-volatile.test.ts`
+// (the established recipe) does. `./data-view` is deliberately NOT
+// mocked: the driver needs the real decision function and helpers.
+
+vi.mock('@deneb-viz/utils/logging', () => ({
+    logTimeStart: vi.fn(),
+    logTimeEnd: vi.fn(),
+    logDebug: vi.fn()
+}));
+vi.mock('../../lib/dataset/drilldown', () => ({
+    isDrilldownFeatureEnabled: vi.fn(() => false),
+    resolveDrilldownComponents: vi.fn(),
+    resolveDrilldownFlat: vi.fn()
+}));
+vi.mock('@deneb-viz/data-core/dataset', () => ({
+    DATASET_DEFAULT_NAME: 'Values'
+}));
+vi.mock('@deneb-viz/data-core/field', () => ({
+    DRILL_FIELD_FLAT: '__drillFlat__',
+    DRILL_FIELD_NAME: '__drill__',
+    ROW_INDEX_FIELD_NAME: '__row__'
+}));
+vi.mock('@deneb-viz/data-core/value', () => ({}));
+vi.mock('@deneb-viz/data-core/support-fields', () => ({
+    buildProcessingPlan: vi.fn(),
+    buildDataRow: vi.fn(),
+    resolveFieldDefaults: vi.fn()
+}));
+vi.mock('../../lib/dataset/values', () => ({
+    getCastedPrimitiveValue: vi.fn(),
+    getDatumValueEntriesFromDataview: vi.fn(() => [])
+}));
+vi.mock('../../lib/dataset/fields', () => ({
+    getDatumFieldMetadataFromDataView: vi.fn(() => []),
+    getDatumFieldsFromMetadata: vi.fn(() => ({})),
+    getEncodedFieldName: vi.fn((n: string) => n),
+    isSourceField: vi.fn(() => true)
+}));
+vi.mock('../../lib/dataset/support-field-provider', () => ({
+    createPbiSupportFieldProvider: vi.fn()
+}));
+vi.mock('../../lib/dataset/support-field-migration', () => ({
+    isLegacySpec: vi.fn(() => false)
+}));
+vi.mock('@deneb-viz/app-core', () => ({
+    getDenebState: vi.fn(() => ({
+        project: {
+            spec: '{}',
+            supportFieldConfiguration: {},
+            setSupportFieldConfiguration: vi.fn(),
+            setDenebMetaVersion: vi.fn(),
+            denebMetaVersion: 2
+        }
+    }))
+}));
+vi.mock('../../lib/interactivity', () => ({
+    InteractivityManager: { clearSelectors: vi.fn(), addRowSelector: vi.fn() },
+    isCrossFilterPropSet: vi.fn(() => false),
+    isCrossHighlightPropSet: vi.fn(() => false)
+}));
+vi.mock('mergician', () => ({ mergician: vi.fn((a: unknown) => a) }));
+
+import { SUPERSEDED_FAILURE_REASON } from '../../lib/rendering-lifecycle/types';
+import {
+    createUpdateCycleDriver,
+    type UpdateCycleDriverConfig
+} from './update-cycle-driver';
+import {
+    buildCategorical,
+    buildDataView,
+    buildReducedRestartCreate,
+    buildTransitionUpdateReusingDataView,
+    buildUpdateOptions,
+    FRACTIONAL_VIEWPORT,
+    OPERATION_KIND_APPEND,
+    OPERATION_KIND_CREATE,
+    UPDATE_TYPE_DATA,
+    UPDATE_TYPE_RESIZE_WITH_END
+} from './fixtures';
+
+// ─── Harness wiring ───────────────────────────────────────────────────────────
+
+/**
+ * `hasDataViewChanged` keeps its reference cache in module-level state,
+ * so each scenario re-imports a fresh copy (the registered mocks above
+ * survive `vi.resetModules`). The driver receives it through the
+ * `hasDataChanged` seam with the interactivity/support-field flags held
+ * constant — those inputs have their own focused suite.
+ */
+const createDriver = async (
+    config: Omit<UpdateCycleDriverConfig, 'hasDataChanged'> = {}
+) => {
+    vi.resetModules();
+    const { hasDataViewChanged } = await import('../../lib/dataset/processing');
+    // Converge the detector's seed-state branches before the scenario
+    // starts: on a fresh module the first call reports "changed" via
+    // the consolidate-parameters seed and the second via the
+    // interactivity-settings seed, regardless of references. Two
+    // throwaway calls settle both (mirroring a visual that has already
+    // processed its constructor-era updates), so scenario updates
+    // exercise the pure reference-based detection the documented host
+    // quirks hinge on.
+    const throwaway = buildCategorical(1);
+    hasDataViewChanged(throwaway, false, false, {}, true);
+    hasDataViewChanged(throwaway, false, false, {}, true);
+    return createUpdateCycleDriver({
+        ...config,
+        hasDataChanged: (categorical) =>
+            hasDataViewChanged(categorical, false, false, {}, true)
+    });
+};
+
+// ─── Scenario 1: single update lifecycle ──────────────────────────────────────
+
+describe('scenario: single update → compile → render-start → close', () => {
+    it('emits exactly one renderingStarted and one renderingFinished; no failures; no open ids', async () => {
+        const driver = await createDriver();
+        const options = buildUpdateOptions({
+            dataView: buildDataView({ categorical: buildCategorical(100) }),
+            operationKind: OPERATION_KIND_CREATE,
+            type: UPDATE_TYPE_DATA
+        });
+
+        driver.update(options);
+        // Rendering dispatch resolved: dataset committed, render pending.
+        expect(driver.actions).toEqual([
+            { kind: 'finalise', reason: 'normal' }
+        ]);
+        expect(driver.dataset.setDatasetCalls).toHaveLength(1);
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+
+        // Async render side completes.
+        driver.startRender();
+        driver.completeRender();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+
+        // Safety-net was cancelled by the close — firing anything left
+        // must not produce a second terminal (exactly-once).
+        driver.fireSafetyNets();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+    });
+
+    it('drives cleanly with the documented isInFocus: undefined host quirk on the options envelope', async () => {
+        const driver = await createDriver();
+        const options = buildUpdateOptions({
+            dataView: buildDataView({ categorical: buildCategorical(10) }),
+            operationKind: OPERATION_KIND_CREATE
+        });
+        // Fixture default IS the quirk — pin it so a fixture change
+        // cannot silently drop the coverage.
+        expect((options as { isInFocus?: boolean }).isInFocus).toBeUndefined();
+
+        driver.update(options);
+        driver.startRender();
+        driver.completeRender();
+        expect(driver.caughtErrors).toEqual([]);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+
+    it('safety-net closes an orphaned rendering update exactly once (render callbacks never fire)', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(50) })
+            })
+        );
+        expect(driver.pendingSafetyNetCount()).toBe(1);
+        driver.fireSafetyNets();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+        // A late render callback after the safety-net close no-ops.
+        driver.completeRender();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+    });
+
+    it('safety-net defers while a render is in flight; the render close then lands exactly once', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(50) })
+            })
+        );
+        driver.startRender();
+        driver.fireSafetyNets();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        driver.completeRender();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+    });
+});
+
+// ─── Scenario 2: segmented fetch (multi-update chain) ────────────────────────
+
+describe('scenario: segmented fetch chain (Create → Append → terminal Append)', () => {
+    it('each segment closes its own lifecycle 1:1; no supersedes; no orphaned ids', async () => {
+        const driver = await createDriver({
+            fetchMoreResponses: [true, true]
+        });
+
+        // Segment 1: Create with more segments advertised.
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({
+                    categorical: buildCategorical(10000),
+                    segment: true
+                }),
+                operationKind: OPERATION_KIND_CREATE
+            })
+        );
+        expect(driver.actions.at(-1)).toEqual({ kind: 'fetch-more' });
+        expect(driver.dataset.state.isFetchingAdditional).toBe(true);
+        expect(driver.host.fetchMoreCalls).toHaveLength(1);
+
+        // Segment 2: Append, still more advertised.
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({
+                    categorical: buildCategorical(20000),
+                    segment: true
+                }),
+                operationKind: OPERATION_KIND_APPEND
+            })
+        );
+        expect(driver.actions.at(-1)).toEqual({ kind: 'fetch-more' });
+        expect(driver.host.fetchMoreCalls).toHaveLength(2);
+
+        // Terminal segment: no `segment` marker → normal finalise.
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({
+                    categorical: buildCategorical(27000)
+                }),
+                operationKind: OPERATION_KIND_APPEND
+            })
+        );
+        expect(driver.actions.at(-1)).toEqual({
+            kind: 'finalise',
+            reason: 'normal'
+        });
+        driver.startRender();
+        driver.completeRender();
+
+        // 3 updates → 3 started, 3 finished, 0 failed. Segment updates
+        // closed synchronously so no supersede ever fired.
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(3);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(3);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+        expect(driver.dataset.state.isFetchingAdditional).toBe(false);
+        expect(driver.dataset.state.rowsLoaded).toBe(27000);
+        expect(driver.dataset.setDatasetCalls).toHaveLength(1);
+    });
+
+    it('host declines fetch-more → finalises with the rows already loaded (rendering path)', async () => {
+        const driver = await createDriver({
+            fetchMoreResponses: [false]
+        });
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({
+                    categorical: buildCategorical(30000),
+                    segment: true
+                }),
+                operationKind: OPERATION_KIND_CREATE
+            })
+        );
+        // Host declined — the driver fell through to finalise-with-
+        // what-we-have and bound the pending render.
+        expect(driver.dataset.state.isFetchingAdditional).toBe(false);
+        expect(driver.dataset.setDatasetCalls).toHaveLength(1);
+        driver.startRender();
+        driver.completeRender();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+});
+
+// ─── Scenario 3: viewer↔editor transition mid-fetch (documented quirks) ──────
+
+describe('scenario: viewer↔editor transition interrupts a segmented fetch', () => {
+    it('quirk #1 — reference-equal DataView transition update while fetching → recovery, dataset slice preserved', async () => {
+        const driver = await createDriver({
+            fetchMoreResponses: [true]
+        });
+        // Start a segmented fetch (Create accepted → flag stuck true).
+        const dataUpdate = buildUpdateOptions({
+            dataView: buildDataView({
+                categorical: buildCategorical(10000),
+                segment: true
+            }),
+            operationKind: OPERATION_KIND_CREATE
+        });
+        driver.update(dataUpdate);
+        expect(driver.dataset.state.isFetchingAdditional).toBe(true);
+
+        // The transition update re-ships the SAME DataView objects
+        // reference-equal (documented quirk) — real hasDataViewChanged
+        // must report no change; the stuck flag routes to recovery.
+        driver.update(buildTransitionUpdateReusingDataView(dataUpdate));
+        expect(driver.actions.at(-1)).toEqual({
+            kind: 'finalise',
+            reason: 'recover-interrupted-fetch'
+        });
+        // Decision-table contract: recovery clears the transient flag
+        // ONLY. No setDataset — the existing slice is preserved.
+        expect(driver.dataset.state.isFetchingAdditional).toBe(false);
+        expect(driver.dataset.setDatasetCalls).toHaveLength(0);
+        // Both updates were non-rendering closes: 2 started, 2 finished.
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(2);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(2);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+        // Only the original data update requested a segment.
+        expect(driver.host.fetchMoreCalls).toHaveLength(1);
+    });
+
+    it('quirks #3 + #4 — re-shipped reduced first segment (Create while fetching) → recovery preserves rowsLoaded via Math.max and never re-enters fetchMoreData', async () => {
+        // Fully-loaded multi-segment dataset with the fetch flag stuck
+        // true (the interrupted chain), as on the second editor-open.
+        const fullyLoadedValues = Array.from({ length: 27000 }, (_, i) => ({
+            __row: i
+        }));
+        const driver = await createDriver({
+            fetchMoreResponses: [true],
+            initialDatasetState: {
+                isFetchingAdditional: true,
+                rowsLoaded: 27000,
+                values: fullyLoadedValues
+            }
+        });
+
+        // Host restarts the chain with a REDUCED first segment.
+        driver.update(buildReducedRestartCreate(10000));
+        expect(driver.actions).toEqual([
+            { kind: 'finalise', reason: 'recover-interrupted-fetch' }
+        ]);
+        // Host-restart guard: fetchMoreData must NOT be called (the
+        // host accepts but never honours the restart — quirk #4).
+        expect(driver.host.fetchMoreCalls).toHaveLength(0);
+        // Decision-table contract: no setDataset (reduced payload would
+        // clobber 27K rows); Math.max keeps rowsLoaded at the preserved
+        // slice's count, not the reduced restart's 10K.
+        expect(driver.dataset.setDatasetCalls).toHaveLength(0);
+        expect(driver.dataset.state.values).toBe(fullyLoadedValues);
+        expect(driver.dataset.state.rowsLoaded).toBe(27000);
+        expect(driver.dataset.state.isFetchingAdditional).toBe(false);
+        // Non-rendering close: balanced pair, nothing orphaned.
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+
+    it('post-recovery: a repeat of the same reduced payload is skipped (bounded cache/slice divergence is self-healing)', async () => {
+        const driver = await createDriver({
+            initialDatasetState: {
+                isFetchingAdditional: true,
+                rowsLoaded: 27000
+            }
+        });
+        const reducedRestart = buildReducedRestartCreate(10000);
+        driver.update(reducedRestart);
+        expect(driver.actions.at(-1)).toEqual({
+            kind: 'finalise',
+            reason: 'recover-interrupted-fetch'
+        });
+        // Same reduced refs arrive again (flag now clear) → change
+        // detection cache already points at them → skip.
+        driver.update(reducedRestart);
+        expect(driver.actions.at(-1)).toEqual({ kind: 'skip' });
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(2);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(2);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+});
+
+// ─── Scenario 4: resize storm ─────────────────────────────────────────────────
+
+describe('scenario: update storm (rapid updates racing unfinished renders)', () => {
+    it('each newer update supersede-fails the prior open id; exactly-once emission holds end-to-end', async () => {
+        const driver = await createDriver();
+        // Fractional viewports throughout (Desktop snap-to-grid off).
+        const storm = [1, 2, 3].map((n) =>
+            buildUpdateOptions({
+                dataView: buildDataView({
+                    categorical: buildCategorical(100 + n)
+                }),
+                type: UPDATE_TYPE_RESIZE_WITH_END,
+                viewport: {
+                    width: FRACTIONAL_VIEWPORT.width + n * 0.37,
+                    height: FRACTIONAL_VIEWPORT.height + n * 0.21
+                }
+            })
+        );
+        // Renders never complete between updates — every dispatch is a
+        // rendering path whose pending render is displaced.
+        storm.forEach((options) => driver.update(options));
+
+        const failed = driver.host.emitterCalls.filter(
+            (c) => c.method === 'renderingFailed'
+        );
+        expect(failed).toHaveLength(2);
+        expect(
+            failed.every(
+                (c) =>
+                    c.method === 'renderingFailed' &&
+                    c.reason === SUPERSEDED_FAILURE_REASON
+            )
+        ).toBe(true);
+        // Supersede targets the DISPLACED updates' options, in order.
+        expect(failed[0].options).toBe(storm[0]);
+        expect(failed[1].options).toBe(storm[1]);
+
+        // Only the last update's render completes.
+        driver.startRender();
+        driver.completeRender();
+        const finished = driver.host.emitterCalls.filter(
+            (c) => c.method === 'renderingFinished'
+        );
+        expect(finished).toHaveLength(1);
+        expect(finished[0].options).toBe(storm[2]);
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(3);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+
+        // Stale callbacks and leftover safety-nets are inert.
+        driver.completeRender();
+        driver.fireSafetyNets();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(2);
+    });
+});
+
+// ─── Scenario 5: update() throws ──────────────────────────────────────────────
+
+describe('scenario: update() throws', () => {
+    it('failCurrent routes the error to exactly one renderingFailed with the derived reason', async () => {
+        const driver = await createDriver();
+        driver.queueFault(new Error('boom'));
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(10) })
+            })
+        );
+        expect(driver.caughtErrors).toHaveLength(1);
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        const failed = driver.host.emitterCalls.filter(
+            (c) => c.method === 'renderingFailed'
+        );
+        expect(failed).toHaveLength(1);
+        expect(failed[0].method === 'renderingFailed' && failed[0].reason).toBe(
+            'boom'
+        );
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+        // The id already failed, so the finally-block arm no-opped and
+        // nothing is left to fire.
+        expect(driver.pendingSafetyNetCount()).toBe(0);
+        driver.fireSafetyNets();
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
+    });
+
+    it('fetchMoreData throwing synchronously clears the fetching flag before failing the lifecycle (no permanent FetchingMessage)', async () => {
+        const driver = await createDriver({
+            fetchMoreResponses: [new Error('host exploded')]
+        });
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({
+                    categorical: buildCategorical(5000),
+                    segment: true
+                }),
+                operationKind: OPERATION_KIND_CREATE
+            })
+        );
+        // Defensive-path contract: the flag set before the host call is
+        // cleared on the throw path, then the update fails exactly once.
+        expect(driver.dataset.state.isFetchingAdditional).toBe(false);
+        expect(driver.dataset.setIsFetchingAdditionalCalls).toEqual([
+            { isFetchingAdditional: true, rowsLoaded: 5000 },
+            { isFetchingAdditional: false, rowsLoaded: 5000 }
+        ]);
+        expect(driver.caughtErrors).toHaveLength(1);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+});

--- a/src/__test__/harness/update-cycle-driver.ts
+++ b/src/__test__/harness/update-cycle-driver.ts
@@ -275,9 +275,11 @@ export const createUpdateCycleDriver = (
     const resolveDataset = (
         options: powerbi.extensibility.visual.VisualUpdateOptions
     ): void => {
-        const categorical = getCategoricalDataViewFromOptions(
-            options
-        ) as powerbi.DataViewCategorical;
+        const categorical = getCategoricalDataViewFromOptions(options);
+        if (!categorical) {
+            coordinator.closeCurrent();
+            return;
+        }
         const canFetchMore = canFetchMoreFromDataview(
             settings,
             options?.dataViews?.[0]?.metadata as powerbi.DataViewMetadata

--- a/src/__test__/harness/update-cycle-driver.ts
+++ b/src/__test__/harness/update-cycle-driver.ts
@@ -1,0 +1,383 @@
+import type powerbi from 'powerbi-visuals-api';
+
+import {
+    canFetchMoreFromDataview,
+    getCategoricalDataViewFromOptions,
+    getCategoricalRowCount,
+    resolveDatasetUpdateAction,
+    type DatasetUpdateAction
+} from '../../lib/dataset/data-view';
+import { createRenderingLifecycleCoordinator } from '../../lib/rendering-lifecycle/coordinator';
+import type {
+    RenderingLifecycleEvent,
+    RenderingLifecycleId,
+    SafetyNetHandle,
+    SafetyNetScheduler
+} from '../../lib/rendering-lifecycle/types';
+import type { VisualFormattingSettingsModel } from '../../lib/persistence';
+import {
+    createFakeVisualHost,
+    type FakeVisualHostHandle,
+    type FetchMoreResponse
+} from './fake-visual-host';
+import {
+    createMockDatasetSlice,
+    type MockDatasetSlice,
+    type MockDatasetState,
+    type SetDatasetPayload
+} from './mock-dataset-slice';
+import { OPERATION_KIND_CREATE } from './fixtures';
+
+/**
+ * Scripted update-cycle driver: the U4 fake-host lifecycle harness.
+ *
+ * WHAT IS REAL vs WHAT IS MIRRORED
+ * ────────────────────────────────
+ * Real production modules under test:
+ *  - `createRenderingLifecycleCoordinator` (src/lib/rendering-lifecycle/
+ *    coordinator.ts) — attached via its existing DI seams (`emitter` =
+ *    the fake host's event service, `scheduler` = a synthetic
+ *    safety-net scheduler, `observer` = a recording sink).
+ *  - `resolveDatasetUpdateAction` and the pure data-view helpers
+ *    (src/lib/dataset/data-view.ts).
+ *  - Optionally `hasDataViewChanged` (src/lib/dataset/processing.ts),
+ *    wired in by the scenario suite through the `hasDataChanged` seam.
+ *
+ * Mirrored (NOT real): the dispatch glue of `Deneb.update()` /
+ * `Deneb.resolveDataset()` and its handlers in src/index.ts. The Deneb
+ * visual class has heavy constructor side effects (React root, host
+ * services, i18n, store wiring) that make it impractical to instantiate
+ * in a node test, so `driveUpdate` transcribes the dispatch shape
+ * statement-for-statement. If src/index.ts's dispatch changes, THIS
+ * MIRROR MUST BE UPDATED to match — each mirrored block carries a
+ * pointer to its source. The invariants the scenarios assert (exactly-
+ * once terminals, supersede ordering, recovery preserving the dataset
+ * slice) are enforced by the REAL coordinator and decision function,
+ * not by the mirror.
+ */
+
+export type UpdateCycleDriverConfig = {
+    /**
+     * Change-detection seam (mirrors the `hasDataViewChanged` call in
+     * `Deneb.gatherDatasetUpdateContext`). Scenario suites wire the
+     * real `hasDataViewChanged` here (freshly imported per test so its
+     * module-level reference cache starts clean).
+     */
+    hasDataChanged: (categorical: powerbi.DataViewCategorical) => boolean;
+    /** Script for the fake host's `fetchMoreData` responses. */
+    fetchMoreResponses?: FetchMoreResponse[];
+    /** Seed state for the mocked dataset slice. */
+    initialDatasetState?: Partial<MockDatasetState>;
+    /**
+     * Value of the `dataLimit.loading.override` setting consumed by the
+     * real `canFetchMoreFromDataview`. Defaults to true (segmented
+     * fetching enabled) since that is the interesting path.
+     */
+    dataLimitOverride?: boolean;
+    /**
+     * Stand-in for `getMappedDataset` (the real mapper needs the full
+     * data-core processing chain and host locale — out of scope for
+     * lifecycle orchestration). Defaults to a row-count-faithful
+     * lightweight mapping.
+     */
+    mapDataset?: (
+        categorical: powerbi.DataViewCategorical
+    ) => SetDatasetPayload;
+};
+
+export type UpdateCycleDriver = {
+    /** Drive one host update through the mirrored dispatch. */
+    update: (options: powerbi.extensibility.visual.VisualUpdateOptions) => void;
+    /**
+     * Make the NEXT `update()` throw from inside the update body after
+     * `open()` (mirrors any dispatch-internal failure — change
+     * detection, mapping, store sync). Consumed once.
+     */
+    queueFault: (error: Error) => void;
+    /** Async render side: React/Vega embed reports the render began. */
+    startRender: () => void;
+    /** Async render side: embed completed — close the pending render. */
+    completeRender: () => void;
+    /** Async render side: embed errored — fail the pending render. */
+    failRender: (error: unknown) => void;
+    /** Fire every armed (uncancelled) safety-net callback. */
+    fireSafetyNets: () => void;
+    /** Number of armed, uncancelled, unfired safety-net callbacks. */
+    pendingSafetyNetCount: () => number;
+    /** The fake host handle (emitter record + fetchMoreData record). */
+    host: FakeVisualHostHandle;
+    /** Ordered coordinator observer events. */
+    observerEvents: RenderingLifecycleEvent[];
+    /** Ordered `DatasetUpdateAction`s the real decision function resolved. */
+    actions: DatasetUpdateAction[];
+    /** Errors update() caught (mirroring `Deneb.update`'s catch). */
+    caughtErrors: unknown[];
+    /** The mocked dataset slice (state + recorded mutations). */
+    dataset: MockDatasetSlice;
+    /** Ids opened but not yet terminally closed/failed (must be empty at scenario end). */
+    getOpenLifecycleIds: () => RenderingLifecycleId[];
+};
+
+/**
+ * Deterministic stand-in for the production `setTimeout`-based
+ * safety-net scheduler (same shape as the synthetic scheduler in the
+ * coordinator's unit suite, extended to hold multiple pending
+ * callbacks so update-storm scenarios can arm several nets).
+ */
+const createSyntheticSafetyNetScheduler = () => {
+    const pending = new Map<number, () => void>();
+    let nextHandle = 1;
+    const scheduler: SafetyNetScheduler = {
+        schedule: (callback) => {
+            const handleId = nextHandle;
+            nextHandle++;
+            pending.set(handleId, callback);
+            const handle: SafetyNetHandle = {
+                cancel: () => {
+                    pending.delete(handleId);
+                }
+            };
+            return handle;
+        }
+    };
+    return {
+        scheduler,
+        fireAll: () => {
+            const callbacks = [...pending.values()];
+            pending.clear();
+            callbacks.forEach((callback) => callback());
+        },
+        pendingCount: () => pending.size
+    };
+};
+
+const defaultMapDataset = (
+    categorical: powerbi.DataViewCategorical
+): SetDatasetPayload => {
+    const rowsLoaded = getCategoricalRowCount(categorical);
+    return {
+        values: Array.from({ length: rowsLoaded }, (_, i) => ({ __row: i })),
+        rowsLoaded
+    };
+};
+
+/**
+ * Minimal settings surface for the real `canFetchMoreFromDataview`,
+ * which only reads `dataLimit.loading.override.value`. The cast is the
+ * same structural-subset pattern the existing dataset tests use.
+ */
+const buildSettingsStub = (
+    dataLimitOverride: boolean
+): VisualFormattingSettingsModel =>
+    ({
+        dataLimit: {
+            loading: { override: { value: dataLimitOverride } }
+        }
+    }) as unknown as VisualFormattingSettingsModel;
+
+export const createUpdateCycleDriver = (
+    config: UpdateCycleDriverConfig
+): UpdateCycleDriver => {
+    const host = createFakeVisualHost({
+        fetchMoreResponses: config.fetchMoreResponses
+    });
+    const observerEvents: RenderingLifecycleEvent[] = [];
+    const safetyNet = createSyntheticSafetyNetScheduler();
+    const coordinator = createRenderingLifecycleCoordinator({
+        emitter: host.host.eventService,
+        scheduler: safetyNet.scheduler,
+        observer: (event) => observerEvents.push(event)
+    });
+    const dataset = createMockDatasetSlice(config.initialDatasetState);
+    const settings = buildSettingsStub(config.dataLimitOverride ?? true);
+    const mapDataset = config.mapDataset ?? defaultMapDataset;
+    const actions: DatasetUpdateAction[] = [];
+    const caughtErrors: unknown[] = [];
+    let queuedFault: Error | null = null;
+
+    /**
+     * Mirrors `Deneb.handleFetchMore` (src/index.ts): set the fetching
+     * flag, ask the host for the next segment, and either close the
+     * lifecycle synchronously (host accepted — the next segment arrives
+     * as its own update) or fall through to finalise-with-what-we-have
+     * (host declined). A synchronous host throw clears the flag before
+     * re-throwing so the visual cannot get stuck on FetchingMessage.
+     */
+    const dispatchFetchMore = (
+        categorical: powerbi.DataViewCategorical,
+        rowsLoaded: number
+    ): void => {
+        dataset.setIsFetchingAdditional({
+            isFetchingAdditional: true,
+            rowsLoaded
+        });
+        let fetchSuccess: boolean;
+        try {
+            fetchSuccess = host.host.fetchMoreData(true);
+        } catch (e) {
+            dataset.setIsFetchingAdditional({
+                isFetchingAdditional: false,
+                rowsLoaded
+            });
+            throw e;
+        }
+        if (fetchSuccess) {
+            coordinator.closeCurrent();
+            return;
+        }
+        dataset.setIsFetchingAdditional({
+            isFetchingAdditional: false,
+            rowsLoaded
+        });
+        dataset.setDataset(mapDataset(categorical));
+        coordinator.bindPendingRenderCurrent();
+    };
+
+    /**
+     * Mirrors `Deneb.handleRecoverInterruptedFetch` (src/index.ts):
+     * clear the stuck flag ONLY — the existing dataset slice is
+     * preserved (no `setDataset`), and `Math.max` prevents the host's
+     * re-shipped reduced payload from shrinking `rowsLoaded` below
+     * what actually sits in `dataset.values`. Non-rendering: closes
+     * the lifecycle synchronously.
+     */
+    const dispatchRecoverInterruptedFetch = (rowsLoaded: number): void => {
+        const currentStateRowsLoaded = dataset.state.rowsLoaded;
+        dataset.setIsFetchingAdditional({
+            isFetchingAdditional: false,
+            rowsLoaded: Math.max(currentStateRowsLoaded, rowsLoaded)
+        });
+        coordinator.closeCurrent();
+    };
+
+    /**
+     * Mirrors `Deneb.handleNormalFinalise` (src/index.ts): commit the
+     * mapped dataset and bind the pending render so the async embed
+     * callbacks target this update's lifecycle id.
+     */
+    const dispatchNormalFinalise = (
+        categorical: powerbi.DataViewCategorical,
+        rowsLoaded: number
+    ): void => {
+        dataset.setIsFetchingAdditional({
+            isFetchingAdditional: false,
+            rowsLoaded
+        });
+        dataset.setDataset(mapDataset(categorical));
+        coordinator.bindPendingRenderCurrent();
+    };
+
+    /**
+     * Mirrors `Deneb.resolveDataset` + `Deneb.gatherDatasetUpdateContext`
+     * (src/index.ts): gather the decision inputs, resolve the action via
+     * the REAL `resolveDatasetUpdateAction`, and dispatch.
+     */
+    const resolveDataset = (
+        options: powerbi.extensibility.visual.VisualUpdateOptions
+    ): void => {
+        const categorical = getCategoricalDataViewFromOptions(
+            options
+        ) as powerbi.DataViewCategorical;
+        const canFetchMore = canFetchMoreFromDataview(
+            settings,
+            options?.dataViews?.[0]?.metadata as powerbi.DataViewMetadata
+        );
+        const dataChanged = config.hasDataChanged(categorical);
+        const isInitialSegment =
+            (
+                options as {
+                    operationKind?: powerbi.VisualDataChangeOperationKind;
+                }
+            ).operationKind === OPERATION_KIND_CREATE;
+        const action = resolveDatasetUpdateAction({
+            dataChanged,
+            canFetchMore,
+            isFetchingAdditional: dataset.state.isFetchingAdditional,
+            isInitialSegment
+        });
+        actions.push(action);
+
+        if (action.kind === 'skip') {
+            // Non-rendering dispatch — balanced started/finished pair.
+            coordinator.closeCurrent();
+            return;
+        }
+        const rowsLoaded = getCategoricalRowCount(categorical);
+        if (action.kind === 'fetch-more') {
+            dispatchFetchMore(categorical, rowsLoaded);
+            return;
+        }
+        switch (action.reason) {
+            case 'recover-interrupted-fetch': {
+                dispatchRecoverInterruptedFetch(rowsLoaded);
+                return;
+            }
+            case 'normal': {
+                dispatchNormalFinalise(categorical, rowsLoaded);
+                return;
+            }
+            default: {
+                const _exhaustive: never = action.reason;
+                throw new Error(
+                    `Unhandled finalise reason: ${String(_exhaustive)}`
+                );
+            }
+        }
+    };
+
+    /**
+     * Mirrors `Deneb.update` (src/index.ts): open the lifecycle FIRST
+     * inside the try, dispatch, route any throw to `failCurrent`, and
+     * arm the safety-net in the finally for whichever id was opened.
+     */
+    const update = (
+        options: powerbi.extensibility.visual.VisualUpdateOptions
+    ): void => {
+        let openId: RenderingLifecycleId | undefined;
+        try {
+            openId = coordinator.open(options);
+            if (queuedFault) {
+                const fault = queuedFault;
+                queuedFault = null;
+                throw fault;
+            }
+            resolveDataset(options);
+        } catch (e) {
+            coordinator.failCurrent(e);
+            caughtErrors.push(e);
+        } finally {
+            if (openId !== undefined) {
+                coordinator.armSafetyNet(openId);
+            }
+        }
+    };
+
+    const getOpenLifecycleIds = (): RenderingLifecycleId[] => {
+        const opened = new Set<RenderingLifecycleId>();
+        for (const event of observerEvents) {
+            if (event.kind === 'opened') opened.add(event.id);
+            if (event.kind === 'closed' || event.kind === 'failed') {
+                opened.delete(event.id);
+            }
+        }
+        return [...opened];
+    };
+
+    return {
+        update,
+        queueFault: (error) => {
+            queuedFault = error;
+        },
+        startRender: () => coordinator.markPendingRenderStarted(),
+        completeRender: () => coordinator.closePendingRender(),
+        failRender: (error) => coordinator.failPendingRender(error),
+        fireSafetyNets: safetyNet.fireAll,
+        pendingSafetyNetCount: safetyNet.pendingCount,
+        host,
+        observerEvents,
+        actions,
+        caughtErrors,
+        dataset,
+        getOpenLifecycleIds
+    };
+};

--- a/src/lib/dataset/__test__/support-field-consolidation.test.ts
+++ b/src/lib/dataset/__test__/support-field-consolidation.test.ts
@@ -82,7 +82,22 @@ vi.mock('@deneb-viz/app-core', () => ({
             }),
             setConsolidateFieldParameters: vi.fn((value: boolean) => {
                 mockProject.consolidateFieldParameters = value;
-            })
+            }),
+            // Single transactional commit for the legacy migration (#689):
+            // stamps all three fields in one store update.
+            applySupportFieldMigrationStamp: vi.fn(
+                (payload: {
+                    supportFieldConfiguration: object;
+                    denebMetaVersion: number;
+                    consolidateFieldParameters: boolean;
+                }) => {
+                    mockProject.supportFieldConfiguration =
+                        payload.supportFieldConfiguration;
+                    mockProject.denebMetaVersion = payload.denebMetaVersion;
+                    mockProject.consolidateFieldParameters =
+                        payload.consolidateFieldParameters;
+                }
+            )
         }
     }))
 }));

--- a/src/lib/state/__test__/display-mode.test.ts
+++ b/src/lib/state/__test__/display-mode.test.ts
@@ -26,21 +26,33 @@ import type { DisplayMode } from '../display-mode';
  * stuck flag.
  */
 describe('doesModeAllowEmbedViewportSet', () => {
-    const cases: Array<{ mode: DisplayMode; expected: boolean }> = [
+    // `Record<DisplayMode, boolean>` is the exhaustiveness guard: if a
+    // new DisplayMode is added to the union, this literal (and the
+    // production `EMBED_VIEWPORT_COMMIT_ALLOWED` record in
+    // display-mode.ts, which the compiler also checks) fails to
+    // compile, forcing the author to make an explicit commit/exclude
+    // decision rather than silently defaulting to "allowed". This
+    // replaces the earlier array-comparison runtime check flagged in
+    // the segmented-fetch learning doc.
+    const expectedGateByMode: Record<DisplayMode, boolean> = {
         // Allowed — modes where the host viewport is the correct
         // committed value for the embed canvas.
-        { mode: 'initializing', expected: true },
-        { mode: 'landing', expected: true },
-        { mode: 'no-project', expected: true },
-        { mode: 'viewer', expected: true },
+        initializing: true,
+        landing: true,
+        'no-project': true,
+        viewer: true,
         // Excluded — host viewport at this moment is wrong for the
-        // viewer's eventual canvas. See JSDoc on the function for
-        // per-mode rationale.
-        { mode: 'editor', expected: false },
-        { mode: 'transition-viewer-editor', expected: false },
-        { mode: 'transition-editor-viewer', expected: false },
-        { mode: 'fetching', expected: false }
-    ];
+        // viewer's eventual canvas. See JSDoc on the production record
+        // for per-mode rationale.
+        editor: false,
+        'transition-viewer-editor': false,
+        'transition-editor-viewer': false,
+        fetching: false
+    };
+
+    const cases = (
+        Object.entries(expectedGateByMode) as Array<[DisplayMode, boolean]>
+    ).map(([mode, expected]) => ({ mode, expected }));
 
     it.each(cases)(
         'returns $expected for mode "$mode"',
@@ -48,27 +60,6 @@ describe('doesModeAllowEmbedViewportSet', () => {
             expect(doesModeAllowEmbedViewportSet(mode)).toBe(expected);
         }
     );
-
-    it('covers every DisplayMode value (exhaustiveness guard)', () => {
-        // If a new DisplayMode is added to the union, this array literal
-        // must include it; the type assertion below will fail to compile
-        // (or the runtime length check will fail) and force the author
-        // to make an explicit commit/exclude decision rather than
-        // silently defaulting to "allowed".
-        const allKnownModes: DisplayMode[] = [
-            'initializing',
-            'landing',
-            'no-project',
-            'fetching',
-            'viewer',
-            'transition-viewer-editor',
-            'transition-editor-viewer',
-            'editor'
-        ];
-        expect(cases.map((c) => c.mode).sort()).toEqual(
-            [...allKnownModes].sort()
-        );
-    });
 });
 
 /**

--- a/src/lib/state/display-mode.ts
+++ b/src/lib/state/display-mode.ts
@@ -63,11 +63,11 @@ export type GetUpdatedHistoryListPayload = {
 const MAX_UPDATE_HISTORY_RETENTION = 100;
 
 /**
- * Whether the current display mode is one where the embed viewport may
- * be committed from the live host viewport.
+ * Whether each display mode is one where the embed viewport may be
+ * committed from the live host viewport.
  *
- * Excluded modes report a host viewport that does not match the canvas
- * size the viewer should be rendered at:
+ * Modes mapped to `false` report a host viewport that does not match
+ * the canvas size the viewer should be rendered at:
  *  - `editor` and the two `transition-*` modes report the editor's
  *    full-screen area; committing it would resize the viewer to the
  *    editor pane on the next viewer entry.
@@ -79,15 +79,30 @@ const MAX_UPDATE_HISTORY_RETENTION = 100;
  *    viewport, which then survives into the viewer post-fetch. The
  *    correct committed viewport is set when fetch completes and mode
  *    resolves to `viewer`/`no-project`.
+ *
+ * The `Record<DisplayMode, boolean>` shape is a compile-time
+ * exhaustiveness guard: adding a member to the `DisplayMode` union
+ * fails compilation here, forcing an explicit commit-safe/unsafe
+ * decision for the new mode instead of a silent default.
  */
-export const doesModeAllowEmbedViewportSet = (mode: DisplayMode): boolean => {
-    return (
-        mode !== 'editor' &&
-        mode !== 'transition-viewer-editor' &&
-        mode !== 'transition-editor-viewer' &&
-        mode !== 'fetching'
-    );
+const EMBED_VIEWPORT_COMMIT_ALLOWED: Record<DisplayMode, boolean> = {
+    initializing: true,
+    landing: true,
+    'no-project': true,
+    fetching: false,
+    viewer: true,
+    'transition-viewer-editor': false,
+    'transition-editor-viewer': false,
+    editor: false
 };
+
+/**
+ * Whether the current display mode is one where the embed viewport may
+ * be committed from the live host viewport. See
+ * {@link EMBED_VIEWPORT_COMMIT_ALLOWED} for the per-mode rationale.
+ */
+export const doesModeAllowEmbedViewportSet = (mode: DisplayMode): boolean =>
+    EMBED_VIEWPORT_COMMIT_ALLOWED[mode];
 
 /**
  * Numeric value of `powerbi.ViewMode.View` (the published-report

--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,17 @@
             "dependsOn": ["^eslint"]
         },
         "test": {
+            "dependsOn": ["//#test:root"],
             "outputs": ["coverage/**"]
+        },
+        "//#test:root": {
+            "inputs": [
+                "src/**",
+                "vitest.root.config.ts",
+                "package.json",
+                "tsconfig.json"
+            ],
+            "outputs": []
         },
         "bench": {
             "cache": false


### PR DESCRIPTION
## What

Implements the **minimal fake-host integration harness** (plan U4, ideation idea #1) and closes the audit's CI-wiring gap (F1: root-level tests never ran in CI).

## Harness

Node-env (per-file `@vitest-environment node` docblocks, matching repo convention), no RTL, no component rendering — the shape the segmented-fetch solution doc's *Known follow-up* specified. Drives the **real** `resolveDatasetUpdateAction` orchestrator, real `hasDataViewChanged`, and the real coordinator attached via its existing DI seams (emitter/scheduler/observer — zero coordinator changes needed). The `update()` dispatch glue from `src/index.ts` is transcribed in the driver with per-block source pointers (constructor side effects make direct instantiation impractical — the plan's accepted scope).

**Scenarios (16 tests):** single update → exactly one `renderingFinished`; segmented fetch id supersede with no orphaned ids; viewer↔editor transition mid-fetch (all four documented quirks); resize-storm supersede-as-failed with exactly-once emission; update-throw → `failCurrent` → single `renderingFailed`. Fixture library pins the five documented host quirks (reference-equal DataViews, re-shipped reduced first segment, fractional viewports, `isInFocus: undefined`, viewport-before-iframe-resize).

**Mutation-validated:** disabling the coordinator's supersede loop fails the storm scenario; adding a dummy `DisplayMode` member fails compilation via the new `Record<DisplayMode, boolean>` guard on `doesModeAllowEmbedViewportSet` (behavior-identical refactor; the segmented-fetch doc's flagged upgrade).

## CI wiring

New `//#test:root` turbo root task, depended on by `test` — `npm run test` (and therefore the existing CI step, no workflow change) now executes the root suite. Previously `test:root` was a standalone script no pipeline invoked, meaning every root-level test was CI-invisible.

## Verification

`npm run test:root` 18 files / 231 green; `npm run test` 7 tasks with `//#test:root` observed; tsc/eslint clean.

**Note for reviewers:** `npm run prettier-check` fails on 10 files this PR does not touch (`src/index.ts`, `pbiviz.json`, dev-overlay/tally files) — pre-existing drift on `next`, flagged separately.

Part of the 2026-07-03 audit remediation program (unit U4 of 18; prior: #687, #688, #689). U5/U7/U8 stack on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)