### PR TITLE
fix(visual): truthful update setter, constructor-failure signal, destroy() (M4, L5, M8)

### DIFF
--- a/src/__test__/harness/scenarios.test.ts
+++ b/src/__test__/harness/scenarios.test.ts
@@ -635,7 +635,7 @@ describe('scenario: settle-timer close vs. in-flight render (H2 / U5)', () => {
 // undefined coordinator (the audit's L5 failure mode).
 
 describe('scenario: constructor failed → update() short-circuits (L5)', () => {
-    it('emits renderingFailed directly via the host without opening a lifecycle; no secondary throw', async () => {
+    it('emits a balanced renderingStarted/renderingFailed pair directly via the host without opening a lifecycle; no secondary throw', async () => {
         const driver = await createDriver();
         driver.failConstruction(new Error('bind chain exploded'));
 
@@ -645,11 +645,12 @@ describe('scenario: constructor failed → update() short-circuits (L5)', () => 
             })
         );
 
-        // The coordinator's open() was never reached: no renderingStarted,
-        // no open id.
-        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(0);
+        // The coordinator's open() was never reached, so no lifecycle id
+        // is opened — but a balanced renderingStarted → renderingFailed
+        // pair is emitted DIRECTLY via the host event service so the host
+        // never sees an unpaired terminal.
         expect(driver.getOpenLifecycleIds()).toEqual([]);
-        // renderingFailed emitted DIRECTLY through the host event service.
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(1);
         expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
         const failed = driver.host.emitterCalls.filter(
             (c) => c.method === 'renderingFailed'
@@ -676,8 +677,9 @@ describe('scenario: constructor failed → update() short-circuits (L5)', () => 
         driver.update(mk());
         driver.update(mk());
 
+        // Each post-failure update emits its own balanced pair.
         expect(driver.host.countEmitterCalls('renderingFailed')).toBe(3);
-        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(0);
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(3);
         expect(driver.constructionErrorRenderCount()).toBe(1);
         expect(driver.getOpenLifecycleIds()).toEqual([]);
     });
@@ -774,5 +776,31 @@ describe('scenario: destroy() teardown (M8)', () => {
         expect(driver.host.countEmitterCalls('renderingStarted')).toBe(1);
         expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
         expect(driver.host.countEmitterCalls('renderingFailed')).toBe(0);
+    });
+
+    it('update() after destroy() is inert: no new renderingStarted, no open id', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(100) })
+            })
+        );
+        driver.startRender();
+        driver.completeRender();
+        driver.destroy();
+        const startedBefore = driver.host.countEmitterCalls('renderingStarted');
+
+        // Contract-forbidden, but a rapid re-mount can deliver an
+        // update() after destroy(). It must not open the coordinator or
+        // emit a fresh renderingStarted on the torn-down visual.
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(100) })
+            })
+        );
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(
+            startedBefore
+        );
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
     });
 });

--- a/src/__test__/harness/scenarios.test.ts
+++ b/src/__test__/harness/scenarios.test.ts
@@ -473,6 +473,28 @@ describe('scenario: update() throws', () => {
         expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
     });
 
+    it('M4: a synchronous throw from the (de-asynced) settings-model resolution routes to failCurrent — one renderingFailed, no success-path close', async () => {
+        // `setVisualUpdateOptions` (src/state/updates.ts) is synchronous
+        // after M4, so a throw from `getVisualFormattingModel` propagates
+        // into `update()`'s try instead of rejecting a fire-and-forget
+        // promise the catch never sees. The queued fault stands in for
+        // that synchronous throw at the settings-resolution point. Today
+        // (async setter) the same throw would be an unhandled rejection
+        // and the update would close on the success path.
+        const driver = await createDriver();
+        driver.queueFault(new Error('getVisualFormattingModel failed'));
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(10) })
+            })
+        );
+        expect(driver.caughtErrors).toHaveLength(1);
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+
     it('fetchMoreData throwing synchronously clears the fetching flag before failing the lifecycle (no permanent FetchingMessage)', async () => {
         const driver = await createDriver({
             fetchMoreResponses: [new Error('host exploded')]
@@ -497,5 +519,160 @@ describe('scenario: update() throws', () => {
         expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
         expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
         expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+});
+
+// ─── Scenario 6: construction failure (L5) ────────────────────────────────────
+//
+// The Deneb class has heavy constructor side effects (React root, host
+// services, i18n, store wiring), so construction failure is DRIVEN
+// against the coordinator + host emitter and MIRRORED for the
+// `update()` construction-failure guard (a faithful transcription of
+// the top of `Deneb.update` + `Deneb.handleConstructionFailure`; see
+// the driver). Reverting the mirror's guard turns these red — a
+// `renderingStarted` is emitted and a lifecycle id opens; in production
+// the reverted path additionally throws a secondary TypeError on the
+// undefined coordinator (the audit's L5 failure mode).
+
+describe('scenario: constructor failed → update() short-circuits (L5)', () => {
+    it('emits renderingFailed directly via the host without opening a lifecycle; no secondary throw', async () => {
+        const driver = await createDriver();
+        driver.failConstruction(new Error('bind chain exploded'));
+
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(10) })
+            })
+        );
+
+        // The coordinator's open() was never reached: no renderingStarted,
+        // no open id.
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+        // renderingFailed emitted DIRECTLY through the host event service.
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
+        const failed = driver.host.emitterCalls.filter(
+            (c) => c.method === 'renderingFailed'
+        );
+        expect(failed[0].method === 'renderingFailed' && failed[0].reason).toBe(
+            'bind chain exploded'
+        );
+        // No throw reached the mirrored try/catch; no safety-net armed.
+        expect(driver.caughtErrors).toEqual([]);
+        expect(driver.pendingSafetyNetCount()).toBe(0);
+        // Static error element rendered.
+        expect(driver.constructionErrorRenderCount()).toBe(1);
+    });
+
+    it('re-reports renderingFailed on every subsequent update but renders the error element only once', async () => {
+        const driver = await createDriver();
+        driver.failConstruction(new Error('boom'));
+        const mk = () =>
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(5) })
+            });
+
+        driver.update(mk());
+        driver.update(mk());
+        driver.update(mk());
+
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(3);
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(0);
+        expect(driver.constructionErrorRenderCount()).toBe(1);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+});
+
+// ─── Scenario 7: destroy() teardown (M8) ──────────────────────────────────────
+//
+// The coordinator + safety-net are REAL in the harness, so the
+// "no orphaned id / no post-destroy emission" guarantees are genuinely
+// exercised. The keydown-listener / React-root / view-clear steps are
+// production-only side effects the driver records as spy counters (a
+// faithful transcription of `Deneb.destroy`).
+
+describe('scenario: destroy() teardown (M8)', () => {
+    it('after a completed render: listener removed, root unmounted, view cleared, no further emissions', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(100) })
+            })
+        );
+        driver.startRender();
+        driver.completeRender();
+        const finishedBefore =
+            driver.host.countEmitterCalls('renderingFinished');
+        const failedBefore = driver.host.countEmitterCalls('renderingFailed');
+        expect(finishedBefore).toBe(1);
+
+        driver.destroy();
+
+        // All production-only teardown side effects ran exactly once.
+        expect(driver.teardown.keydownListenerRemoved).toBe(1);
+        expect(driver.teardown.reactRootUnmounted).toBe(1);
+        expect(driver.teardown.viewCleared).toBe(1);
+        // Render already completed → failCurrent no-op → no new emission.
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(
+            finishedBefore
+        );
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(
+            failedBefore
+        );
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+        // Late callbacks / safety-nets after destroy stay inert.
+        driver.completeRender();
+        driver.fireSafetyNets();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(
+            finishedBefore
+        );
+    });
+
+    it('with a render in flight: open id failed exactly once, safety-net cancelled, no post-destroy renderingFinished', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(100) })
+            })
+        );
+        // Render started but never completes (in flight); safety-net armed.
+        driver.startRender();
+        expect(driver.getOpenLifecycleIds()).toHaveLength(1);
+        expect(driver.pendingSafetyNetCount()).toBe(1);
+
+        driver.destroy();
+
+        // Open id failed exactly once (the teardown terminal); the armed
+        // safety-net was cancelled as part of the fail.
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
+        expect(driver.pendingSafetyNetCount()).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+
+        // Post-destroy: a late render-complete callback and any leftover
+        // safety-net tick must NOT emit renderingFinished.
+        driver.completeRender();
+        driver.fireSafetyNets();
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(0);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(1);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+    });
+
+    it('full construct → update → destroy cycle leaves zero timers and zero open ids', async () => {
+        const driver = await createDriver();
+        driver.update(
+            buildUpdateOptions({
+                dataView: buildDataView({ categorical: buildCategorical(100) })
+            })
+        );
+        driver.startRender();
+        driver.completeRender();
+
+        driver.destroy();
+
+        expect(driver.pendingSafetyNetCount()).toBe(0);
+        expect(driver.getOpenLifecycleIds()).toEqual([]);
+        expect(driver.host.countEmitterCalls('renderingStarted')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFinished')).toBe(1);
+        expect(driver.host.countEmitterCalls('renderingFailed')).toBe(0);
     });
 });

--- a/src/__test__/harness/update-cycle-driver.ts
+++ b/src/__test__/harness/update-cycle-driver.ts
@@ -116,6 +116,33 @@ export type UpdateCycleDriver = {
     dataset: MockDatasetSlice;
     /** Ids opened but not yet terminally closed/failed (must be empty at scenario end). */
     getOpenLifecycleIds: () => RenderingLifecycleId[];
+    /**
+     * Mark construction as having failed (L5 mirror). Models the
+     * constructor's catch setting `#constructionFailed` in src/index.ts.
+     * Subsequent `update()` calls route through the construction-failure
+     * guard instead of opening a lifecycle.
+     */
+    failConstruction: (error?: unknown) => void;
+    /**
+     * Tear the mirrored visual down (M8 mirror of `Deneb.destroy`).
+     * Fails any open lifecycle id through the REAL coordinator (single
+     * terminal + safety-net cancel + map delete), then records the
+     * production-only teardown side effects (keydown-listener removal,
+     * React-root unmount, Vega-view clear) as spy counters.
+     */
+    destroy: () => void;
+    /** Recorded production-only teardown side effects (see `destroy`). */
+    teardown: {
+        keydownListenerRemoved: number;
+        reactRootUnmounted: number;
+        viewCleared: number;
+    };
+    /**
+     * Times the static construction-failure element was (re)rendered.
+     * Mirrors `renderConstructionFailureElement`'s render-once guard —
+     * must be at most 1 no matter how many post-failure updates arrive.
+     */
+    constructionErrorRenderCount: () => number;
 };
 
 /**
@@ -194,6 +221,16 @@ export const createUpdateCycleDriver = (
     const actions: DatasetUpdateAction[] = [];
     const caughtErrors: unknown[] = [];
     let queuedFault: Error | null = null;
+    // L5 / M8 mirror state (see `failConstruction`, `destroy`,
+    // `dispatchConstructionFailure`).
+    let constructionFailed = false;
+    let constructionError: unknown = undefined;
+    let constructionErrorRenders = 0;
+    const teardown = {
+        keydownListenerRemoved: 0,
+        reactRootUnmounted: 0,
+        viewCleared: 0
+    };
 
     /**
      * Mirrors `Deneb.handleFetchMore` (src/index.ts): set the fetching
@@ -328,13 +365,46 @@ export const createUpdateCycleDriver = (
     };
 
     /**
-     * Mirrors `Deneb.update` (src/index.ts): open the lifecycle FIRST
-     * inside the try, dispatch, route any throw to `failCurrent`, and
-     * arm the safety-net in the finally for whichever id was opened.
+     * Mirrors `Deneb.handleConstructionFailure` (src/index.ts): the
+     * coordinator may never have constructed, so emit `renderingFailed`
+     * DIRECTLY through the host event service (bypassing the
+     * coordinator) and record the static error element as rendered
+     * once. Emission is per-update; the render is once.
+     */
+    const dispatchConstructionFailure = (
+        options: powerbi.extensibility.visual.VisualUpdateOptions
+    ): void => {
+        const reason =
+            constructionError instanceof Error
+                ? constructionError.message
+                : String(constructionError);
+        host.host.eventService.renderingFailed(options, reason);
+        if (constructionErrorRenders === 0) {
+            constructionErrorRenders = 1;
+        }
+    };
+
+    /**
+     * Mirrors `Deneb.update` (src/index.ts): short-circuit through the
+     * construction-failure guard if construction failed (L5); otherwise
+     * open the lifecycle FIRST inside the try, dispatch, route any throw
+     * to `failCurrent`, and arm the safety-net in the finally for
+     * whichever id was opened.
      */
     const update = (
         options: powerbi.extensibility.visual.VisualUpdateOptions
     ): void => {
+        // L5 guard: mirrors the top of `Deneb.update`. When construction
+        // failed the coordinator is never touched — the failure is
+        // reported directly via the host event service. Reverting this
+        // guard makes the L5 scenarios red (a `renderingStarted` is
+        // emitted and a lifecycle id opens); in production the reverted
+        // path additionally throws a secondary TypeError on the
+        // undefined coordinator.
+        if (constructionFailed) {
+            dispatchConstructionFailure(options);
+            return;
+        }
         let openId: RenderingLifecycleId | undefined;
         try {
             openId = coordinator.open(options);
@@ -365,6 +435,24 @@ export const createUpdateCycleDriver = (
         return [...opened];
     };
 
+    /**
+     * Mirrors `Deneb.destroy` (src/index.ts). The coordinator +
+     * safety-net are REAL in the harness, so failing any open id (which
+     * cancels its armed safety-net handle and deletes the id from the
+     * coordinator's map) is genuinely exercised — this is what proves
+     * the "no orphaned id / no post-destroy emission" guarantee. The
+     * React-root / keydown-listener / view-clear steps are
+     * production-only side effects recorded here as spy counters.
+     */
+    const destroy = (): void => {
+        coordinator.failCurrent(
+            new Error('Visual destroyed before render completed.')
+        );
+        teardown.keydownListenerRemoved++;
+        teardown.reactRootUnmounted++;
+        teardown.viewCleared++;
+    };
+
     return {
         update,
         queueFault: (error) => {
@@ -380,6 +468,13 @@ export const createUpdateCycleDriver = (
         actions,
         caughtErrors,
         dataset,
-        getOpenLifecycleIds
+        getOpenLifecycleIds,
+        failConstruction: (error) => {
+            constructionFailed = true;
+            constructionError = error;
+        },
+        destroy,
+        teardown,
+        constructionErrorRenderCount: () => constructionErrorRenders
     };
 };

--- a/src/__test__/harness/update-cycle-driver.ts
+++ b/src/__test__/harness/update-cycle-driver.ts
@@ -235,6 +235,7 @@ export const createUpdateCycleDriver = (
     let constructionFailed = false;
     let constructionError: unknown = undefined;
     let constructionErrorRenders = 0;
+    let destroyed = false;
     const teardown = {
         keydownListenerRemoved: 0,
         reactRootUnmounted: 0,
@@ -375,10 +376,11 @@ export const createUpdateCycleDriver = (
 
     /**
      * Mirrors `Deneb.handleConstructionFailure` (src/index.ts): the
-     * coordinator may never have constructed, so emit `renderingFailed`
-     * DIRECTLY through the host event service (bypassing the
-     * coordinator) and record the static error element as rendered
-     * once. Emission is per-update; the render is once.
+     * coordinator may never have constructed, so emit a balanced
+     * `renderingStarted` → `renderingFailed` pair DIRECTLY through the
+     * host event service (bypassing the coordinator) and record the
+     * static error element as rendered once. Emission is per-update; the
+     * render is once.
      */
     const dispatchConstructionFailure = (
         options: powerbi.extensibility.visual.VisualUpdateOptions
@@ -387,6 +389,7 @@ export const createUpdateCycleDriver = (
             constructionError instanceof Error
                 ? constructionError.message
                 : String(constructionError);
+        host.host.eventService.renderingStarted(options);
         host.host.eventService.renderingFailed(options, reason);
         if (constructionErrorRenders === 0) {
             constructionErrorRenders = 1;
@@ -403,6 +406,11 @@ export const createUpdateCycleDriver = (
     const update = (
         options: powerbi.extensibility.visual.VisualUpdateOptions
     ): void => {
+        // M8 guard: mirrors the top of `Deneb.update`. A destroyed
+        // visual is inert — no coordinator open, no emission.
+        if (destroyed) {
+            return;
+        }
         // L5 guard: mirrors the top of `Deneb.update`. When construction
         // failed the coordinator is never touched — the failure is
         // reported directly via the host event service. Reverting this
@@ -454,6 +462,7 @@ export const createUpdateCycleDriver = (
      * production-only side effects recorded here as spy counters.
      */
     const destroy = (): void => {
+        destroyed = true;
         coordinator.failCurrent(
             new Error('Visual destroyed before render completed.')
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,6 +198,14 @@ export class Deneb implements IVisual {
     #constructionFailed = false;
     #constructionError: unknown;
     #constructionFailureRendered = false;
+    // Teardown state (M8). `destroy()` sets this; `update()` checks it at
+    // the top and returns inertly. Power BI's contract does not call
+    // `update()` after `destroy()`, but rapid re-mounts can — and the
+    // coordinator object is still live (only its `openIds` map was
+    // cleared), so an unguarded post-destroy update would emit a fresh
+    // `renderingStarted` on a torn-down visual (root unmounted, view
+    // cleared).
+    #destroyed = false;
 
     constructor(options: VisualConstructorOptions) {
         logHost('Constructor has been called.', { options });
@@ -327,14 +335,24 @@ export class Deneb implements IVisual {
     }
 
     public update(options: VisualUpdateOptions) {
+        // M8: a destroyed visual is inert. `destroy()` cleared the
+        // coordinator's open-id map but the coordinator object is still
+        // live, so an unguarded `update()` here would `open()` a fresh
+        // id and emit `renderingStarted` on a torn-down visual. Return
+        // silently — no emission, no render. (Power BI's contract does
+        // not call `update()` after `destroy()`, but rapid re-mounts
+        // can.)
+        if (this.#destroyed) {
+            return;
+        }
         // L5: if construction failed, the coordinator (and the React
         // root) may never have been built. Short-circuit BEFORE
         // touching `#coordinator` — otherwise this update, and every
         // one after it, throws a secondary TypeError on the undefined
         // coordinator and the visual stays permanently blank.
-        // `handleConstructionFailure` emits `renderingFailed` directly
-        // through the host event service and renders a static error
-        // element instead.
+        // `handleConstructionFailure` emits a renderingStarted →
+        // renderingFailed pair directly through the host event service
+        // and renders a static error element instead.
         if (this.#constructionFailed) {
             this.handleConstructionFailure(options);
             return;
@@ -426,6 +444,10 @@ export class Deneb implements IVisual {
      */
     public destroy(): void {
         logHost('Destroy has been called.');
+        // Set first, before any teardown step that could throw, so a
+        // post-destroy `update()` is guaranteed inert even if a step
+        // below fails (each is best-effort and swallows its own error).
+        this.#destroyed = true;
         try {
             this.#coordinator?.failCurrent(
                 new Error(VISUAL_DESTROYED_FAILURE_REASON)
@@ -465,15 +487,15 @@ export class Deneb implements IVisual {
     /**
      * Degraded-mode handler invoked from the top of `update()` when the
      * constructor failed (L5). The coordinator may never have been
-     * constructed, so this bypasses it entirely: it emits
-     * `renderingFailed` DIRECTLY through the host event service (so the
-     * host sees a terminal for this update rather than waiting on a
-     * render that will never come) and renders a minimal static error
-     * element into the root element once. Best-effort throughout — the
-     * host reference may be absent if the failure preceded its capture,
-     * and this path must never itself throw. Emission is per-update
-     * (truthful: the host asked us to render and we cannot); the error
-     * element is rendered only once.
+     * constructed, so this bypasses it entirely: it emits a balanced
+     * `renderingStarted` → `renderingFailed` pair DIRECTLY through the
+     * host event service (so the host sees a terminal for this update
+     * rather than waiting on a render that will never come) and renders
+     * a minimal static error element into the root element once.
+     * Best-effort throughout — the host reference may be absent if the
+     * failure preceded its capture, and this path must never itself
+     * throw. Emission is per-update (truthful: the host asked us to
+     * render and we cannot); the error element is rendered only once.
      */
     private handleConstructionFailure(options: VisualUpdateOptions): void {
         logDebug('Visual update called after construction failure.', {
@@ -484,10 +506,19 @@ export class Deneb implements IVisual {
                 ? this.#constructionError.message
                 : String(this.#constructionError);
         try {
+            // Emit a balanced renderingStarted → renderingFailed pair.
+            // IVisualEventService pairs a start with a terminal; a lone
+            // renderingFailed (no preceding start) can leave the host's
+            // per-visual render tracker — which export / print-to-PDF
+            // rely on to know a visual has settled — inconsistent across
+            // repeated post-failure updates. Emitted directly, not via
+            // the coordinator (which may never have constructed), so no
+            // lifecycle id is opened.
+            this.#host?.eventService?.renderingStarted(options);
             this.#host?.eventService?.renderingFailed(options, reason);
         } catch (e) {
             logDebug(
-                'Failed to emit renderingFailed after construction failure.',
+                'Failed to emit rendering events after construction failure.',
                 { error: e }
             );
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
 } from '@deneb-viz/app-core';
 import type { SupportFieldConfiguration } from '@deneb-viz/data-core/support-fields';
 import { VegaExtensibilityServices } from '@deneb-viz/vega-runtime/extensibility';
+import { VegaViewServices } from '@deneb-viz/vega-runtime/view';
 import {
     canFetchMoreFromDataview,
     getCategoricalDataViewFromOptions,
@@ -105,6 +106,15 @@ const IS_LIFECYCLE_OBSERVER_ENABLED = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
 const SAFETY_NET_BOUND_MS = 10_000;
 
 /**
+ * Reason string emitted to the host's `renderingFailed` when
+ * {@link Deneb.destroy} tears the visual down with a render still in
+ * flight (M8). Distinguishes a teardown-aborted render from a genuine
+ * render error in host telemetry / the dev overlay.
+ */
+const VISUAL_DESTROYED_FAILURE_REASON =
+    'Visual destroyed before render completed.';
+
+/**
  * Real-`setTimeout` scheduler for the rendering-lifecycle coordinator.
  * Unit tests inject a synthetic scheduler that exposes the pending
  * callback directly; production uses this one.
@@ -161,12 +171,31 @@ export class Deneb implements IVisual {
     #onRenderingStartedAdapter: () => void;
     #onRenderingFinishedAdapter: () => void;
     #onRenderingErrorAdapter: (error: Error) => void;
+    // Root element captured up front (L5) so the construction-failure
+    // path can still render a static error element even when a later
+    // constructor step throws before `#applicationWrapper` is built.
+    #hostElement: HTMLElement | undefined;
+    // Keydown handler reference retained (M8) so `destroy()` can remove
+    // the document-level listener that `bindTabCycling` attaches.
+    #handleTabCycleKeydown: ((event: KeyboardEvent) => void) | undefined;
+    // Construction-failure state (L5). When the constructor's catch
+    // fires, `#coordinator` / `#root` may be undefined; `update()`
+    // checks this flag at the top and routes to a degraded handler
+    // instead of dereferencing a half-built visual.
+    #constructionFailed = false;
+    #constructionError: unknown;
+    #constructionFailureRendered = false;
 
     constructor(options: VisualConstructorOptions) {
         logHost('Constructor has been called.', { options });
         try {
-            const { host } = options;
+            const { host, element } = options;
             this.#host = host;
+            // Capture the root element up front so the
+            // construction-failure path (see `update()` /
+            // `handleConstructionFailure`) can still render a static
+            // error element even if a later constructor step throws.
+            this.#hostElement = element;
             // Coordinator owns ALL host.eventService.rendering*
             // emission from this point forward. The host event
             // service is the structural emitter; the safety-net uses
@@ -244,7 +273,6 @@ export class Deneb implements IVisual {
                 options.host.createLocalizationManager()
             );
             initializeStoreSynchronization();
-            const { element } = options;
             this.#applicationWrapper = document.createElement('div');
             this.#applicationWrapper.id = 'deneb-application-wrapper';
             element.appendChild(this.#applicationWrapper);
@@ -263,11 +291,33 @@ export class Deneb implements IVisual {
                 ev.preventDefault();
             };
         } catch (e) {
-            console?.error('Error', e);
+            // Construction failed (L5). Do NOT `console.error` — it is
+            // banned on certified paths (see the note in `update()`'s
+            // catch). Record the failure so `update()` short-circuits
+            // into `handleConstructionFailure` instead of dereferencing
+            // a half-built visual (`#coordinator` / `#root` may be
+            // undefined here, which would otherwise make every later
+            // `update()` throw a secondary TypeError). Forensic detail
+            // goes to the dev-time log gate.
+            this.#constructionFailed = true;
+            this.#constructionError = e;
+            logDebug('Error during visual construction.', { error: e });
         }
     }
 
     public update(options: VisualUpdateOptions) {
+        // L5: if construction failed, the coordinator (and the React
+        // root) may never have been built. Short-circuit BEFORE
+        // touching `#coordinator` — otherwise this update, and every
+        // one after it, throws a secondary TypeError on the undefined
+        // coordinator and the visual stays permanently blank.
+        // `handleConstructionFailure` emits `renderingFailed` directly
+        // through the host event service and renders a static error
+        // element instead.
+        if (this.#constructionFailed) {
+            this.handleConstructionFailure(options);
+            return;
+        }
         // The coordinator's `open()` is the FIRST statement inside the
         // try so `renderingStarted` is emitted before anything else can
         // throw (R1). If `open()` itself throws (the host throws on
@@ -325,6 +375,126 @@ export class Deneb implements IVisual {
             if (openId !== undefined) {
                 this.#coordinator.armSafetyNet(openId);
             }
+        }
+    }
+
+    /**
+     * Tear the visual down cleanly (IVisual contract, M8). Power BI does
+     * not expect `destroy()` to throw, so each step is isolated: a throw
+     * in one does not prevent the others and none propagates out.
+     *
+     * Teardown guarantees (per the rendering-lifecycle coordinator
+     * solution doc): no orphaned open lifecycle id and no `rendering*`
+     * emission after destroy.
+     *  - `failCurrent` fails any still-open id (a single terminal),
+     *    cancels its armed safety-net handle, and deletes the id from
+     *    the coordinator's map — so a late React render callback
+     *    (`closePendingRender`) or a safety-net tick that fires after
+     *    destroy finds nothing open and no-ops. When the render already
+     *    completed there is no open id and `failCurrent` no-ops (no
+     *    emission).
+     *  - The document keydown listener added by `bindTabCycling` is
+     *    removed so it cannot fire against a torn-down wrapper.
+     *  - The React root is unmounted and the Vega view cleared so no
+     *    stale view state survives into a subsequent visual instance.
+     *
+     * All references are read defensively (`?.`) because a failed
+     * construction may leave `#coordinator` / `#root` /
+     * `#handleTabCycleKeydown` undefined.
+     */
+    public destroy(): void {
+        logHost('Destroy has been called.');
+        try {
+            this.#coordinator?.failCurrent(
+                new Error(VISUAL_DESTROYED_FAILURE_REASON)
+            );
+        } catch (e) {
+            logDebug('Error failing open lifecycle during destroy.', {
+                error: e
+            });
+        }
+        try {
+            if (this.#handleTabCycleKeydown) {
+                document.removeEventListener(
+                    'keydown',
+                    this.#handleTabCycleKeydown
+                );
+                this.#handleTabCycleKeydown = undefined;
+            }
+        } catch (e) {
+            logDebug('Error removing keydown listener during destroy.', {
+                error: e
+            });
+        }
+        try {
+            this.#root?.unmount();
+        } catch (e) {
+            logDebug('Error unmounting React root during destroy.', {
+                error: e
+            });
+        }
+        try {
+            VegaViewServices.clearView();
+        } catch (e) {
+            logDebug('Error clearing Vega view during destroy.', { error: e });
+        }
+    }
+
+    /**
+     * Degraded-mode handler invoked from the top of `update()` when the
+     * constructor failed (L5). The coordinator may never have been
+     * constructed, so this bypasses it entirely: it emits
+     * `renderingFailed` DIRECTLY through the host event service (so the
+     * host sees a terminal for this update rather than waiting on a
+     * render that will never come) and renders a minimal static error
+     * element into the root element once. Best-effort throughout — the
+     * host reference may be absent if the failure preceded its capture,
+     * and this path must never itself throw. Emission is per-update
+     * (truthful: the host asked us to render and we cannot); the error
+     * element is rendered only once.
+     */
+    private handleConstructionFailure(options: VisualUpdateOptions): void {
+        logDebug('Visual update called after construction failure.', {
+            error: this.#constructionError
+        });
+        const reason =
+            this.#constructionError instanceof Error
+                ? this.#constructionError.message
+                : String(this.#constructionError);
+        try {
+            this.#host?.eventService?.renderingFailed(options, reason);
+        } catch (e) {
+            logDebug(
+                'Failed to emit renderingFailed after construction failure.',
+                { error: e }
+            );
+        }
+        this.renderConstructionFailureElement();
+    }
+
+    /**
+     * Render a minimal, non-localized error element into the root
+     * element exactly once. i18n and React may have failed to
+     * initialize during a construction failure, so this uses plain DOM
+     * and a static string (no store, no Fluent, no translation
+     * catalog). Guarded so repeated `update()` calls after a
+     * construction failure do not stack elements.
+     */
+    private renderConstructionFailureElement(): void {
+        if (this.#constructionFailureRendered) return;
+        if (!this.#hostElement) return;
+        try {
+            const errorElement = document.createElement('div');
+            errorElement.className = 'deneb-construction-error';
+            errorElement.setAttribute('role', 'alert');
+            errorElement.textContent =
+                'Deneb failed to initialize. Please reload the visual.';
+            this.#hostElement.replaceChildren(errorElement);
+            this.#constructionFailureRendered = true;
+        } catch (e) {
+            logDebug('Failed to render construction-failure element.', {
+                error: e
+            });
         }
     }
 
@@ -714,7 +884,11 @@ export class Deneb implements IVisual {
      * wraps to the last. Esc is not intercepted — Power BI handles exiting the visual.
      */
     private bindTabCycling() {
-        document.addEventListener('keydown', (event) => {
+        // Retain the handler reference (M8) so `destroy()` can remove
+        // this document-level listener; an anonymous inline handler
+        // could never be removed and would leak across visual
+        // teardown/re-create cycles.
+        this.#handleTabCycleKeydown = (event) => {
             if (event.key !== 'Tab') return;
             // When an overlay that manages its own focus is present (modal
             // dialog, Fluent UI PopoverSurface, etc.), yield to it — the
@@ -730,7 +904,8 @@ export class Deneb implements IVisual {
             ) {
                 event.preventDefault();
             }
-        });
+        };
+        document.addEventListener('keydown', this.#handleTabCycleKeydown);
     }
 
     /**

--- a/src/state/__test__/updates.test.ts
+++ b/src/state/__test__/updates.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+//
+// `setVisualUpdateOptions` (the M4 target) is exercised in isolation:
+// the slice creator only invokes `set`/`get` lazily inside the setter,
+// so structural stubs are sufficient. `getVisualFormattingModel` is the
+// synchronous throw source the audit identified; `../../lib/state`
+// helpers and the configuration constant are stubbed so the module
+// loads without its heavier real dependencies.
+
+vi.mock('../../lib/persistence', () => ({
+    getVisualFormattingModel: vi.fn()
+}));
+vi.mock('../../lib/state', () => ({
+    getUpdatedDisplayHistoryList: vi.fn(() => []),
+    doesModeAllowEmbedViewportSet: vi.fn(() => false),
+    isVisualUpdateTypeResizeEnd: vi.fn(() => false),
+    isVisualUpdateTypeVolatile: vi.fn(() => false)
+}));
+vi.mock('@deneb-viz/configuration', () => ({
+    DEFAULT_VIEWPORT_SCALE: 1
+}));
+
+import { getVisualFormattingModel } from '../../lib/persistence';
+import { createUpdatesSlice, type VisualUpdateDataPayload } from '../updates';
+
+// ─── Harness ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build the `setVisualUpdateOptions` setter against stubbed `set`/`get`.
+ * The slice creator does not touch `set`/`get` at creation time (only
+ * when a setter runs), so the `unknown` casts here are safe — the store
+ * middleware types are irrelevant to what this test drives.
+ */
+const buildSetVisualUpdateOptions = (getState: () => unknown) => {
+    const stateCreator = createUpdatesSlice();
+    const set = vi.fn();
+    const get = vi.fn(getState);
+    const slice = stateCreator(
+        set as unknown as Parameters<typeof stateCreator>[0],
+        get as unknown as Parameters<typeof stateCreator>[1],
+        {} as unknown as Parameters<typeof stateCreator>[2]
+    );
+    return slice.setVisualUpdateOptions;
+};
+
+const buildPayload = (): VisualUpdateDataPayload =>
+    ({
+        options: {
+            dataViews: [{}],
+            viewport: { width: 100, height: 100 },
+            type: 0,
+            isInFocus: false
+        },
+        isDeveloperMode: false
+    }) as unknown as VisualUpdateDataPayload;
+
+const buildSuccessGetState = () => ({
+    interface: {
+        embedViewport: undefined,
+        mode: 'view',
+        viewport: { width: 0, height: 0 },
+        setEmbedViewport: vi.fn(),
+        setViewport: vi.fn()
+    },
+    dataset: { isFetchingAdditional: false }
+});
+
+const buildSuccessSettingsStub = () =>
+    ({
+        resolveDeveloperSettings: vi.fn(),
+        stateManagement: {
+            viewport: {
+                viewportHeight: { value: '0' },
+                viewportWidth: { value: '0' }
+            }
+        }
+    }) as unknown as ReturnType<typeof getVisualFormattingModel>;
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('updates slice: setVisualUpdateOptions (M4 — truthful synchronous setter)', () => {
+    it('throws SYNCHRONOUSLY when getVisualFormattingModel throws (does not swallow the throw into a rejected promise)', () => {
+        // Pre-fix (async setter) this call would return a rejected
+        // promise and NOT throw synchronously — `update()`'s try/catch
+        // would miss it and the update would close on the success path.
+        vi.mocked(getVisualFormattingModel).mockImplementation(() => {
+            throw new Error('settings model resolution failed');
+        });
+        const setVisualUpdateOptions = buildSetVisualUpdateOptions(() => ({}));
+        expect(() => setVisualUpdateOptions(buildPayload())).toThrow(
+            'settings model resolution failed'
+        );
+    });
+
+    it('returns void (not a Promise) on the success path', () => {
+        vi.mocked(getVisualFormattingModel).mockImplementation(() =>
+            buildSuccessSettingsStub()
+        );
+        const setVisualUpdateOptions = buildSetVisualUpdateOptions(
+            buildSuccessGetState
+        );
+        const result = setVisualUpdateOptions(buildPayload());
+        expect(result).toBeUndefined();
+        expect(result).not.toBeInstanceOf(Promise);
+    });
+});

--- a/src/state/__test__/updates.test.ts
+++ b/src/state/__test__/updates.test.ts
@@ -99,9 +99,8 @@ describe('updates slice: setVisualUpdateOptions (M4 — truthful synchronous set
         vi.mocked(getVisualFormattingModel).mockImplementation(() =>
             buildSuccessSettingsStub()
         );
-        const setVisualUpdateOptions = buildSetVisualUpdateOptions(
-            buildSuccessGetState
-        );
+        const setVisualUpdateOptions =
+            buildSetVisualUpdateOptions(buildSuccessGetState);
         const result = setVisualUpdateOptions(buildPayload());
         expect(result).toBeUndefined();
         expect(result).not.toBeInstanceOf(Promise);

--- a/src/state/updates.ts
+++ b/src/state/updates.ts
@@ -37,7 +37,16 @@ export type UpdatesSlice = {
      * — older events are dropped from the head.
      */
     lifecycleEvents: RenderingLifecycleEvent[];
-    setVisualUpdateOptions: (payload: VisualUpdateDataPayload) => Promise<void>;
+    /**
+     * Synchronous (M4). This setter is called from `update()`'s try (via
+     * `Deneb.resolveUpdateOptions`) and does not await anything
+     * internally, so it is intentionally NOT `async`: a synchronous
+     * throw inside (e.g. `getVisualFormattingModel`) must propagate into
+     * `update()`'s try/catch → `coordinator.failCurrent`, rather than
+     * becoming an unhandled rejection on a fire-and-forget promise that
+     * bypasses the catch and lets the update close on the success path.
+     */
+    setVisualUpdateOptions: (payload: VisualUpdateDataPayload) => void;
     /**
      * Append a single observer event to {@link lifecycleEvents}. The
      * ring is trimmed from the head to maintain its bound. Designed
@@ -88,7 +97,7 @@ export const createUpdatesSlice = (): StateCreator<
                 false,
                 'updates.recordLifecycleEvent'
             ),
-        setVisualUpdateOptions: async (payload) => {
+        setVisualUpdateOptions: (payload) => {
             const { options, isDeveloperMode } = payload;
             const settings = getVisualFormattingModel(options?.dataViews?.[0]);
             settings.resolveDeveloperSettings(isDeveloperMode);


### PR DESCRIPTION
## What

Fixes audit findings **M4**, **L5**, **M8** (plan U7) — the visual entry path (`src/index.ts`) now propagates failures truthfully and tears down cleanly.

- **M4** — `setVisualUpdateOptions` was `async` but awaited nothing and was called fire-and-forget from `update()`'s try. A synchronous throw inside it (e.g. `getVisualFormattingModel`) became an unhandled rejection that bypassed the catch, so `update()` closed on the *success* path and the coordinator never saw the failure. De-asynced → throws reach `coordinator.failCurrent`. **Scoped:** the selector setters (`setSelectors`/`setSelectionLimitExceeded`) stay async because `interactivity-manager` `.then`-chains them and its callback types require `Promise<void>` — that change is U9's. `dataset.ts` (listed in the plan) is unchanged for the same reason: its only async setter is `.then`-chained. Per-setter call-site audit in the commit body.
- **L5** — the constructor catch called `console.error` and returned, leaving `#coordinator`/`#root` possibly undefined so *every* subsequent `update()` threw a secondary TypeError (permanently blank visual, no host signal). Now the catch sets a construction-failed flag (host + root element captured as the first constructor statements); `update()` short-circuits at the top, emits `renderingFailed` **directly through the host event service** (the coordinator may never have constructed), and renders a static error element. No `console.error` (certified-path ban).
- **M8** — implemented `destroy()`: `failCurrent` any open lifecycle id (single terminal, cancels the armed safety-net, clears the coordinator map so a late `closePendingRender`/safety-net tick no-ops), remove the document keydown listener from `bindTabCycling`, unmount the React root, `VegaViewServices.clearView()`. Each step isolated in try/catch (Power BI doesn't expect `destroy()` to throw); no post-destroy emission.

## Tests

New `src/state/__test__/updates.test.ts` (2 tests) is the authoritative M4 red/green — with `async` restored, the throw surfaces as an unhandled rejection (the audit's exact bug). Harness scenarios 12→18: M4 tie-in, constructor-failure short-circuit (L5), and three `destroy()` teardown scenarios (M8) proving no orphaned ids and no post-destroy `renderingFinished`. Both "today fails" scenarios revert-validated red. What was driven (real coordinator + safety-net + real setter) vs mirrored (the `update()`/`destroy()` glue, per the U4 driver convention) is detailed in the subagent record.

`npm run test` 7 tasks green (313 root); tsc clean; healthy-path `update()` ordering unchanged.

Part of the 2026-07-03 audit remediation program (unit U7 of 18; U1–U6 in #687–#692). This closes all three HIGH findings (H1/H2/H3) plus M4/M8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)