### PR TITLE
chore(ci): gate gh pr create on ci:local via a Claude Code hook

### DIFF
--- a/.claude/hooks/ci-local-before-pr.js
+++ b/.claude/hooks/ci-local-before-pr.js
@@ -64,27 +64,29 @@ function isPrCreate(payload) {
         process.exit(0);
     }
 
+    process.stderr.write(
+        '[ci:local hook] Running `npm run ci:local` before proposing the PR. ' +
+            'This runs the full CI job (build -> eslint -> prettier -> tests -> ' +
+            'package) and can take several minutes; its output streams below. ' +
+            'Bypass with CI_LOCAL_HOOK_SKIP=1.\n'
+    );
+
     try {
-        execSync('npm run ci:local', {
-            cwd: repoRoot,
-            stdio: 'pipe',
-            maxBuffer: 64 * 1024 * 1024
-        });
-    } catch (err) {
-        const out = `${(err && err.stdout) || ''}${(err && err.stderr) || ''}`;
-        const tail = out.split(/\r?\n/).slice(-40).join('\n');
+        // stdio: 'inherit' streams the child's output live so progress is
+        // visible during the multi-minute run, rather than buffered until it
+        // exits. The failing step's output therefore appears as it happens.
+        execSync('npm run ci:local', { cwd: repoRoot, stdio: 'inherit' });
+    } catch {
         process.stderr.write(
-            'Blocked `gh pr create`: `npm run ci:local` failed. Fix the failures ' +
-                'below (or set CI_LOCAL_HOOK_SKIP=1 to bypass intentionally), then ' +
-                'propose the PR again.\n\n' +
-                tail +
-                '\n'
+            '\nBlocked `gh pr create`: `npm run ci:local` failed (see its output ' +
+                'above). Fix the failures, or set CI_LOCAL_HOOK_SKIP=1 to bypass ' +
+                'intentionally, then propose the PR again.\n'
         );
         process.exit(2);
     }
 
     process.stderr.write(
-        '[ci:local hook] local CI passed — proposing the PR.\n'
+        '\n[ci:local hook] local CI passed — proposing the PR.\n'
     );
     process.exit(0);
 })();

--- a/.claude/hooks/ci-local-before-pr.js
+++ b/.claude/hooks/ci-local-before-pr.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Claude Code PreToolUse hook (matcher: Bash).
+ *
+ * Before a `gh pr create` runs, execute the local CI check (`npm run ci:local` —
+ * the same steps as the GitHub `ci` job, run against `.env.ci`). If it fails,
+ * block the PR creation (exit 2) so problems are caught before the PR is
+ * proposed rather than on CI.
+ *
+ * Only `gh pr create` is gated; every other Bash command passes straight
+ * through (exit 0). Escapes:
+ *   - CI_LOCAL_HOOK_SKIP=1   bypass the check (e.g. an intentional draft PR)
+ *   - CI_LOCAL_HOOK_DRYRUN=1 decide-only, don't run ci:local (used by tests)
+ */
+const { execSync } = require('child_process');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function readStdin() {
+    return new Promise((resolve) => {
+        if (process.stdin.isTTY) {
+            resolve('');
+            return;
+        }
+        let data = '';
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', (chunk) => (data += chunk));
+        process.stdin.on('end', () => resolve(data));
+        process.stdin.on('error', () => resolve(''));
+    });
+}
+
+function isPrCreate(payload) {
+    if ((payload.tool_name || '') !== 'Bash') return false;
+    const command = (payload.tool_input && payload.tool_input.command) || '';
+    return /\bgh\s+pr\s+create\b/.test(command);
+}
+
+(async () => {
+    let payload = {};
+    try {
+        payload = JSON.parse((await readStdin()) || '{}');
+    } catch {
+        // Malformed payload — never get in the way of the tool call.
+        process.exit(0);
+    }
+
+    if (!isPrCreate(payload)) {
+        process.exit(0);
+    }
+
+    if (process.env.CI_LOCAL_HOOK_SKIP === '1') {
+        process.stderr.write(
+            '[ci:local hook] CI_LOCAL_HOOK_SKIP=1 — skipping the local CI check.\n'
+        );
+        process.exit(0);
+    }
+
+    if (process.env.CI_LOCAL_HOOK_DRYRUN === '1') {
+        process.stderr.write(
+            '[ci:local hook] dry run — would run `npm run ci:local`.\n'
+        );
+        process.exit(0);
+    }
+
+    try {
+        execSync('npm run ci:local', {
+            cwd: repoRoot,
+            stdio: 'pipe',
+            maxBuffer: 64 * 1024 * 1024
+        });
+    } catch (err) {
+        const out = `${(err && err.stdout) || ''}${(err && err.stderr) || ''}`;
+        const tail = out.split(/\r?\n/).slice(-40).join('\n');
+        process.stderr.write(
+            'Blocked `gh pr create`: `npm run ci:local` failed. Fix the failures ' +
+                'below (or set CI_LOCAL_HOOK_SKIP=1 to bypass intentionally), then ' +
+                'propose the PR again.\n\n' +
+                tail +
+                '\n'
+        );
+        process.exit(2);
+    }
+
+    process.stderr.write(
+        '[ci:local hook] local CI passed — proposing the PR.\n'
+    );
+    process.exit(0);
+})();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "node .claude/hooks/ci-local-before-pr.js",
+                        "timeout": 900
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/bin/ci-local.js
+++ b/bin/ci-local.js
@@ -89,4 +89,15 @@ if (failed) {
     process.exit(1);
 } else {
     log('CI LOCAL: ALL CHECKS PASSED');
+    console.log(
+        [
+            '',
+            'Note: the Prettier step ran with --end-of-line auto, but remote CI',
+            'uses endOfLine: lf. A file committed with CRLF passes here yet fails',
+            'CI, so ci:local can go green while CI goes red on the same change.',
+            'The repo .gitattributes normalizes to LF on commit, so this is rare —',
+            'but if CI fails on Prettier alone, check the committed line endings',
+            '(git add --renormalize <file>).'
+        ].join('\n')
+    );
 }

--- a/bin/ci-local.js
+++ b/bin/ci-local.js
@@ -24,7 +24,14 @@ const steps = [
         cmd: 'npm run validate-config-for-commit'
     },
     { name: 'Linting Checks', cmd: 'npm run eslint' },
-    { name: 'Prettier Checks', cmd: 'npm run prettier-check' },
+    // --end-of-line auto so this matches CI's post-normalization result: git
+    // stores/checks out LF (CI), but a Windows working tree may hold CRLF, which
+    // the strict `prettier-check` (endOfLine: lf) would flag as false failures.
+    // This still catches real content-formatting drift.
+    {
+        name: 'Prettier Checks',
+        cmd: 'npm run prettier-check -- --end-of-line auto'
+    },
     { name: 'Tests', cmd: 'npm run test' },
     {
         name: 'Confirm pbiviz package (AppSource Version)',


### PR DESCRIPTION
## Gate `gh pr create` on `ci:local` (Claude Code hook)

Motivated by PR #695, which passed a local ad-hoc gate but failed CI (a new suite loaded a transitive ESM graph that CI's Node rejects). This adds an automatic local-CI gate before PRs are proposed.

### What
- **`.claude/settings.json` + `.claude/hooks/ci-local-before-pr.js`** — a Claude Code `PreToolUse` hook (matcher `Bash`) that, before any `gh pr create`, runs `npm run ci:local` and blocks the PR (exit 2) if it fails. Every other Bash command passes straight through. Bypass an intentional draft with `CI_LOCAL_HOOK_SKIP=1`.
- **`bin/ci-local.js`** — the prettier step now runs with `--end-of-line auto`, so it matches CI's post-normalization (LF) result instead of false-failing on Windows working trees that hold CRLF (which otherwise made `ci:local` red as a gate).

### Verification
- Hook decision logic checked: matches `gh pr create`, ignores `gh pr view` / non-Bash, honors skip/dry-run.
- `npm run ci:local` runs green end-to-end locally (build, validate-packages-sync, validate-config, eslint, prettier, test, package; `.env` swapped to `.env.ci` and restored).

### Note
This is a **Claude Code** hook, not a git hook, and mirrors the CI `ci` job. Caveat: local Node is 24 vs CI's Node 22, so `ci:local` can't reproduce Node-version-specific ESM failures — the fix for those stays "isolate `@deneb-viz/app-core` imports with `vi.mock`."

🤖 Generated with [Claude Code](https://claude.com/claude-code)