### PR TITLE
fix(visual): serialize incremental updates; sink signal-write and dataset-lookup failures (M7, M6, L3)

### DIFF
--- a/packages/app-core/src/features/visual-viewer/__tests__/incremental-update.test.ts
+++ b/packages/app-core/src/features/visual-viewer/__tests__/incremental-update.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { View } from 'vega';
+import {
+    performIncrementalUpdate,
+    resolveDataChangeAction
+} from '../incremental-update';
+
+// incremental-update.ts imports only `logDebug` from this module.
+vi.mock('@deneb-viz/utils/logging', () => ({
+    logDebug: vi.fn()
+}));
+
+type Deferred = {
+    promise: Promise<unknown>;
+    resolve: (value?: unknown) => void;
+    reject: (reason?: unknown) => void;
+};
+
+/**
+ * Build a minimal fake Vega `View` whose `runAsync()` returns a controllable
+ * deferred each call, so a test can hold an update "in flight" and settle it
+ * deterministically. `error` is a plain read/write property matching the
+ * `ViewWithError` shape the module casts to.
+ */
+const makeFakeView = (originalError?: (err: Error) => void) => {
+    const deferreds: Deferred[] = [];
+    const view = {
+        error: originalError,
+        data: vi.fn(),
+        runAsync: vi.fn(() => {
+            let resolve!: (value?: unknown) => void;
+            let reject!: (reason?: unknown) => void;
+            const promise = new Promise<unknown>((res, rej) => {
+                resolve = res;
+                reject = rej;
+            });
+            deferreds.push({ promise, resolve, reject });
+            return promise;
+        })
+    };
+    return { view, deferreds };
+};
+
+/** Flush microtasks + the current macrotask so `.then`/`.catch` chains run. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const asView = (view: unknown) => view as unknown as View;
+
+describe('performIncrementalUpdate — happy path', () => {
+    it('applies a single data update and restores the original error handler on success', async () => {
+        const trueOriginal = vi.fn();
+        const { view, deferreds } = makeFakeView(trueOriginal);
+        const onFailure = vi.fn();
+        const onSuccess = vi.fn();
+
+        performIncrementalUpdate({
+            view: asView(view),
+            values: [{ a: 1 }],
+            onFailure,
+            onSuccess
+        });
+
+        expect(view.data).toHaveBeenCalledTimes(1);
+        expect(view.data).toHaveBeenCalledWith('dataset', [{ a: 1 }]);
+        expect(view.runAsync).toHaveBeenCalledTimes(1);
+        // Override installed (not the original) while the update is in flight.
+        expect(view.error).not.toBe(trueOriginal);
+
+        deferreds[0].resolve(view);
+        await flush();
+
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onFailure).not.toHaveBeenCalled();
+        expect(view.error).toBe(trueOriginal);
+    });
+});
+
+describe('performIncrementalUpdate — serialization (M7 overlap / revert-check)', () => {
+    it('defers a second update that overlaps the first, leaving the TRUE original handler installed', async () => {
+        const trueOriginal = vi.fn();
+        const { view, deferreds } = makeFakeView(trueOriginal);
+        const onFailure1 = vi.fn();
+        const onSuccess1 = vi.fn();
+        const onFailure2 = vi.fn();
+        const onSuccess2 = vi.fn();
+
+        // Update 1 starts; its runAsync() stays pending.
+        performIncrementalUpdate({
+            view: asView(view),
+            values: [{ a: 1 }],
+            onFailure: onFailure1,
+            onSuccess: onSuccess1
+        });
+        // Update 2 arrives while update 1's runAsync() is still pending.
+        performIncrementalUpdate({
+            view: asView(view),
+            values: [{ a: 2 }],
+            onFailure: onFailure2,
+            onSuccess: onSuccess2
+        });
+
+        // Serialized: update 2 must not have installed a second override or run
+        // the view — it defers to a re-compile via onFailure. (On the pre-fix
+        // code, runAsync is called twice here.)
+        expect(view.runAsync).toHaveBeenCalledTimes(1);
+        expect(onFailure2).toHaveBeenCalledTimes(1);
+        expect(onFailure2).toHaveBeenCalledWith(
+            expect.stringContaining('concurrent'),
+            null
+        );
+
+        // Settle both runs (guard deferreds[1] so the assertion is meaningful
+        // on the pre-fix path too, where update 2 also ran).
+        deferreds[0].resolve(view);
+        await flush();
+        if (deferreds[1]) {
+            deferreds[1].resolve(view);
+            await flush();
+        }
+
+        expect(onSuccess1).toHaveBeenCalledTimes(1);
+        // The corruption this guards: on the pre-fix code update 1's override is
+        // left permanently installed. With serialization + token-checked
+        // restore, the true original handler is what remains.
+        expect(view.error).toBe(trueOriginal);
+    });
+});
+
+describe('performIncrementalUpdate — failure fallbacks', () => {
+    it('falls back on an internal Vega error surfaced via the error handler', async () => {
+        const trueOriginal = vi.fn();
+        const { view, deferreds } = makeFakeView(trueOriginal);
+        const onFailure = vi.fn();
+        const onSuccess = vi.fn();
+
+        performIncrementalUpdate({
+            view: asView(view),
+            values: [{ a: 1 }],
+            onFailure,
+            onSuccess
+        });
+
+        // Simulate Vega routing a dataflow error through the (overridden)
+        // handler during runAsync().
+        (view.error as (err: Error) => void)(new Error('transform failed'));
+        // Original handler still invoked (logging preserved).
+        expect(trueOriginal).toHaveBeenCalledTimes(1);
+
+        deferreds[0].resolve(view);
+        await flush();
+
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onFailure).toHaveBeenCalledWith(
+            'internal Vega error during update',
+            'transform failed'
+        );
+        expect(view.error).toBe(trueOriginal);
+    });
+
+    it('falls back when runAsync rejects', async () => {
+        const trueOriginal = vi.fn();
+        const { view, deferreds } = makeFakeView(trueOriginal);
+        const onFailure = vi.fn();
+        const onSuccess = vi.fn();
+
+        performIncrementalUpdate({
+            view: asView(view),
+            values: [{ a: 1 }],
+            onFailure,
+            onSuccess
+        });
+
+        deferreds[0].reject(new Error('async fail'));
+        await flush();
+
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onFailure).toHaveBeenCalledWith('runAsync rejected', 'async fail');
+        expect(view.error).toBe(trueOriginal);
+    });
+
+    it('falls back synchronously when view.data throws and releases the in-flight lock', async () => {
+        const trueOriginal = vi.fn();
+        const { view, deferreds } = makeFakeView(trueOriginal);
+        view.data = vi.fn(() => {
+            throw new Error('data boom');
+        });
+        const onFailure = vi.fn();
+
+        performIncrementalUpdate({
+            view: asView(view),
+            values: [{ a: 1 }],
+            onFailure,
+            onSuccess: vi.fn()
+        });
+
+        expect(onFailure).toHaveBeenCalledWith(
+            'exception during update',
+            'data boom'
+        );
+        expect(view.error).toBe(trueOriginal);
+        expect(view.runAsync).not.toHaveBeenCalled();
+
+        // The in-flight lock must have been released so a subsequent update on
+        // the same view is NOT wrongly treated as an overlap.
+        view.data = vi.fn();
+        const onSuccess2 = vi.fn();
+        performIncrementalUpdate({
+            view: asView(view),
+            values: [{ a: 2 }],
+            onFailure: vi.fn(),
+            onSuccess: onSuccess2
+        });
+        expect(view.runAsync).toHaveBeenCalledTimes(1);
+
+        deferreds[0].resolve(view);
+        await flush();
+        expect(onSuccess2).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('resolveDataChangeAction (L3 routing)', () => {
+    it("returns 'ignore' when the dataset is absent (inline/remote data)", () => {
+        expect(resolveDataChangeAction('absent', true, 10, 500)).toBe('ignore');
+    });
+
+    it("returns 'recompile' when the dataset lookup failed, even for a small enabled update", () => {
+        expect(resolveDataChangeAction('error', true, 1, 500)).toBe('recompile');
+    });
+
+    it("returns 'incremental' for a present dataset within threshold when enabled", () => {
+        expect(resolveDataChangeAction('present', true, 100, 500)).toBe(
+            'incremental'
+        );
+    });
+
+    it("returns 'recompile' for a present dataset when incremental updates are disabled", () => {
+        expect(resolveDataChangeAction('present', false, 10, 500)).toBe(
+            'recompile'
+        );
+    });
+
+    it("returns 'recompile' for a present dataset above the threshold", () => {
+        expect(resolveDataChangeAction('present', true, 501, 500)).toBe(
+            'recompile'
+        );
+    });
+
+    it('treats the threshold as inclusive (row count == threshold stays incremental)', () => {
+        expect(resolveDataChangeAction('present', true, 500, 500)).toBe(
+            'incremental'
+        );
+    });
+});

--- a/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
+++ b/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
@@ -18,7 +18,10 @@ import { VegaViewServices } from '@deneb-viz/vega-runtime/view';
 import { VegaEmbed } from './vega-embed';
 import { VegaEmbedErrorBoundary } from './vega-embed-error-boundary';
 import { VEGA_CONTAINER_ID } from '../constants';
-import { performIncrementalUpdate } from '../incremental-update';
+import {
+    performIncrementalUpdate,
+    resolveDataChangeAction
+} from '../incremental-update';
 import { useDenebState } from '../../../state';
 import { useDenebPlatformProvider } from '../../../components/deneb-platform';
 import { INCREMENTAL_UPDATE_CONFIGURATION } from '../../../lib/vega/incremental-update-configuration';
@@ -125,6 +128,7 @@ export const VisualViewer = ({
         enableIncrementalDataUpdates,
         incrementalUpdateThreshold,
         viewReady,
+        logError,
         logDurableError,
         logDurableWarn,
         translate
@@ -155,6 +159,7 @@ export const VisualViewer = ({
         incrementalUpdateThreshold:
             state.compilation.incrementalUpdateThreshold,
         viewReady: state.compilation.viewReady,
+        logError: state.compilation.logError,
         logDurableError: state.compilation.logDurableError,
         logDurableWarn: state.compilation.logDurableWarn,
         translate: state.i18n.translate
@@ -245,31 +250,43 @@ export const VisualViewer = ({
             return;
         }
 
-        if (
-            VegaViewServices.getDataByName(DATASET_DEFAULT_NAME) === undefined
-        ) {
-            logDebug(
-                'VisualViewer: Spec uses inline data (no dataset binding) - ignoring data change'
-            );
-            return;
-        }
-
         // Do "recompile threshold" checks
         const effectiveThreshold = Math.min(
             incrementalUpdateThreshold,
             INCREMENTAL_UPDATE_CONFIGURATION.maxThreshold
         );
 
-        if (
-            !enableIncrementalDataUpdates ||
-            values.length > effectiveThreshold
-        ) {
+        // Distinguish "the spec has no `dataset` binding (inline/remote data)"
+        // from "the dataset lookup failed" (L3). `getDataByName` swallows both
+        // into `undefined`; `getDatasetPresence` separates them so a genuine
+        // failure falls through to a full re-compile below instead of being
+        // mistaken for inline data and silently dropping the update.
+        const datasetPresence =
+            VegaViewServices.getDatasetPresence(DATASET_DEFAULT_NAME);
+        const dataChangeAction = resolveDataChangeAction(
+            datasetPresence,
+            enableIncrementalDataUpdates,
+            values.length,
+            effectiveThreshold
+        );
+
+        if (dataChangeAction === 'ignore') {
+            logDebug(
+                'VisualViewer: Spec uses inline data (no dataset binding) - ignoring data change'
+            );
+            return;
+        }
+
+        if (dataChangeAction === 'recompile') {
             logDebug(
                 'VisualViewer: Data changed - triggering full re-compile',
                 {
-                    reason: !enableIncrementalDataUpdates
-                        ? 'incremental updates disabled'
-                        : 'dataset too large',
+                    reason:
+                        datasetPresence === 'error'
+                            ? 'dataset lookup failed'
+                            : !enableIncrementalDataUpdates
+                              ? 'incremental updates disabled'
+                              : 'dataset too large',
                     rowCount: values.length,
                     threshold: effectiveThreshold
                 }
@@ -549,8 +566,14 @@ export const VisualViewer = ({
                 scrollLeft: throttledScrollPosition.scrollLeft
             }
         });
-        VegaViewServices.setSignalByName(signal.name, signal.value);
-    }, [throttledScrollPosition, viewReady]);
+        VegaViewServices.setSignalByName(signal.name, signal.value, (error) => {
+            logError(
+                `VisualViewer: Failed to update scroll signal: ${
+                    error instanceof Error ? error.message : String(error)
+                }`
+            );
+        });
+    }, [throttledScrollPosition, viewReady, logError]);
 
     const scrollbarStyleVars = getScrollbarStyleVars(
         scrollbarColor,

--- a/packages/app-core/src/features/visual-viewer/incremental-update.ts
+++ b/packages/app-core/src/features/visual-viewer/incremental-update.ts
@@ -34,6 +34,20 @@ export type IncrementalUpdateOptions = {
 };
 
 /**
+ * Views that currently have an incremental update in flight.
+ *
+ * `viewReady` is NOT toggled during an incremental update, so a second rapid
+ * Power BI update can call `performIncrementalUpdate` again while the first
+ * call's `runAsync()` is still pending. Two overlapping runs corrupt the
+ * `view.error` handler chain: the second captures the first's OVERRIDE as "the
+ * original" and, on restore, can leave a dead override permanently installed
+ * (audit M7). We serialize per view — the second call defers to a full
+ * re-compile instead of installing an overlapping override. A `WeakSet` keyed
+ * to the `View` releases the entry automatically once the view is GC'd.
+ */
+const inFlightIncrementalUpdates = new WeakSet<View>();
+
+/**
  * Performs an incremental data update on a Vega view using the view.data() API.
  *
  * This function handles:
@@ -52,6 +66,23 @@ export const performIncrementalUpdate = ({
     onSuccess
 }: IncrementalUpdateOptions): void => {
     /**
+     * Serialize per view (audit M7). If a previous update on this view is still
+     * pending, do NOT start a second overlapping override — that would corrupt
+     * the `view.error` restore chain. Defer to a full re-compile, which rebuilds
+     * the view from the latest data and supersedes the in-flight run. We must
+     * not clear the in-flight flag here: it belongs to the run already in
+     * progress, which will clear it when it settles.
+     */
+    if (inFlightIncrementalUpdates.has(view)) {
+        logDebug(
+            'IncrementalUpdate: an update is already in flight for this view - deferring to re-compile'
+        );
+        onFailure('a concurrent update was already in progress', null);
+        return;
+    }
+    inFlightIncrementalUpdates.add(view);
+
+    /**
      * Track if Vega logs an error during runAsync(). Vega catches errors internally during dataflow evaluation and
      * routes them through `view.error()` rather than rejecting the promise. We temporarily override the error handler
      * to detect these internal errors.
@@ -60,7 +91,12 @@ export const performIncrementalUpdate = ({
     let internalErrorMessage: string | null = null;
     const originalErrorHandler = viewWithError.error;
 
-    viewWithError.error = (err: Error) => {
+    /**
+     * The override we install. Kept as a stable reference so the restore below
+     * can verify — via identity — that OURS is still the active handler before
+     * writing the original back.
+     */
+    const errorOverride = (err: Error) => {
         internalErrorMessage = err?.message || String(err);
         logDebug('IncrementalUpdate: Vega internal error detected', {
             error: internalErrorMessage
@@ -68,12 +104,29 @@ export const performIncrementalUpdate = ({
         // Call original handler to preserve logging
         originalErrorHandler?.call(view, err);
     };
+    viewWithError.error = errorOverride;
+
+    /**
+     * Restore the error handler and release the in-flight flag. Run on every
+     * terminal path (success, failure, exception).
+     *
+     * The restore is token-checked (audit M7): only write `originalErrorHandler`
+     * back if OUR override is still installed. If something else (a later run,
+     * teardown) has since replaced it, leave that newer handler in place rather
+     * than clobbering it or reinstating a stale override.
+     */
+    const finalize = () => {
+        if (viewWithError.error === errorOverride) {
+            viewWithError.error = originalErrorHandler;
+        }
+        inFlightIncrementalUpdates.delete(view);
+    };
 
     /**
      * Helper to restore error handler and handle failure.
      */
     const handleFailure = (reason: string, error?: unknown) => {
-        viewWithError.error = originalErrorHandler;
+        finalize();
 
         // Build error details string from captured error or passed error
         const errorDetails =
@@ -105,12 +158,10 @@ export const performIncrementalUpdate = ({
         view.data(DATASET_DEFAULT_NAME, valuesCopy);
         view.runAsync()
             .then(() => {
-                // Restore original error handler
-                viewWithError.error = originalErrorHandler;
-
                 if (internalErrorMessage) {
                     handleFailure('internal Vega error during update');
                 } else {
+                    finalize();
                     logDebug(
                         'IncrementalUpdate: SUCCESS - Data updated via view.data() API'
                     );
@@ -123,4 +174,44 @@ export const performIncrementalUpdate = ({
     } catch (error) {
         handleFailure('exception during update', error);
     }
+};
+
+/**
+ * How the data-change effect should respond to a host data update.
+ *
+ * - `'ignore'`      — the compiled view has no binding for the default dataset
+ *   (the spec uses inline or remote data), so the change is irrelevant.
+ * - `'recompile'`   — perform a full re-compile. Chosen when the dataset lookup
+ *   FAILED (so the update is not silently dropped — audit L3), when incremental
+ *   updates are disabled, or when the row count exceeds the effective threshold.
+ * - `'incremental'` — reconcile the new data in place via `view.data()`.
+ */
+export type DataChangeAction = 'ignore' | 'recompile' | 'incremental';
+
+/**
+ * Decide how to apply a host data change, given whether the view binds the
+ * default dataset (`datasetPresence`) and the incremental-update settings.
+ *
+ * Distinguishing a failed dataset lookup (`'error'`) from a genuine absence
+ * (`'absent'`) is the crux of audit L3: a failure routes to a full re-compile
+ * rather than being mistaken for "spec uses inline data" and dropped. The
+ * three-state input comes from `VegaViewServices.getDatasetPresence`.
+ */
+export const resolveDataChangeAction = (
+    datasetPresence: 'present' | 'absent' | 'error',
+    enableIncrementalDataUpdates: boolean,
+    rowCount: number,
+    effectiveThreshold: number
+): DataChangeAction => {
+    if (datasetPresence === 'absent') {
+        return 'ignore';
+    }
+    if (
+        datasetPresence === 'error' ||
+        !enableIncrementalDataUpdates ||
+        rowCount > effectiveThreshold
+    ) {
+        return 'recompile';
+    }
+    return 'incremental';
 };

--- a/packages/vega-runtime/src/lib/view/__tests__/service.test.ts
+++ b/packages/vega-runtime/src/lib/view/__tests__/service.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { View } from 'vega';
+import { logDebug } from '@deneb-viz/utils/logging';
+import { VegaViewServices } from '../service';
+
+// service.ts imports only `logDebug` from this module; stub it so we can assert
+// the internal debug-log sink is used and keep test output quiet.
+vi.mock('@deneb-viz/utils/logging', () => ({
+    logDebug: vi.fn()
+}));
+
+/**
+ * Minimal stand-in for a Vega `View`. Only the members the service touches are
+ * implemented; each test supplies just the behaviour it exercises.
+ */
+type FakeView = {
+    getState?: (opts: unknown) => unknown;
+    signal?: (name: string, value?: unknown) => unknown;
+    runAsync?: () => Promise<unknown>;
+    data?: (name: string, values?: unknown) => unknown;
+};
+
+const bindFakeView = (fake: FakeView) => {
+    VegaViewServices.bind(fake as unknown as View);
+};
+
+beforeEach(() => {
+    vi.mocked(logDebug).mockClear();
+});
+
+afterEach(() => {
+    VegaViewServices.clearView();
+});
+
+describe('VegaViewServices.setSignalByName (M6 — no floating runAsync)', () => {
+    it('does not set the signal or run the view when the signal does not exist', () => {
+        const signal = vi.fn();
+        const runAsync = vi.fn(() => Promise.resolve());
+        bindFakeView({ getState: () => ({ signals: {} }), signal, runAsync });
+
+        const result = VegaViewServices.setSignalByName('missing', 1);
+
+        expect(signal).not.toHaveBeenCalled();
+        expect(runAsync).not.toHaveBeenCalled();
+        expect(result).toBeUndefined();
+    });
+
+    it('sets the signal and runs the view when the signal exists (happy path, sink untouched)', async () => {
+        const signal = vi.fn();
+        const runAsync = vi.fn(() => Promise.resolve());
+        const onError = vi.fn();
+        bindFakeView({
+            getState: () => ({ signals: { mySignal: 0 } }),
+            signal,
+            runAsync
+        });
+
+        await VegaViewServices.setSignalByName('mySignal', 42, onError);
+
+        expect(signal).toHaveBeenCalledWith('mySignal', 42);
+        expect(runAsync).toHaveBeenCalledTimes(1);
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('routes a runAsync rejection to the onError sink and settles (nothing unhandled)', async () => {
+        const error = new Error('dataflow boom');
+        const onError = vi.fn();
+        bindFakeView({
+            getState: () => ({ signals: { mySignal: 0 } }),
+            signal: vi.fn(),
+            runAsync: () => Promise.reject(error)
+        });
+
+        // The returned promise resolving (not rejecting) proves the rejection
+        // was caught inside the service — no unhandled rejection escapes.
+        await expect(
+            VegaViewServices.setSignalByName('mySignal', 1, onError)
+        ).resolves.toBeUndefined();
+
+        expect(onError).toHaveBeenCalledWith(error);
+    });
+
+    it('swallows a runAsync rejection into the debug log when no sink is provided', async () => {
+        bindFakeView({
+            getState: () => ({ signals: { mySignal: 0 } }),
+            signal: vi.fn(),
+            runAsync: () => Promise.reject(new Error('dataflow boom'))
+        });
+
+        await expect(
+            VegaViewServices.setSignalByName('mySignal', 1)
+        ).resolves.toBeUndefined();
+
+        expect(vi.mocked(logDebug)).toHaveBeenCalled();
+    });
+});
+
+describe('VegaViewServices.getDatasetPresence (L3 — absent vs failed lookup)', () => {
+    it("returns 'error' when no view is bound", () => {
+        VegaViewServices.clearView();
+        expect(VegaViewServices.getDatasetPresence('dataset')).toBe('error');
+    });
+
+    it("returns 'present' when the view exposes the named dataset", () => {
+        bindFakeView({
+            getState: () => ({ data: { dataset: [{ a: 1 }], source_0: [] } })
+        });
+        expect(VegaViewServices.getDatasetPresence('dataset')).toBe('present');
+    });
+
+    it("returns 'absent' when the state read succeeds but the dataset is not present", () => {
+        bindFakeView({ getState: () => ({ data: { source_0: [] } }) });
+        expect(VegaViewServices.getDatasetPresence('dataset')).toBe('absent');
+    });
+
+    it("returns 'error' (not 'absent') when reading the view state throws", () => {
+        bindFakeView({
+            getState: () => {
+                throw new Error('corrupt view');
+            }
+        });
+        expect(VegaViewServices.getDatasetPresence('dataset')).toBe('error');
+    });
+});

--- a/packages/vega-runtime/src/lib/view/service.ts
+++ b/packages/vega-runtime/src/lib/view/service.ts
@@ -80,6 +80,46 @@ export const VegaViewServices = {
         }
     },
     /**
+     * Determine whether a named dataset is present in the current view,
+     * distinguishing a genuine absence from a failed lookup.
+     *
+     * `getDataByName` cannot make this distinction: it swallows every error
+     * (including the "Unrecognized data set" throw Vega raises for a name the
+     * spec never bound) and returns `undefined` in all of those cases as well
+     * as for a legitimately-absent dataset. Callers that must treat only a true
+     * absence as "ignore this data change" — and a real failure as "fall back
+     * to a re-compile" — use this instead of `getDataByName(name) === undefined`.
+     *
+     * Reads the view's data-source keys via `getState` (which lists the
+     * datasets that exist without throwing for an individual missing name), so
+     * an absence and a failure are cleanly separable:
+     * - `'present'` — the view exposes a dataset with this name.
+     * - `'absent'`  — reading the state succeeded and there is no such dataset
+     *   (e.g. the spec uses inline or remote data).
+     * - `'error'`   — no view is bound, or reading the view's state threw. The
+     *   caller must NOT treat this as a legitimate absence.
+     */
+    getDatasetPresence: (name: string): 'present' | 'absent' | 'error' => {
+        if (!view) {
+            return 'error';
+        }
+        try {
+            const data =
+                view.getState({
+                    data: truthy,
+                    signals: falsy,
+                    recurse: true
+                })?.data ?? {};
+            return name in data ? 'present' : 'absent';
+        } catch (error) {
+            logDebug(
+                `VegaViewServices.getDatasetPresence: Error checking dataset ${name}`,
+                { error }
+            );
+            return 'error';
+        }
+    },
+    /**
      * Get specified signal from view by name. Returns undefined if an error occurs.
      */
     getSignalByName: (name: string) => {
@@ -94,14 +134,36 @@ export const VegaViewServices = {
         }
     },
     /**
-     * Set specified signal in view by name. f it does not exist, it will not be set.
+     * Set specified signal in view by name. If it does not exist, it will not
+     * be set.
+     *
+     * Writing a signal re-runs the dataflow, which can reject (e.g. a stateful
+     * transform errors on the new value). That `runAsync()` promise must not be
+     * left floating — an unhandled rejection would surface nowhere useful. The
+     * rejection is always caught and logged at debug level here; when an
+     * `onError` sink is supplied by the caller it is also routed there so the
+     * failure can reach a user-facing channel (mirroring the dual-channel
+     * handling in `incremental-update.ts`). The already-handled promise is
+     * returned so callers/tests can await settling; existing two-argument
+     * callers are unaffected and default to the internal debug-log sink.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    setSignalByName: (name: string, value: any) => {
-        if (VegaViewServices.doesSignalNameExist(name)) {
-            view?.signal(name, value);
-            view?.runAsync();
+    setSignalByName: (
+        name: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        value: any,
+        onError?: (error: unknown) => void
+    ): Promise<unknown> | undefined => {
+        if (!VegaViewServices.doesSignalNameExist(name)) {
+            return undefined;
         }
+        view?.signal(name, value);
+        return view?.runAsync().catch((error) => {
+            logDebug(
+                `VegaViewServices.setSignalByName: Error running view after setting signal ${name}`,
+                { error }
+            );
+            onError?.(error);
+        });
     },
     /**
      * Obtain the current Vega view.


### PR DESCRIPTION
## What

Fixes audit findings **M7**, **M6**, **L3** (plan U8) — the incremental-update path and view-service error handling.

- **M7 — overlapping incremental updates corrupted the `view.error` chain.** `performIncrementalUpdate` installed a `view.error` override with blind capture-and-restore, but `viewReady` isn't toggled during an incremental update, so a second rapid Power BI update captured the *first's* override as "the original" and restored in the wrong order — leaving a stale override permanently installed, writing into a dead `internalErrorMessage` capture. Now serialized per-view via a `WeakSet` (skip-and-recompile on overlap — the overlapping update's data still renders through the existing recompile fallback, nothing dropped), and `view.error` is restored only when the current handler is still the one we installed (token check).
- **M6 — `setSignalByName` left its `runAsync()` promise floating**, so a dataflow rejection from a signal write surfaced nowhere. It now always catches + debug-logs, optionally routes to an `onError` sink, and returns the handled promise. The scroll-signal call site routes to `compilation.logError`; both call sites (scroll + viewport-resize) are now non-floating. Existing two-arg callers unaffected.
- **L3 — `getDataByName(...) === undefined` conflated "spec uses inline data" with "lookup failed"** (`getDataByName` swallows errors → `undefined` for both), silently dropping genuine-failure updates. New `getDatasetPresence` returns `present`/`absent`/`error` via `getState` (which lists datasets without throwing for a missing name); only `absent` is treated as ignore, `error` falls through to a full recompile.

## Tests

app-core 521→532, vega-runtime 227→235. The M7 overlap test is revert-validated (pre-fix: a second `runAsync` fires; post-fix: serialized). `npm run test` 7 tasks green; tsc clean; app-core boundaries canary green.

## Scope notes

- `vega-embed.tsx`'s `setSignalByName` caller (the viewport-resize effect) is outside U8's three-file scope, so it keeps its two-arg call — but it is now protected by the service's internal `.catch` (no longer floating). Only the in-scope scroll site gets the user-facing `compilation.logError` sink.
- The `present|absent|error` union is written inline in both files rather than a shared exported type, to avoid editing `view/index.ts`/`view/types.ts` (out of scope). A future dedup pass could hoist it.
- **Build note for CI/reviewers:** this changes `@deneb-viz/vega-runtime`'s public `view` surface (`getDatasetPresence`, `setSignalByName` signature), so app-core typecheck needs a fresh vega-runtime build — the CI pipeline builds packages, so this is a no-op there; local reviewers may need `npm run build --workspace=@deneb-viz/vega-runtime`.

Part of the 2026-07-03 audit remediation program (unit U8 of 18; U1–U7 in #687–#693).

🤖 Generated with [Claude Code](https://claude.com/claude-code)