### PR TITLE
fix(visual): settle timer defers on in-flight render; safety-net is a true backstop (H2)

### DIFF
--- a/docs/solutions/architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md
+++ b/docs/solutions/architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md
@@ -114,13 +114,14 @@ The narrower type omits the id-bearing methods, so the type system rejects produ
 
 ### 5. Bounded safety-net — cert ceiling, not a tuning knob
 
-The coordinator can arm a bounded timer per id. When it fires:
+The coordinator can arm a bounded timer per id. It is a **true backstop**: reaching the bound while the id is still open means no other terminal fired, so the safety-net closes it. When it fires:
 
-- If the id already closed normally, the map lookup misses — inert.
-- If `renderStarted === false`, the render never began — close it as an orphan.
-- If `renderStarted === true`, the render is in-flight — trust it, don't close.
+- If the id already closed normally, the map lookup misses — inert (the normal close cancelled the armed handle).
+- Otherwise the id is still open — close it terminally (`renderingFinished`, `via: 'safety-net'`), whether the render never began (orphan) or began but never signalled completion (started-but-stuck).
 
-The bound in `src/index.ts` is `SAFETY_NET_BOUND_MS = 10_000`. **This is the Power BI certification ceiling, not a tunable.** If a legitimate path is exceeding the bound, the fix is to wire that path through the coordinator, not to raise the constant.
+An earlier iteration **deferred** an in-flight (`renderStarted === true`) render here — "trust it, don't close". That was safe only by accident: `app.tsx`'s 500 ms settle timer was the sole terminal for a started-but-stuck render. Once the settle timer correctly defers on an in-flight render (the H2 fix — see the settle-timer note under _App-side adapters_ below), deferring here too would leave a stuck render's `renderingStarted` orphaned forever — cert-blocking. So the tick now closes terminally at the bound instead of deferring. `renderStarted` is still tracked, but the safety-net no longer branches on it; it is consumed by the settle-close variant (`closePendingRenderSettle`).
+
+The bound in `src/index.ts` is `SAFETY_NET_BOUND_MS = 10_000`. **This is the Power BI certification ceiling, not a tunable.** The H2 fix changed the tick's _decision_ (defer → terminal close), not the bound, and added no re-arm or longer wait. If a legitimate path is exceeding the bound, the fix is to wire that path through the coordinator, not to raise the constant.
 
 ### 6. Dependency injection at the seams
 
@@ -180,22 +181,29 @@ If `open()` itself throws (host rejected the `renderingStarted` emission), `open
 
 ### App-side adapters
 
-The React app never imports the coordinator. `src/index.ts` builds three no-arg / one-arg adapters in the constructor and hands them to `<App>` as props:
+The React app never imports the coordinator. `src/index.ts` builds four no-arg / one-arg adapters in the constructor and hands them to `<App>` as props:
 
 ```ts
 this.#onRenderingStartedAdapter = () =>
     this.#coordinator.markPendingRenderStarted();
+// Embed-path REAL render-complete close — terminal.
 this.#onRenderingFinishedAdapter = () => this.#coordinator.closePendingRender();
+// Settle-timer close (app.tsx) — DEFERS to the real close / safety-net
+// when a render is in flight (H2). MUST be a distinct reference.
+this.#onSettleCloseAdapter = () =>
+    this.#coordinator.closePendingRenderSettle();
 this.#onRenderingErrorAdapter = (error) =>
     this.#coordinator.failPendingRender(error);
 ```
 
-`app.tsx` threads these unchanged through the platform provider's `onRendering*` slots. There's no `visualUpdateOptions` capture and no risk of stale attribution — the id was bound before `update()` returned.
+`app.tsx` threads `onRenderingStarted` / `onRenderingFinished` / `onRenderingError` unchanged through the platform provider's `onRendering*` slots (the embed path). There's no `visualUpdateOptions` capture and no risk of stale attribution — the id was bound before `update()` returned. `onSettleClose` is used only by the settle timer below; it is **not** threaded to the embed path.
+
+**Why the settle-close adapter is a distinct reference (H2).** A single `onRenderingFinished` adapter used to serve _both_ the embed-path real close and `app.tsx`'s settle timer. Pointing that shared reference at the deferring variant would make _every_ real render close defer to the 10 s safety-net — a severe regression. So the settle timer gets its own `onSettleClose` adapter routed to `closePendingRenderSettle`, while the embed path keeps the terminal `closePendingRender`.
 
 A companion `useEffect` in `app.tsx` handles the two paths Vega's callbacks can't cover:
 
-- **Renderless modes** close synchronously when the effect runs.
-- **Rendering modes with no Vega-affecting change** get a 500 ms settle timer that closes via `onRenderingFinished()`. React's built-in effect cleanup caps in-flight timers at one regardless of update storm size. When Vega does close first, the timer eventually fires against a coordinator that already deleted the id — the exactly-once guard makes it a no-op.
+- **Renderless modes** close synchronously via the terminal `onRenderingFinished()` when the effect runs — Vega never embeds in these modes, so there is never an in-flight render to protect and the close is unambiguously correct.
+- **Rendering modes with no Vega-affecting change** get a 500 ms settle timer that closes via `onSettleClose()` — the **deferring** variant. The earlier claim that "when Vega does close first, the timer fires against an already-deleted id so the exactly-once guard makes it a no-op" is only true for a _fast_ render; it is **false for a slow render**, where at the 500 ms mark Vega has _not_ finished (`renderStarted === true`). Closing there would emit `renderingFinished` mid-render and let Power BI's export/snapshot service capture pre-render content (audit finding H2). The deferring variant fixes this: if a render is in flight the settle close **defers** (no-op, no emission), and the terminal belongs to Vega's own `onRenderingFinished` when the embed completes — or the safety-net at its bound if it never does. When _no_ Vega render starts for the update (the non-Vega-affecting formatting-change case this timer targets, `renderStarted === false`), the settle close closes terminally, as designed. React's built-in effect cleanup still caps in-flight timers at one regardless of update-storm size.
 
 ## Why This Matters
 

--- a/src/__test__/harness/scenarios.test.ts
+++ b/src/__test__/harness/scenarios.test.ts
@@ -188,7 +188,7 @@ describe('scenario: single update → compile → render-start → close', () =>
         expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
     });
 
-    it('safety-net defers while a render is in flight; the render close then lands exactly once', async () => {
+    it('safety-net terminally closes an in-flight render at the bound; a late embed close then no-ops (U5 true backstop)', async () => {
         const driver = await createDriver();
         driver.update(
             buildUpdateOptions({
@@ -196,8 +196,14 @@ describe('scenario: single update → compile → render-start → close', () =>
             })
         );
         driver.startRender();
+        // Render began but never signalled completion. At the 10s bound
+        // the safety-net is the TRUE backstop: it closes the still-open
+        // id exactly once (before U5 it deferred here, leaving the id
+        // open forever).
         driver.fireSafetyNets();
-        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+        // A late embed completion after the bound finds the id gone.
         driver.completeRender();
         expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
     });
@@ -496,6 +502,122 @@ describe('scenario: update() throws', () => {
         expect(driver.caughtErrors).toHaveLength(1);
         expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
         expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+});
+
+// ─── Scenario 6: settle-timer close defers to the render (H2 / U5) ───────────
+//
+// The app-side 500ms settle timer (`app.tsx` → `onSettleClose`) is
+// modelled by `driver.settleClose()`, which routes to the coordinator's
+// DEFERRING `closePendingRenderSettle`. `driver.completeRender()` still
+// models the embed-path terminal close. These scenarios pin the H2 fix:
+// a settle firing mid-render must never emit `renderingFinished` early,
+// yet a non-Vega-affecting update must still close promptly at the
+// settle bound, and a started-but-stuck render must still reach exactly
+// one terminal at the 10s safety-net bound.
+
+describe('scenario: settle-timer close vs. in-flight render (H2 / U5)', () => {
+    it('(a) non-Vega-affecting update → settle closes; exactly one renderingFinished, no open ids', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(100) })
+            })
+        );
+        // Rendering dispatch bound a pending render, but Vega's input
+        // deps did not change (formatting-only update) so no embed
+        // callback fires and no render starts. The settle timer is the
+        // designed close path here.
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        driver.settleClose();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+        // Leftover async callbacks / safety-net are inert (exactly-once).
+        driver.completeRender();
+        driver.fireSafetyNets();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+    });
+
+    it('(b) slow render (>500ms) → settle no-ops mid-render; renderingFinished only when the embed completes', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(100) })
+            })
+        );
+        // Render started but is slow — still in flight when the settle
+        // timer fires.
+        driver.startRender();
+        driver.settleClose();
+        // H2: the settle close must DEFER — no renderingFinished
+        // mid-render. (This assertion is red on the pre-U5 code, where
+        // the settle path closed unconditionally.)
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toHaveLength(1);
+        // The embed finally completes → the real close emits the terminal.
+        driver.completeRender();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+
+    it('(c) render starts and completes before the bound → real close wins; the settle then no-ops', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(100) })
+            })
+        );
+        // Fast render: starts and completes before the 500ms timer.
+        driver.startRender();
+        driver.completeRender();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        // The settle timer fires later against an already-closed id.
+        driver.settleClose();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+
+    it('(d) render starts but never completes → settle defers, safety-net is the sole terminal at the bound (exactly once)', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(100) })
+            })
+        );
+        driver.startRender();
+        // Settle fires mid-render → defers (H2).
+        driver.settleClose();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toHaveLength(1);
+        // The embed never completes. The 10s safety-net is the true
+        // backstop and closes the still-open id exactly once. (Red on
+        // the pre-U5 code, where the safety-net deferred forever on a
+        // started render and the id never closed.)
+        driver.fireSafetyNets();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+        // Nothing left to fire.
+        expect(driver.pendingSafetyNetCount()).toBe(0);
+    });
+
+    it('(e) render fails after the settle timer is scheduled → renderingFailed, never renderingFinished', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(100) })
+            })
+        );
+        driver.startRender();
+        // Embed errors out — the failure terminal must win.
+        driver.failRender(new Error('embed blew up'));
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
+        // The settle timer (scheduled earlier) fires against the now-
+        // closed id → no-op; it must NOT convert a failure into a finish.
+        driver.settleClose();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
         expect(driver.getOpenLifecycleIds()).toEqual([]);
     });
 });

--- a/src/__test__/harness/update-cycle-driver.ts
+++ b/src/__test__/harness/update-cycle-driver.ts
@@ -98,6 +98,15 @@ export type UpdateCycleDriver = {
     startRender: () => void;
     /** Async render side: embed completed — close the pending render. */
     completeRender: () => void;
+    /**
+     * App-side settle timer fired (mirrors `app.tsx`'s
+     * {@link RENDERING_MODE_SETTLE_MS} `setTimeout` → `onSettleClose`).
+     * Routes to the coordinator's DEFERRING `closePendingRenderSettle`:
+     * closes the pending render only if no render is in flight, else
+     * no-ops (H2 / U5). Distinct from {@link completeRender}, which
+     * mirrors the embed-path terminal close.
+     */
+    settleClose: () => void;
     /** Async render side: embed errored — fail the pending render. */
     failRender: (error: unknown) => void;
     /** Fire every armed (uncancelled) safety-net callback. */
@@ -372,6 +381,7 @@ export const createUpdateCycleDriver = (
         },
         startRender: () => coordinator.markPendingRenderStarted(),
         completeRender: () => coordinator.closePendingRender(),
+        settleClose: () => coordinator.closePendingRenderSettle(),
         failRender: (error) => coordinator.failPendingRender(error),
         fireSafetyNets: safetyNet.fireAll,
         pendingSafetyNetCount: safetyNet.pendingCount,

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -55,9 +55,16 @@ import { handlePersistBooleanProperty } from '../features/settings/helpers';
  * non-pathological specs complete in under 200ms; 500ms gives any
  * legitimate render comfortable headroom while closing
  * non-Vega-affecting property updates (which would otherwise wait
- * the full 10s safety-net bound) within half a second. Idempotent
- * against the U9/U10 close paths — whichever closes the
- * pending-render id first wins.
+ * the full 10s safety-net bound) within half a second.
+ *
+ * The settle close is DEFERRING (H2 / U5): it fires through
+ * `onSettleClose`, which no-ops when a render is already in flight
+ * (`renderStarted === true`). So the 500ms bound is a lower bound on
+ * "how long before we conclude no Vega render is coming", NOT a
+ * deadline that can pre-empt a slow render — a render taking longer
+ * than 500ms is closed by its own embed callback, not by this timer.
+ * Idempotent against the U9/U10 close paths via the coordinator's
+ * exactly-once guard.
  */
 const RENDERING_MODE_SETTLE_MS = 500;
 
@@ -76,6 +83,17 @@ type AppProps = {
      */
     onRenderingStarted: () => void;
     onRenderingFinished: () => void;
+    /**
+     * Settle-timer close (H2 / U5). DISTINCT from
+     * {@link onRenderingFinished}: this adapter routes to the
+     * coordinator's deferring `closePendingRenderSettle`, so if the
+     * settle timer fires while a Vega render is still in flight it
+     * NO-OPS (the real embed close or the safety-net owns the terminal)
+     * instead of emitting `renderingFinished` mid-render. Used ONLY by
+     * the settle timer below — never by the embed path, which keeps the
+     * terminal {@link onRenderingFinished}.
+     */
+    onSettleClose: () => void;
     onRenderingError: (error: Error) => void;
 };
 
@@ -83,6 +101,7 @@ export const App = ({
     host,
     onRenderingStarted,
     onRenderingFinished,
+    onSettleClose,
     onRenderingError
 }: AppProps) => {
     const [isDownloadPermitted, setIsDownloadPermitted] = useState<
@@ -217,36 +236,51 @@ export const App = ({
      * built-in effect cleanup, which fires when `visualUpdateOptions`
      * / `mode` change for the next update.
      *
-     * So the actual behavior is:
-     *  - **Isolated update**: Vega closes the pending render via
-     *    U9/U10 within typical render time (<200ms); the settle
-     *    timer continues for the remaining ~300ms and then fires
-     *    `onRenderingFinished()`, which is a no-op via the
-     *    coordinator's exactly-once guard (the bound id has already
-     *    been deleted from the openIds map). One wasted timer per
-     *    update — negligible.
+     * So the actual behavior is (H2 / U5 — the settle timer calls
+     * `onSettleClose`, the coordinator's DEFERRING close variant, NOT
+     * the terminal `onRenderingFinished`):
+     *  - **Isolated fast render** (<{@link RENDERING_MODE_SETTLE_MS}):
+     *    Vega closes the pending render via U9/U10 within typical
+     *    render time (<200ms); the settle timer fires ~300ms later and
+     *    is a no-op via the coordinator's exactly-once guard (the id
+     *    was already deleted from the openIds map). One wasted timer
+     *    per update — negligible.
+     *  - **Isolated SLOW render** (>{@link RENDERING_MODE_SETTLE_MS}):
+     *    the render is still in flight when the settle timer fires.
+     *    Because `markPendingRenderStarted` has run, `onSettleClose`
+     *    DEFERS (no-op) — it does NOT emit `renderingFinished`
+     *    mid-render. The terminal is owned by Vega's own
+     *    `onRenderingFinished` when the embed completes (or the 10s
+     *    safety-net if it never does). This is the H2 fix: previously
+     *    the settle timer closed unconditionally here, letting Power
+     *    BI's export/snapshot capture pre-render content.
      *  - **Storm of N updates** (resize burst, live-data refresh):
      *    each new update's effect cleanup `clearTimeout`s the
      *    previous timer before scheduling a new one, so at most ONE
      *    settle timer is in flight at any moment regardless of N.
      *    React effect cleanup is the cap.
-     *  - **Settle wins**: when neither U9 nor U10 closes within the
-     *    bound (the editor-theme-via-formatting-pane case this
-     *    effect targets), the timer fires and emits
-     *    `renderingFinished` via the coordinator. This is the
-     *    designed close path for non-Vega-affecting updates in
-     *    rendering modes.
+     *  - **Settle wins**: when no Vega render starts for this update
+     *    (the non-Vega-affecting editor-theme-via-formatting-pane case
+     *    this effect targets — `renderStarted` stays false), the timer
+     *    fires and `onSettleClose` closes terminally via the
+     *    coordinator. This is the designed close path for
+     *    non-Vega-affecting updates in rendering modes.
      *
      * A first-class cancellation token keyed on the coordinator's
      * observer stream would eliminate the wasted-timer-per-update
      * cost, but the perf impact is negligible and the indirection
      * isn't worth it until U11's observer wiring is in place.
      *
+     * Renderless modes still use the terminal `onRenderingFinished`
+     * (closed synchronously): Vega never embeds in those modes, so
+     * there is never an in-flight render to protect and the close is
+     * unambiguously correct.
+     *
      * `bindPendingRenderCurrent` fires in `handleNormalFinalise` /
      * `handleFetchMore` host-decline before the resolved display
-     * mode is known; `onRenderingFinished` is a stable reference
-     * from `src/index.ts` so the effect's deps add no spurious
-     * re-runs.
+     * mode is known; `onRenderingFinished` / `onSettleClose` are
+     * stable references from `src/index.ts` so the effect's deps add
+     * no spurious re-runs.
      */
     useEffect(() => {
         const isRenderlessMode =
@@ -261,12 +295,12 @@ export const App = ({
             return;
         }
         const settleId = window.setTimeout(() => {
-            onRenderingFinished();
+            onSettleClose();
         }, RENDERING_MODE_SETTLE_MS);
         return () => {
             window.clearTimeout(settleId);
         };
-    }, [visualUpdateOptions, mode, onRenderingFinished]);
+    }, [visualUpdateOptions, mode, onRenderingFinished, onSettleClose]);
 
     const mainComponent = useMemo(() => {
         switch (mode) {

--- a/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
+++ b/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
@@ -98,7 +98,6 @@ export const VisualUpdateHistoryOverlay = () => {
             ` sup: ${tally.fails.superseded})`,
         `safety-net:   armed ${tally.safetyNet.armed}` +
             ` / ticks: closed ${tally.safetyNet.closedByTick},` +
-            ` def ${tally.safetyNet.deferred},` +
             ` inert ${tally.safetyNet.inert}`,
         `pending:      ${tally.pending}` +
             (tally.pendingIds.length > 0

--- a/src/features/visual-update-history-overlay/lib/__test__/compute-tally.test.ts
+++ b/src/features/visual-update-history-overlay/lib/__test__/compute-tally.test.ts
@@ -194,17 +194,17 @@ describe('computeLifecycleTally — resilience to stale events', () => {
         // that increments `closes.safetyNet`. The tally surfaces
         // both — `closedByTick` is the safety-net's perspective,
         // `closes.safetyNet` is the close surface's perspective.
-        // A tick with result `deferred` or `inert` is observed but
-        // does NOT emit a separate `closed` event.
+        // A tick with result `inert` is observed but does NOT emit a
+        // separate `closed` event.
         const events: RenderingLifecycleEvent[] = [
             { kind: 'opened', id: id(1), options: FAKE_OPTIONS },
             { kind: 'safety-net-armed', id: id(1) },
-            { kind: 'safety-net-tick', id: id(1), result: 'deferred' },
+            { kind: 'safety-net-tick', id: id(1), result: 'inert' },
             { kind: 'safety-net-tick', id: id(1), result: 'closed' },
             { kind: 'closed', id: id(1), via: 'safety-net' }
         ];
         const tally = computeLifecycleTally(events);
-        expect(tally.safetyNet.deferred).toBe(1);
+        expect(tally.safetyNet.inert).toBe(1);
         expect(tally.safetyNet.closedByTick).toBe(1);
         expect(tally.closes.safetyNet).toBe(1);
         expect(tally.closes.total).toBe(1);

--- a/src/features/visual-update-history-overlay/lib/compute-tally.ts
+++ b/src/features/visual-update-history-overlay/lib/compute-tally.ts
@@ -34,7 +34,6 @@ export type FailTally = {
 export type SafetyNetTally = {
     armed: number;
     closedByTick: number;
-    deferred: number;
     inert: number;
 };
 
@@ -92,7 +91,6 @@ export const computeLifecycleTally = (
         safetyNet: {
             armed: 0,
             closedByTick: 0,
-            deferred: 0,
             inert: 0
         },
         pending: 0,
@@ -145,9 +143,6 @@ export const computeLifecycleTally = (
                 switch (event.result) {
                     case 'closed':
                         tally.safetyNet.closedByTick++;
-                        break;
-                    case 'deferred':
-                        tally.safetyNet.deferred++;
                         break;
                     case 'inert':
                         tally.safetyNet.inert++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,9 +82,14 @@ const IS_LIFECYCLE_OBSERVER_ENABLED = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
 
 /**
  * Bound (ms) after which the rendering-lifecycle safety-net checks an
- * armed id. If the id is still open and no render ever began
- * (`state.renderStarted === false`), the safety-net closes it as an
- * orphan; if a render is in flight, the close is deferred.
+ * armed id. If the id is still open at the bound the safety-net closes
+ * it terminally (`renderingFinished`) — whether the render never began
+ * (orphan) or began but never signalled completion (started-but-stuck).
+ * Reaching the bound while still open means no other terminal fired, so
+ * closing here is the only thing standing between the host and an
+ * orphaned `renderingStarted`. (Before U5 an in-flight id was deferred
+ * here; that left started-but-stuck renders relying on app.tsx's settle
+ * timer as their accidental terminal — which H2 removed.)
  *
  * Known close paths that fall through to the safety-net today:
  *  - Incremental data-update path (`performIncrementalUpdate` in
@@ -160,6 +165,14 @@ export class Deneb implements IVisual {
     // coordinator itself.
     #onRenderingStartedAdapter: () => void;
     #onRenderingFinishedAdapter: () => void;
+    // Distinct settle-close adapter (H2 / U5). app.tsx's settle timer
+    // uses THIS one — routed to the coordinator's deferring
+    // `closePendingRenderSettle` so a settle firing mid-render no-ops
+    // instead of emitting `renderingFinished` early. It must NOT share
+    // `#onRenderingFinishedAdapter`: that adapter is also the embed
+    // path's real render-complete close and must stay terminal, or
+    // every real close would defer to the 10s safety-net.
+    #onSettleCloseAdapter: () => void;
     #onRenderingErrorAdapter: (error: Error) => void;
 
     constructor(options: VisualConstructorOptions) {
@@ -211,8 +224,15 @@ export class Deneb implements IVisual {
             // is set to this update's id.
             this.#onRenderingStartedAdapter = () =>
                 this.#coordinator.markPendingRenderStarted();
+            // Embed-path REAL render-complete close — terminal, closes
+            // the pending render regardless of in-flight state.
             this.#onRenderingFinishedAdapter = () =>
                 this.#coordinator.closePendingRender();
+            // Settle-timer close (app.tsx) — DEFERS to the real close /
+            // safety-net when a render is in flight (H2). Separate
+            // reference so the embed path above stays terminal.
+            this.#onSettleCloseAdapter = () =>
+                this.#coordinator.closePendingRenderSettle();
             this.#onRenderingErrorAdapter = (error: Error) =>
                 this.#coordinator.failPendingRender(error);
             const {
@@ -256,6 +276,7 @@ export class Deneb implements IVisual {
                     host,
                     onRenderingStarted: this.#onRenderingStartedAdapter,
                     onRenderingFinished: this.#onRenderingFinishedAdapter,
+                    onSettleClose: this.#onSettleCloseAdapter,
                     onRenderingError: this.#onRenderingErrorAdapter
                 })
             );
@@ -315,10 +336,11 @@ export class Deneb implements IVisual {
             //   finalise, fetch-more host-decline — U9), the id stays
             //   open, the safety-net is armed, the React render
             //   eventually calls `markPendingRenderStarted()` (so
-            //   the safety-net defers on tick instead of closing
-            //   in-flight work), then `closePendingRender()` fires
-            //   and cancels the safety-net handle as part of the
-            //   close.
+            //   app.tsx's settle timer defers instead of closing
+            //   in-flight work — H2), then `closePendingRender()` fires
+            //   and cancels the safety-net handle as part of the close.
+            //   If that real close never arrives, the safety-net closes
+            //   the still-open id terminally at the bound.
             // - When `open()` itself threw (host rejected
             //   `renderingStarted`), `openId` stayed `undefined` and
             //   the guard skips arming.

--- a/src/lib/rendering-lifecycle/__test__/coordinator.test.ts
+++ b/src/lib/rendering-lifecycle/__test__/coordinator.test.ts
@@ -400,17 +400,21 @@ describe('createRenderingLifecycleCoordinator — safety-net', () => {
         ).toHaveLength(1);
     });
 
-    it('safety-net does NOT close in-flight render (renderStarted=true defers the close)', () => {
+    it('safety-net terminally closes an in-flight render at the bound (started-but-stuck), then a late real close no-ops', () => {
         const { coordinator, calls, tick } = buildHarness();
         const id = coordinator.open(FAKE_OPTIONS_A);
         coordinator.bindPendingRender(id);
         coordinator.markPendingRenderStarted();
         coordinator.armSafetyNet(id);
+        // The render started but never signalled completion. At the
+        // bound the safety-net is the TRUE backstop (U5): it closes the
+        // still-open id exactly once rather than deferring forever.
         tick();
         expect(
             calls.filter((c) => c.method === 'renderingFinished')
-        ).toHaveLength(0);
-        // The pending-render close should still work afterward.
+        ).toHaveLength(1);
+        // A late real close (embed finally resolves after the bound)
+        // finds the id already deleted and no-ops — exactly-once holds.
         coordinator.closePendingRender();
         expect(
             calls.filter((c) => c.method === 'renderingFinished')
@@ -442,7 +446,7 @@ describe('createRenderingLifecycleCoordinator — safety-net', () => {
         expect(ticked && 'result' in ticked && ticked.result).toBe('closed');
     });
 
-    it('open with no close, render-started, then tick → safety-net defers (in-flight)', () => {
+    it('open with no close, render-started, then tick → safety-net tick reports closed (terminal backstop, no longer deferred)', () => {
         const { coordinator, events, tick } = buildHarness();
         const id = coordinator.open(FAKE_OPTIONS_A);
         coordinator.bindPendingRender(id);
@@ -450,7 +454,7 @@ describe('createRenderingLifecycleCoordinator — safety-net', () => {
         coordinator.armSafetyNet(id);
         tick();
         const ticked = events.find((e) => e.kind === 'safety-net-tick');
-        expect(ticked && 'result' in ticked && ticked.result).toBe('deferred');
+        expect(ticked && 'result' in ticked && ticked.result).toBe('closed');
     });
 
     it('tick after a separate close path resolved → safety-net tick reports inert (already closed)', () => {
@@ -463,6 +467,90 @@ describe('createRenderingLifecycleCoordinator — safety-net', () => {
         tick();
         const ticks = events.filter((e) => e.kind === 'safety-net-tick');
         expect(ticks).toHaveLength(0);
+    });
+});
+
+describe('createRenderingLifecycleCoordinator — settle-timer close (closePendingRenderSettle)', () => {
+    it('no render started → closes terminally like closePendingRender (one renderingFinished, via=async-pending-render)', () => {
+        const { coordinator, calls, events } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRender(id);
+        // renderStarted is false (markPendingRenderStarted never fired)
+        // — the non-Vega-affecting formatting-change case this settle
+        // path targets. It closes exactly as the real pending close.
+        coordinator.closePendingRenderSettle();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(1);
+        const closed = events.find((e) => e.kind === 'closed');
+        expect(closed && 'via' in closed && closed.via).toBe(
+            'async-pending-render'
+        );
+    });
+
+    it('render already started → DEFERS (no emission, id stays open); the later real close then lands exactly once', () => {
+        const { coordinator, calls } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRender(id);
+        coordinator.markPendingRenderStarted();
+        // Settle timer fires WHILE the render is in flight — must NOT
+        // emit renderingFinished mid-render (H2).
+        coordinator.closePendingRenderSettle();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(0);
+        // The embed's own real render-complete close terminates it.
+        coordinator.closePendingRender();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(1);
+    });
+
+    it('deferred settle emits no observer event (start-vs-close tally must not count it)', () => {
+        const { coordinator, events } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRender(id);
+        coordinator.markPendingRenderStarted();
+        const eventCountBefore = events.length;
+        coordinator.closePendingRenderSettle();
+        expect(events.length).toBe(eventCountBefore);
+    });
+
+    it('no pending-render bound → no-op (no host emission, no observer event)', () => {
+        const { coordinator, calls, events } = buildHarness();
+        coordinator.closePendingRenderSettle();
+        expect(calls).toEqual([]);
+        expect(events).toEqual([]);
+    });
+
+    it('already-closed pending id → no-op via exactly-once guard', () => {
+        const { coordinator, calls } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRender(id);
+        // Real close deletes the id from the map first.
+        coordinator.closePendingRender();
+        // A settle timer firing afterward finds nothing and no-ops.
+        coordinator.closePendingRenderSettle();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(1);
+    });
+
+    it('terminal settle close cancels the armed safety-net (no second terminal on a later tick)', () => {
+        const { coordinator, calls, tick } = buildHarness();
+        const id = coordinator.open(FAKE_OPTIONS_A);
+        coordinator.bindPendingRender(id);
+        coordinator.armSafetyNet(id);
+        // No render started → settle closes terminally; closeInternal
+        // must cancel the armed safety-net handle.
+        coordinator.closePendingRenderSettle();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(1);
+        tick();
+        expect(
+            calls.filter((c) => c.method === 'renderingFinished')
+        ).toHaveLength(1);
     });
 });
 

--- a/src/lib/rendering-lifecycle/coordinator.ts
+++ b/src/lib/rendering-lifecycle/coordinator.ts
@@ -20,8 +20,10 @@ import {
  * ever hold open ids. No separate `closed` flag is needed.
  *
  *  - `renderStarted` flips true via `markRenderStarted` /
- *    `markPendingRenderStarted`; consumed by the safety-net to
- *    distinguish orphan vs. in-flight.
+ *    `markPendingRenderStarted`; consumed by
+ *    `closePendingRenderSettle` to DEFER the settle-timer close of an
+ *    in-flight render (the safety-net no longer branches on it — it
+ *    terminally closes any still-open id at the bound).
  *  - `safetyNet` holds the cancellation handle while the safety-net
  *    is armed and not yet fired/cancelled.
  */
@@ -154,20 +156,30 @@ export const createRenderingLifecycleCoordinator = (
     const onSafetyNetTick = (id: RenderingLifecycleId): void => {
         const state = openIds.get(id);
         if (!state) {
+            // Already closed normally — the close cancelled this
+            // handle, so reaching here means the map entry is gone.
+            // Inert.
             observe({ kind: 'safety-net-tick', id, result: 'inert' });
             return;
         }
-        if (state.renderStarted) {
-            // In-flight render — extend the wait by NOT closing. The
-            // caller (the render's own callback chain) will emit the
-            // terminal in due course; or, if it never does, a future
-            // arming would re-evaluate. For U7 there's no auto-rearm;
-            // the practical safety case for in-flight is "the render
-            // is happening, trust it" since the cert-blocking failure
-            // mode is orphans, not slow renders.
-            observe({ kind: 'safety-net-tick', id, result: 'deferred' });
-            return;
-        }
+        // TRUE backstop (audit H2): the id is STILL OPEN at the bound,
+        // so no other terminal fired — close it now, whether the render
+        // started or not. Reaching this point means either the render
+        // never began (orphan) OR it began but never signalled
+        // completion (started-but-stuck); both leave the host with an
+        // orphaned `renderingStarted` unless closed here.
+        //
+        // Before U5 an in-flight (`renderStarted === true`) id was
+        // DEFERRED here (returned without closing, no re-arm). That was
+        // only safe because the 500ms settle timer was accidentally
+        // acting as the terminal for started-but-stuck renders. Now that
+        // the settle timer itself defers on in-flight (its own H2 fix,
+        // `closePendingRenderSettle`), deferring here too would leave a
+        // stuck render's lifecycle open forever — replacing early-finish
+        // with never-finish. The bound is unchanged (R9,
+        // `SAFETY_NET_BOUND_MS = 10_000`); only the tick's decision
+        // changes from defer to terminal close. No re-arm, no longer
+        // wait.
         observe({ kind: 'safety-net-tick', id, result: 'closed' });
         closeInternal(id, 'safety-net');
     };
@@ -260,6 +272,30 @@ export const createRenderingLifecycleCoordinator = (
             closeInternal(pendingRenderId, 'async-pending-render');
         };
 
+    const closePendingRenderSettle: RenderingLifecycleCoordinator['closePendingRenderSettle'] =
+        () => {
+            if (pendingRenderId === null) return;
+            const state = openIds.get(pendingRenderId);
+            // Already closed (exactly-once guard) or never opened —
+            // no-op, exactly like `closePendingRender`.
+            if (!state) return;
+            // H2 defer: a render is in flight. Closing here would emit
+            // `renderingFinished` mid-render, and Power BI's
+            // export/snapshot service could capture pre-render content.
+            // Leave the id open — the embed's own `onRenderingFinished`
+            // (real close via `closePendingRender`) or the safety-net's
+            // terminal-at-bound will close it. No re-arm; the settle
+            // timer does not fire again for this id. Emits no observer
+            // event by design (see `closePendingRenderSettle` on the
+            // coordinator type: nothing mutates and the start-vs-close
+            // tally must not count a deferred settle).
+            if (state.renderStarted) return;
+            // No render started (the non-Vega-affecting formatting-
+            // change case this settle path targets): close terminally,
+            // identical to `closePendingRender`.
+            closeInternal(pendingRenderId, 'async-pending-render');
+        };
+
     const failPendingRender: RenderingLifecycleCoordinator['failPendingRender'] =
         (error) => {
             if (pendingRenderId === null) return;
@@ -302,6 +338,7 @@ export const createRenderingLifecycleCoordinator = (
         closeCurrent,
         failCurrent,
         closePendingRender,
+        closePendingRenderSettle,
         failPendingRender,
         markPendingRenderStarted,
         close,

--- a/src/lib/rendering-lifecycle/types.ts
+++ b/src/lib/rendering-lifecycle/types.ts
@@ -113,14 +113,13 @@ export type RenderingLifecycleEvent =
     | {
           kind: 'safety-net-tick';
           id: RenderingLifecycleId;
-          // `'deferred'` is retained for shape/back-compat but is no
-          // longer emitted after U5 (H2): the safety-net is now a true
-          // backstop that terminally closes any still-open id at the
-          // bound (see `onSafetyNetTick`), so a tick resolves to
-          // `'closed'` (still open → closed) or `'inert'` (already
-          // closed). The in-flight defer moved to the settle-close
-          // variant, which emits no observer event on defer.
-          result: 'closed' | 'deferred' | 'inert';
+          // The safety-net is a true backstop that terminally closes any
+          // still-open id at the bound (see `onSafetyNetTick`), so a tick
+          // resolves to `'closed'` (still open → closed) or `'inert'`
+          // (already closed). The in-flight defer moved to the
+          // settle-close variant, which emits no observer event on defer,
+          // so there is no `'deferred'` tick result.
+          result: 'closed' | 'inert';
       };
 
 export type RenderingLifecycleObserver = (

--- a/src/lib/rendering-lifecycle/types.ts
+++ b/src/lib/rendering-lifecycle/types.ts
@@ -113,6 +113,13 @@ export type RenderingLifecycleEvent =
     | {
           kind: 'safety-net-tick';
           id: RenderingLifecycleId;
+          // `'deferred'` is retained for shape/back-compat but is no
+          // longer emitted after U5 (H2): the safety-net is now a true
+          // backstop that terminally closes any still-open id at the
+          // bound (see `onSafetyNetTick`), so a tick resolves to
+          // `'closed'` (still open → closed) or `'inert'` (already
+          // closed). The in-flight defer moved to the settle-close
+          // variant, which emits no observer event on defer.
           result: 'closed' | 'deferred' | 'inert';
       };
 
@@ -186,14 +193,19 @@ export type RenderingLifecycleCoordinator = {
      */
     bindPendingRenderCurrent: () => void;
     /**
-     * Arm the bounded safety-net for an id. If the id is still open
-     * (no close / no fail) when the bound elapses, the safety-net
-     * checks whether the render ever began: if `renderStarted ===
-     * false`, it's an orphan and the safety-net closes it with
-     * `renderingFinished`; if `renderStarted === true`, the render is
-     * in flight and the safety-net waits (no close emitted). The
-     * exactly-once guard inside `close` / `fail` makes the safety-net
-     * inert against ids that already closed normally.
+     * Arm the bounded safety-net for an id. The safety-net is a TRUE
+     * backstop: if the id is STILL OPEN (no close / no fail) when the
+     * bound elapses, the safety-net closes it with `renderingFinished`
+     * — regardless of whether the render began. Whether the id is an
+     * orphan (`renderStarted === false`, render never started) or a
+     * started-but-stuck render (`renderStarted === true`, render began
+     * but never signalled completion), the fact that it is still open
+     * at the bound means no other terminal fired, so the host would
+     * otherwise be left with an orphaned `renderingStarted` — which is
+     * cert-blocking. The exactly-once guard inside `close` / `fail`
+     * makes the safety-net inert against ids that already closed
+     * normally (the healthy path, where the close cancels the armed
+     * handle before the bound can elapse).
      */
     armSafetyNet: (id: RenderingLifecycleId) => void;
     /**
@@ -206,19 +218,50 @@ export type RenderingLifecycleCoordinator = {
     /** Fail the currently-open id. Counterpart to `closeCurrent`. */
     failCurrent: (error: unknown) => void;
     /**
-     * Close the pending-render id (used by async React callbacks via
-     * `app.tsx`'s no-arg adapters). No-op if no pending-render is
-     * bound, or the pending-render id has already closed (e.g.
-     * superseded by a later `open`).
+     * Close the pending-render id (used by the async embed-path
+     * render-complete callback via `app.tsx`'s `onRenderingFinished`
+     * adapter — the REAL render close). Terminal regardless of
+     * `renderStarted`. No-op if no pending-render is bound, or the
+     * pending-render id has already closed (e.g. superseded by a later
+     * `open`).
      */
     closePendingRender: () => void;
+    /**
+     * Settle-timer close variant for the pending-render id, used ONLY
+     * by `app.tsx`'s {@link RENDERING_MODE_SETTLE_MS} settle timer (via
+     * a DISTINCT settle-close adapter in `src/index.ts` — never by the
+     * embed-path real close above).
+     *
+     * Behaves like {@link closePendingRender} EXCEPT it DEFERS (no-ops,
+     * with no re-arm) when the render has already started
+     * (`markPendingRenderStarted` has fired for the pending id).
+     * Rationale (audit H2): the settle timer fires on a fixed
+     * wall-clock delay shorter than a slow Vega render; closing
+     * unconditionally would emit `renderingFinished` mid-render and
+     * Power BI's export/snapshot service could capture pre-render
+     * content. While a render is in flight the terminal belongs to the
+     * embed's own `onRenderingFinished` (real close) or, if that never
+     * arrives, to the safety-net at its bound.
+     *
+     * When no render has started (`renderStarted === false` — the
+     * non-Vega-affecting formatting-change case this settle path
+     * targets), it closes exactly as {@link closePendingRender} does.
+     * No-op if no pending-render is bound or the pending-render id has
+     * already closed (exactly-once guard). Mirroring the safety-net's
+     * defer, the deferred branch deliberately emits no observer event:
+     * nothing mutates and the dev-overlay start-vs-close tally must not
+     * count a deferred settle as a close.
+     */
+    closePendingRenderSettle: () => void;
     /** Fail the pending-render id. Counterpart to `closePendingRender`. */
     failPendingRender: (error: unknown) => void;
     /**
      * Mark the pending-render id as having started rendering. The
      * host does NOT see a second `renderingStarted`; this flag is
-     * internal to the coordinator and is consumed by the safety-net
-     * to distinguish orphan vs. in-flight. Idempotent.
+     * internal to the coordinator and is consumed by
+     * {@link closePendingRenderSettle} to DEFER the settle-timer close
+     * of an in-flight render (so the settle timer cannot emit
+     * `renderingFinished` mid-render). Idempotent.
      */
     markPendingRenderStarted: () => void;
 };


### PR DESCRIPTION
## What

Fixes audit finding **H2** (plan U5): the ~500ms settle timer in `app.tsx` closed the pending-render lifecycle id unconditionally, so any render slower than 500ms emitted `renderingFinished` to the host **mid-render**. Power BI's export/snapshot service could capture pre-render content.

## Why the naive fix is wrong (and what this does instead)

Just making the settle timer skip in-flight renders would be a **regression**: the coordinator's 10s safety-net currently *defers* (returns without closing, no re-arm) when `renderStarted` is true, so the settle timer was accidentally the **only** terminal path for a started-but-stuck render. Deferring in both places replaces early-finish with **never-finish** (orphaned `renderingStarted`, cert-blocking). So this is three coupled changes:

1. **`closePendingRenderSettle`** — a new coordinator close variant that defers (no-ops, emits no observer event so the dev-overlay tally stays accurate) when `markPendingRenderStarted` has fired; identical to `closePendingRender` when no render started.
2. **Adapter split in `src/index.ts`** — the embed-path real render-complete close keeps the terminal `closePendingRender`; only app.tsx's settle timer routes to the deferring variant. Sharing one adapter would defer *every* real close to the safety-net.
3. **Safety-net is now a true backstop** — the tick terminally closes any still-open id at the bound regardless of `renderStarted`, instead of deferring in-flight renders.

**`SAFETY_NET_BOUND_MS` unchanged at 10_000 (R9)** — only the tick's *decision* changes (defer → terminal close); no re-arm, no longer wait. Renderless modes keep the terminal close (Vega never embeds there, so there's no in-flight render to protect).

## Tests

Coordinator suite 32→38 (settle variant + changed safety-net semantics); harness scenarios 12→17 (the five H2 scenarios). **Revert-validated:** the slow-render and stuck-render scenarios both go red on unfixed code, and an isolation check confirms the stuck-render scenario depends specifically on the safety-net terminal change. `npm run test` 7 tasks green (316 root); tsc/eslint clean.

## Reviewer note

For a started-but-**stuck** render at the 10s bound, the safety-net closes it as `renderingFinished` (not `renderingFailed`) — consistent with the pre-existing safety-net behavior for un-started renders and avoids expanding the failed-event `via` union (coordinator doc property #7). If you'd prefer `renderingFailed` semantics for the stuck case, that's a one-line change worth flagging now.

Solution doc `rendering-lifecycle-coordinator-single-owner-2026-07-03.md` updated (settle-timer paragraph + safety-net defer semantics; other six properties intact).

Part of the 2026-07-03 audit remediation program (unit U5 of 18; U1–U4 merged in #687–#690).

🤖 Generated with [Claude Code](https://claude.com/claude-code)