### PR TITLE
fix(logging): fail-closed LOG_LEVEL + fail-loud validator; gate logHeading and legacy warning (U10)

### DIFF
--- a/bin/__test__/config-validation.test.ts
+++ b/bin/__test__/config-validation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { collectConfigErrors } from '../config-validation';
+
+const env = (
+    overrides: Record<string, string | undefined>
+): NodeJS.ProcessEnv => overrides as NodeJS.ProcessEnv;
+
+const hasLogLevelError = (errors: string[]) =>
+    errors.some((e) => /LOG_LEVEL/.test(e));
+
+describe('collectConfigErrors — LOG_LEVEL (M14 fail-loud)', () => {
+    it('errors when LOG_LEVEL is absent', () => {
+        const errors = collectConfigErrors(env({ LOG_LEVEL: undefined }));
+        expect(errors.some((e) => /LOG_LEVEL is not set/.test(e))).toBe(true);
+    });
+
+    it('errors when LOG_LEVEL is empty / whitespace', () => {
+        expect(
+            collectConfigErrors(env({ LOG_LEVEL: '' })).some((e) =>
+                /LOG_LEVEL is not set/.test(e)
+            )
+        ).toBe(true);
+        expect(
+            collectConfigErrors(env({ LOG_LEVEL: '   ' })).some((e) =>
+                /LOG_LEVEL is not set/.test(e)
+            )
+        ).toBe(true);
+    });
+
+    it('passes an unrecognized value (resolves to 0; runtime falls closed to NONE)', () => {
+        const errors = collectConfigErrors(env({ LOG_LEVEL: 'abc' }));
+        expect(hasLogLevelError(errors)).toBe(false);
+    });
+
+    it('errors when LOG_LEVEL is a non-zero level', () => {
+        const errors = collectConfigErrors(env({ LOG_LEVEL: '20' }));
+        expect(errors.some((e) => /resolved 20/.test(e))).toBe(true);
+    });
+
+    it('passes when LOG_LEVEL is 0 or a NONE synonym', () => {
+        for (const value of ['0', 'NONE', 'OFF', 'SILENT']) {
+            expect(
+                hasLogLevelError(collectConfigErrors(env({ LOG_LEVEL: value })))
+            ).toBe(false);
+        }
+    });
+});
+
+describe('collectConfigErrors — dev toggles and external URIs', () => {
+    const safe = { LOG_LEVEL: '0' };
+
+    it('is clean for a certified-safe baseline', () => {
+        expect(collectConfigErrors(env(safe))).toEqual([]);
+    });
+
+    it('flags each enabled dev toggle', () => {
+        expect(
+            collectConfigErrors(env({ ...safe, PBIVIZ_DEV_MODE: 'true' })).some(
+                (e) => /PBIVIZ_DEV_MODE/.test(e)
+            )
+        ).toBe(true);
+        expect(
+            collectConfigErrors(
+                env({ ...safe, ZUSTAND_DEV_TOOLS: 'true' })
+            ).some((e) => /ZUSTAND_DEV_TOOLS/.test(e))
+        ).toBe(true);
+    });
+
+    it('rejects ALLOW_EXTERNAL_URI unless packaging mode is standalone', () => {
+        expect(
+            collectConfigErrors(
+                env({ ...safe, ALLOW_EXTERNAL_URI: 'true' })
+            ).some((e) => /ALLOW_EXTERNAL_URI/.test(e))
+        ).toBe(true);
+        expect(
+            collectConfigErrors(
+                env({
+                    ...safe,
+                    ALLOW_EXTERNAL_URI: 'true',
+                    DENEB_PACKAGE_MODE: 'standalone'
+                })
+            ).some((e) => /ALLOW_EXTERNAL_URI/.test(e))
+        ).toBe(false);
+    });
+});

--- a/bin/config-validation.ts
+++ b/bin/config-validation.ts
@@ -1,0 +1,73 @@
+import { parseLogLevel } from '@deneb-viz/utils/logging';
+import { toBoolean } from '@deneb-viz/utils/type-conversion';
+
+/**
+ * Pure configuration validation for the commit/packaging gate. Given an
+ * environment-like object, returns the list of issues that must be resolved
+ * before a certified baseline can be committed/packaged (empty = all good).
+ *
+ * Kept free of I/O and `process`/`exit` side effects so it is unit-testable
+ * across `.env` permutations; the CLI wrapper (`validate-config-for-commit.ts`)
+ * supplies `process.env` and handles printing + exit codes.
+ */
+export const collectConfigErrors = (env: NodeJS.ProcessEnv): string[] => {
+    const errors: string[] = [];
+    const mode = env.DENEB_PACKAGE_MODE;
+    // External URIs are permitted only for the standalone packaging mode.
+    const allowExternalUri = mode === 'standalone';
+
+    // Dev-only toggles: must never be enabled in committed/certified code.
+    if (toBoolean(env.ZUSTAND_DEV_TOOLS)) {
+        errors.push(
+            '❌ .env ZUSTAND_DEV_TOOLS flag is true; this should be false.'
+        );
+    }
+    if (toBoolean(env.PBIVIZ_DEV_MODE)) {
+        errors.push(
+            '❌ .env PBIVIZ_DEV_MODE flag is true; this should be false.'
+        );
+    }
+    if (toBoolean(env.PBIVIZ_DEV_OVERLAY)) {
+        errors.push(
+            '❌ .env PBIVIZ_DEV_OVERLAY flag is true; this should be false.'
+        );
+    }
+    if (toBoolean(env.PBIVIZ_VIEWPORT_GATE_OVERLAY)) {
+        errors.push(
+            '❌ .env PBIVIZ_VIEWPORT_GATE_OVERLAY flag is true; this should be false.'
+        );
+    }
+    if (toBoolean(env.PBIVIZ_DEV_FORCE_READ_MODE)) {
+        errors.push(
+            '❌ .env PBIVIZ_DEV_FORCE_READ_MODE flag is true; this should be false.'
+        );
+    }
+
+    // Log level (M14): must be present AND resolve to 0 (NONE). Absent/empty
+    // fails loud so a certified build can never rely on the runtime fallback.
+    // An explicit non-zero level fails too. An unrecognized value resolves to
+    // the 0 fallback and passes here — which is safe, because the runtime also
+    // falls closed to NONE for garbage, so no logging can ship regardless.
+    const logLevelRaw = env.LOG_LEVEL;
+    if (logLevelRaw === undefined || logLevelRaw.trim() === '') {
+        errors.push(
+            '❌ .env LOG_LEVEL is not set; it must be explicitly set to 0 (NONE) for committed baselines.'
+        );
+    } else {
+        const level = parseLogLevel(logLevelRaw, 0);
+        if (level !== 0) {
+            errors.push(
+                `❌ .env LOG_LEVEL is "${logLevelRaw}" (resolved ${level}); this must be 0 (NONE).`
+            );
+        }
+    }
+
+    // External URIs: not permitted in a certified visual; standalone only.
+    if (toBoolean(env.ALLOW_EXTERNAL_URI) && !allowExternalUri) {
+        errors.push(
+            '❌ .env ALLOW_EXTERNAL_URI flag is true; this should be false.'
+        );
+    }
+
+    return errors;
+};

--- a/bin/validate-config-for-commit.ts
+++ b/bin/validate-config-for-commit.ts
@@ -1,63 +1,10 @@
 import '@dotenvx/dotenvx/config';
 import { exit } from 'process';
-import { parseLogLevel } from '@deneb-viz/utils/logging';
-import { toBoolean } from '@deneb-viz/utils/type-conversion';
+import { collectConfigErrors } from './config-validation';
 
 console.log('Checking visual configuration is correct...\n');
-const MODE = process.env.DENEB_PACKAGE_MODE;
-const LOG_LEVEL = parseLogLevel(process.env.LOG_LEVEL, 0);
-const REDUX_DEV_TOOLS = toBoolean(process.env.ZUSTAND_DEV_TOOLS);
-const PBIVIZ_DEV_MODE = toBoolean(process.env.PBIVIZ_DEV_MODE);
-const PBIVIZ_DEV_OVERLAY = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
-const PBIVIZ_VIEWPORT_GATE_OVERLAY = toBoolean(
-    process.env.PBIVIZ_VIEWPORT_GATE_OVERLAY
-);
-const PBIVIZ_DEV_FORCE_READ_MODE = toBoolean(
-    process.env.PBIVIZ_DEV_FORCE_READ_MODE
-);
-const ALLOW_EXTERNAL_URI = toBoolean(process.env.ALLOW_EXTERNAL_URI);
-const allowExternalUri = MODE === 'standalone';
-const errors: string[] = [];
 
-// Redux dev tools: Should not be set in committed code
-if (REDUX_DEV_TOOLS) {
-    errors.push(
-        '❌ .env ZUSTAND_DEV_TOOLS flag is true; this should be false.'
-    );
-}
-// PBI Developer mode: Should not be set in committed code
-if (PBIVIZ_DEV_MODE) {
-    errors.push('❌ .env PBIVIZ_DEV_MODE flag is true; this should be false.');
-}
-// PBI Developer overlay: Should not be set in committed code
-if (PBIVIZ_DEV_OVERLAY) {
-    errors.push(
-        '❌ .env PBIVIZ_DEV_OVERLAY flag is true; this should be false.'
-    );
-}
-// Viewport-gate debug overlay: Should not be set in committed code
-if (PBIVIZ_VIEWPORT_GATE_OVERLAY) {
-    errors.push(
-        '❌ .env PBIVIZ_VIEWPORT_GATE_OVERLAY flag is true; this should be false.'
-    );
-}
-// Dev force-read-mode override: only for local read-mode persist-gate
-// testing — never ship a build that pretends every update is read mode.
-if (PBIVIZ_DEV_FORCE_READ_MODE) {
-    errors.push(
-        '❌ .env PBIVIZ_DEV_FORCE_READ_MODE flag is true; this should be false.'
-    );
-}
-// Log level: should be 0 (NONE) in committed code
-if (LOG_LEVEL !== 0) {
-    errors.push(`❌ .env LOG_LEVEL is ${LOG_LEVEL}; this should be 0 (NONE).`);
-}
-// External URIs: Not permitted in certified visual; allowed only for standalone packaging mode
-if (ALLOW_EXTERNAL_URI && !allowExternalUri) {
-    errors.push(
-        '❌ .env ALLOW_EXTERNAL_URI flag is true; this should be false.'
-    );
-}
+const errors = collectConfigErrors(process.env);
 
 if (errors.length > 0) {
     console.error(

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -232,7 +232,7 @@ Retention policy: Remove stale flags + tests in the next minor/major release aft
 
 ## 7. Logging & Diagnostics
 
-Logging utilities live under `src/features/logging`. The active log level is set via the `LOG_LEVEL` environment variable in your local `.env` (loaded by `@dotenvx/dotenvx`) using numeric thresholds (see table below). In packaged/certified visuals, the level is forced to `None` to avoid telemetry noise and is guarded by the commit validation script.
+Logging utilities live in `@deneb-viz/utils` (`packages/utils/src/lib/logging.ts`). The active log level is set via the `LOG_LEVEL` environment variable in your local `.env` (loaded by `@dotenvx/dotenvx`) using numeric thresholds (see table below). Set it explicitly: if `LOG_LEVEL` is absent, empty, or unrecognized, the runtime **fails closed to `None`** (no console output) rather than defaulting to `Info`, so you must set a level to see any logs. For a committed/certified baseline the value must be pinned to `0` (`None`), and the commit validation script **fails loud** if it is missing or non-zero — logging can never be enabled by omission.
 
 | Level | Name   | Typical Use                                             |
 | ----- | ------ | ------------------------------------------------------- |
@@ -257,7 +257,7 @@ ZUSTAND_DEV_TOOLS=true  # Enable Redux/Zustand devtools integration
 PBIVIZ_DEV_MODE=false   # Disable PBIVIZ developer-only behaviors
 ```
 
-Validation: `npm run validate-config-for-commit` loads `.env` and fails if `LOG_LEVEL` is non-zero for committed baselines or if dev-only toggles are enabled in non-standalone packaging.
+Validation: `npm run validate-config-for-commit` loads `.env` and fails if `LOG_LEVEL` is **missing or non-zero** for committed baselines, or if dev-only toggles are enabled in non-standalone packaging. (`ci:local` and CI run this against `.env.ci`, which pins `LOG_LEVEL=NONE`.)
 
 ## 8. Production Packaging
 

--- a/packages/utils/src/lib/__tests__/logging.test.ts
+++ b/packages/utils/src/lib/__tests__/logging.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { parseLogLevel } from '../logging';
+
+describe('parseLogLevel', () => {
+    it('returns a finite number input as-is', () => {
+        expect(parseLogLevel(11, -1)).toBe(11);
+        expect(parseLogLevel(0, -1)).toBe(0);
+    });
+
+    it('parses numeric strings', () => {
+        expect(parseLogLevel('20', -1)).toBe(20);
+        expect(parseLogLevel('0', -1)).toBe(0);
+    });
+
+    it('parses recognized level names (case-insensitive) and NONE synonyms', () => {
+        expect(parseLogLevel('INFO', -1)).toBe(3);
+        expect(parseLogLevel('info', -1)).toBe(3);
+        expect(parseLogLevel('NONE', -1)).toBe(0);
+        expect(parseLogLevel('off', -1)).toBe(0);
+        expect(parseLogLevel('SILENT', -1)).toBe(0);
+    });
+
+    it('returns the fallback for absent, empty, or unrecognized input', () => {
+        expect(parseLogLevel(undefined, -1)).toBe(-1);
+        expect(parseLogLevel('', -1)).toBe(-1);
+        expect(parseLogLevel('abc', -1)).toBe(-1);
+        expect(parseLogLevel(NaN, -1)).toBe(-1);
+    });
+});
+
+// The module-level LOG_LEVEL is resolved once at import time from
+// process.env.LOG_LEVEL, so these re-import the module under a stubbed env.
+describe('runtime LOG_LEVEL fail-closed (M14) + logHeading gate (L6)', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+        vi.restoreAllMocks();
+    });
+
+    const loadWith = async (logLevel: string) => {
+        vi.stubEnv('LOG_LEVEL', logLevel);
+        vi.resetModules();
+        return import('../logging');
+    };
+
+    it('emits nothing when LOG_LEVEL is empty (falls closed to NONE, not INFO)', async () => {
+        const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+        const { logInfo, logDebug } = await loadWith('');
+        logInfo('x');
+        logDebug('y');
+        expect(info).not.toHaveBeenCalled();
+        expect(debug).not.toHaveBeenCalled();
+    });
+
+    it('emits nothing when LOG_LEVEL is an unrecognized value', async () => {
+        const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const { logInfo } = await loadWith('abc');
+        logInfo('x');
+        expect(info).not.toHaveBeenCalled();
+    });
+
+    it('emits at an explicit level (positive control)', async () => {
+        const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const { logInfo } = await loadWith('INFO');
+        logInfo('x');
+        expect(info).toHaveBeenCalled();
+    });
+
+    it('logHeading is silent at NONE (L6)', async () => {
+        const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const { logHeading } = await loadWith('NONE');
+        logHeading('title');
+        expect(info).not.toHaveBeenCalled();
+    });
+
+    it('logHeading prints at INFO (L6)', async () => {
+        const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const { logHeading } = await loadWith('INFO');
+        logHeading('title');
+        expect(info).toHaveBeenCalled();
+    });
+});

--- a/packages/utils/src/lib/logging.ts
+++ b/packages/utils/src/lib/logging.ts
@@ -55,7 +55,14 @@ export const parseLogLevel = (input: unknown, fallback: LogLevel): LogLevel => {
     return fallback;
 };
 
-const DEFAULT_LOG_LEVEL = LogLevel.INFO;
+/**
+ * Fail-closed default (M14): when `LOG_LEVEL` is absent, empty, or an
+ * unrecognized value, logging is OFF rather than defaulting to INFO. A build
+ * that ships without an explicit `LOG_LEVEL` therefore emits nothing; the
+ * packaging validator separately fails loud so the value is always pinned
+ * explicitly for certified baselines.
+ */
+const DEFAULT_LOG_LEVEL = LogLevel.NONE;
 
 const LOG_LEVEL: LogLevel = parseLogLevel(
     process.env?.['LOG_LEVEL'],
@@ -130,13 +137,17 @@ const getPaddedImportance = (level: LogLevel) => {
 };
 
 /**
- * Special method to provide decorated log entries in the console.
+ * Special method to provide decorated log entries in the console. Gated at INFO
+ * (L6) so it honours `LOG_LEVEL` like every other log call — a certified build
+ * (`LOG_LEVEL=NONE`) emits no heading banner.
  */
-export const logHeading = (message: string, size = 20) =>
+export const logHeading = (message: string, size = 20) => {
+    if (LOG_LEVEL < LogLevel.INFO) return;
     console.info(
         `%c${message}`,
         `font-family: Segoe UI, wf_segoe-ui_normal, helvetica, arial, sans-serif; font-size:${size}px; font-weight:600`
     );
+};
 
 /**
  * Debug-level logging to the console.

--- a/packages/vega-runtime/src/lib/signals/__tests__/migration.test.ts
+++ b/packages/vega-runtime/src/lib/signals/__tests__/migration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Spy on the gated logWarning without losing the rest of the logging surface,
 // so the once-per-session latch can be asserted by call count (L7/L12).
@@ -11,10 +11,8 @@ vi.mock('@deneb-viz/utils/logging', async (importOriginal) => {
 import {
     replaceLegacySignalReferences,
     hasLegacySignalReferences,
-    logLegacySignalWarning,
     type SignalMigrationResult
 } from '../migration';
-import { logWarning } from '@deneb-viz/utils/logging';
 import {
     SIGNAL_DENEB_CONTAINER,
     SIGNAL_PBI_CONTAINER_LEGACY
@@ -374,16 +372,29 @@ describe('Signal Migration Integration', () => {
 });
 
 describe('logLegacySignalWarning (L7/L12)', () => {
+    // The once-per-session guard is module-level state (migration.ts). Reload
+    // the module before each test so the latch always starts un-issued — the
+    // call-count assertion must not silently depend on this being the only
+    // test in the block that invokes the function.
+    let logLegacySignalWarning: (replacementCount: number) => void;
+    let logWarning: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        // Re-acquire both from the same freshly-reset module graph so the mock
+        // that migration closes over is the one asserted on. The factory
+        // re-runs on each reset, yielding a fresh vi.fn() per test.
+        logWarning = (await import('@deneb-viz/utils/logging'))
+            .logWarning as unknown as ReturnType<typeof vi.fn>;
+        ({ logLegacySignalWarning } = await import('../migration'));
+    });
+
     it('routes through the gated logWarning and warns at most once per session', () => {
-        // The latch is module state; this is the only test that calls it, so it
-        // starts un-issued. Three calls must produce exactly one warning.
         logLegacySignalWarning(2);
         logLegacySignalWarning(3);
         logLegacySignalWarning(1);
 
         expect(logWarning).toHaveBeenCalledTimes(1);
-        expect(vi.mocked(logWarning).mock.calls[0][0]).toContain(
-            "'pbiContainer'"
-        );
+        expect(logWarning.mock.calls[0][0]).toContain("'pbiContainer'");
     });
 });

--- a/packages/vega-runtime/src/lib/signals/__tests__/migration.test.ts
+++ b/packages/vega-runtime/src/lib/signals/__tests__/migration.test.ts
@@ -1,10 +1,24 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// Spy on the gated logWarning without losing the rest of the logging surface,
+// so the once-per-session latch can be asserted by call count (L7/L12).
+vi.mock('@deneb-viz/utils/logging', async (importOriginal) => {
+    const actual =
+        await importOriginal<typeof import('@deneb-viz/utils/logging')>();
+    return { ...actual, logWarning: vi.fn() };
+});
+
 import {
     replaceLegacySignalReferences,
     hasLegacySignalReferences,
+    logLegacySignalWarning,
     type SignalMigrationResult
 } from '../migration';
-import { SIGNAL_DENEB_CONTAINER, SIGNAL_PBI_CONTAINER_LEGACY } from '../deneb-container';
+import { logWarning } from '@deneb-viz/utils/logging';
+import {
+    SIGNAL_DENEB_CONTAINER,
+    SIGNAL_PBI_CONTAINER_LEGACY
+} from '../deneb-container';
 
 describe('replaceLegacySignalReferences', () => {
     it('should replace single legacy signal reference', () => {
@@ -14,7 +28,8 @@ describe('replaceLegacySignalReferences', () => {
             ]
         }`;
 
-        const result: SignalMigrationResult = replaceLegacySignalReferences(spec);
+        const result: SignalMigrationResult =
+            replaceLegacySignalReferences(spec);
 
         expect(result.spec).toContain(SIGNAL_DENEB_CONTAINER);
         expect(result.spec).not.toContain(SIGNAL_PBI_CONTAINER_LEGACY);
@@ -284,7 +299,9 @@ describe('Signal Migration Integration', () => {
         }`;
 
         const firstMigration = replaceLegacySignalReferences(spec);
-        const secondMigration = replaceLegacySignalReferences(firstMigration.spec);
+        const secondMigration = replaceLegacySignalReferences(
+            firstMigration.spec
+        );
 
         expect(firstMigration.hadLegacyReferences).toBe(true);
         expect(secondMigration.hadLegacyReferences).toBe(false);
@@ -353,5 +370,20 @@ describe('Signal Migration Integration', () => {
 
         const parsed = JSON.parse(result.spec);
         expect(parsed.signals[0].name).toBe(SIGNAL_DENEB_CONTAINER);
+    });
+});
+
+describe('logLegacySignalWarning (L7/L12)', () => {
+    it('routes through the gated logWarning and warns at most once per session', () => {
+        // The latch is module state; this is the only test that calls it, so it
+        // starts un-issued. Three calls must produce exactly one warning.
+        logLegacySignalWarning(2);
+        logLegacySignalWarning(3);
+        logLegacySignalWarning(1);
+
+        expect(logWarning).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(logWarning).mock.calls[0][0]).toContain(
+            "'pbiContainer'"
+        );
     });
 });

--- a/packages/vega-runtime/src/lib/signals/migration.ts
+++ b/packages/vega-runtime/src/lib/signals/migration.ts
@@ -1,3 +1,4 @@
+import { logWarning } from '@deneb-viz/utils/logging';
 import {
     SIGNAL_DENEB_CONTAINER,
     SIGNAL_PBI_CONTAINER_LEGACY,
@@ -73,7 +74,10 @@ export const replaceLegacySignalReferences = (
     const heightMatches = migratedSpec.match(heightPattern);
     if (heightMatches) {
         totalReplacementCount += heightMatches.length;
-        migratedSpec = migratedSpec.replace(heightPattern, containerRefs.height);
+        migratedSpec = migratedSpec.replace(
+            heightPattern,
+            containerRefs.height
+        );
     }
 
     // Migration 3: pbiContainer → denebContainer (the main signal object)
@@ -98,13 +102,22 @@ export const replaceLegacySignalReferences = (
 };
 
 /**
- * Log a deprecation warning when legacy signal references are detected.
- * Should be called once per parsing session when migration occurs.
+ * Latch so the legacy-signal deprecation warning is emitted at most once per
+ * session, matching this function's contract (L12).
+ */
+let legacySignalWarningIssued = false;
+
+/**
+ * Log a deprecation warning when legacy signal references are detected. Routed
+ * through the gated `logWarning` (L7) so it honours `LOG_LEVEL`, and latched so
+ * it fires only once per session (L12) no matter how many specs are parsed.
  *
  * @param replacementCount Number of replacements made
  */
 export const logLegacySignalWarning = (replacementCount: number) => {
-    console.warn(
+    if (legacySignalWarningIssued) return;
+    legacySignalWarningIssued = true;
+    logWarning(
         `[Deneb Migration] Deprecated signal 'pbiContainer' detected (${replacementCount} reference${replacementCount === 1 ? '' : 's'}). ` +
             `This has been automatically replaced with 'denebContainer'. ` +
             `Please update your specification to use 'denebContainer' instead. ` +

--- a/packages/vega-runtime/src/lib/spec-processing/__tests__/parse.test.ts
+++ b/packages/vega-runtime/src/lib/spec-processing/__tests__/parse.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
+
+// Spy on the legacy-signal deprecation warning without disabling the real
+// migration. The warning is gated + latched (covered by the signals migration
+// suite); here we only assert that parseSpec invokes it.
+vi.mock('../../signals', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../signals')>();
+    return { ...actual, logLegacySignalWarning: vi.fn() };
+});
+
 import { parseSpec, validateSpec, compileCleanVgSpec } from '../parse';
-import { SIGNAL_DENEB_CONTAINER } from '../../signals';
+import { SIGNAL_DENEB_CONTAINER, logLegacySignalWarning } from '../../signals';
 
 describe('parseSpec', () => {
     it('should parse valid Vega spec', () => {
@@ -154,7 +163,8 @@ describe('parseSpec', () => {
     });
 
     it('should return error for invalid JSON in config', () => {
-        const spec = '{"$schema": "https://vega.github.io/schema/vega/v5.json", "marks": []}';
+        const spec =
+            '{"$schema": "https://vega.github.io/schema/vega/v5.json", "marks": []}';
         const invalidConfig = '{"mark": invalid}';
 
         const result = parseSpec({
@@ -332,8 +342,8 @@ describe('parseSpec', () => {
         expect(result.errors).toHaveLength(0);
     });
 
-    it('should log warning for legacy pbiContainer references', () => {
-        // Spec with pbiContainer signal name
+    it('invokes the legacy-signal deprecation warning when migrating pbiContainer references', () => {
+        // Spec with a legacy pbiContainer reference (in the description).
         const spec = `{
             "$schema": "https://vega.github.io/schema/vega/v5.json",
             "width": 400,
@@ -341,28 +351,24 @@ describe('parseSpec', () => {
             "signals": [{"name": "customSignal", "value": 1}],
             "marks": []
         }`;
-
-        // Add a legacy reference in a comment-like area (description)
         const specWithLegacy = spec.replace(
             '"width"',
             '"description": "Uses pbiContainer signal", "width"'
         );
 
-        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
+        // Isolate this parse's call from any earlier legacy-spec test (the spy
+        // is module-scoped for the file).
+        vi.mocked(logLegacySignalWarning).mockClear();
 
         parseSpec({
             spec: specWithLegacy,
             provider: 'vega'
         });
 
-        expect(consoleWarnSpy).toHaveBeenCalled();
-        const warningCall = consoleWarnSpy.mock.calls.find((call) =>
-            call[0].includes('pbiContainer')
-        );
-        expect(warningCall).toBeDefined();
-        expect(warningCall[0]).toContain('denebContainer');
-
-        consoleWarnSpy.mockRestore();
+        expect(logLegacySignalWarning).toHaveBeenCalledTimes(1);
+        expect(
+            vi.mocked(logLegacySignalWarning).mock.calls[0][0]
+        ).toBeGreaterThan(0);
     });
 
     it('should validate post-patch Vega-Lite spec via compilation', () => {

--- a/vitest.root.config.ts
+++ b/vitest.root.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
     test: {
         environment: 'jsdom',
-        include: ['src/**/__test__/**/*.test.ts']
+        include: [
+            'src/**/__test__/**/*.test.ts',
+            'bin/**/__test__/**/*.test.ts'
+        ]
     }
 });


### PR DESCRIPTION
## U10 — LOG_LEVEL drift closed + logging-gate consistency

Tenth unit of the audit remediation program; package-coupled to the 2.0 cut (lands before the first certified packaging run). Closes R2 (M14), R3 (L6, L7, L12), R9.

### Findings closed
- **M14 (fail-closed runtime + fail-loud packaging).** The runtime logger defaulted to `INFO` when `LOG_LEVEL` was absent/empty/unrecognized, so a build shipping without an explicit level would log. `DEFAULT_LOG_LEVEL` now flips to `NONE` — absent, empty, or garbage values emit nothing. The commit/packaging validator previously collapsed a *missing* `LOG_LEVEL` to `0` and passed it; it now **fails loud** on a missing (or non-zero) value, so a certified baseline can never enable logging by omission. `.env.ci` already pins `LOG_LEVEL=NONE`. Validation logic is extracted to a pure, unit-testable `bin/config-validation.ts`; `validate-config-for-commit.ts` is now a thin CLI. `package-alpha`/`package-beta` wiring untouched (R9).
- **L6.** `logHeading` bypassed the gate (direct `console.info`); now gated at `INFO`, so a certified build (`NONE`) prints no startup banner.
- **L7 + L12.** The legacy `pbiContainer` deprecation warning used a raw `console.warn` and fired per parse; it now routes through the gated `logWarning` and latches to once per session, matching its documented contract.

### Tests
- **utils logging**: `parseLogLevel` matrix, runtime fail-closed (empty/garbage → no output), `logHeading` gating.
- **vega-runtime migration**: once-per-session latch. The pre-existing `parse.test.ts` legacy-warning test is updated from asserting a raw `console.warn` (message as arg 0) to asserting `parseSpec` invokes the now gated + latched warning — the old shape is incompatible with the gated logger.
- **bin validator**: fixture matrix — absent / empty / garbage / `0` / `NONE` synonyms / non-zero, plus dev toggles and `ALLOW_EXTERNAL_URI` standalone-vs-certified. Root vitest now includes `bin/**/__test__`.
- `docs/DEVELOPMENT.md` documents the explicit `LOG_LEVEL` requirement.

### Verification
`npm run ci:local` green end-to-end (build, validate-packages-sync, validate-config, eslint, prettier, test, **package** against `.env.ci`). It caught a ts-node-only type error first (bin scripts type-check through ts-node, not root tsc or vitest's esbuild transpile) — precisely the gate the new ci:local hook enforces. Root suite 348 · utils 90 · vega-runtime 236 · eslint 0 errors.

### Note on garbage `LOG_LEVEL`
An unrecognized value (e.g. `abc`) resolves to `0` and passes the validator. That's deliberate and safe: the runtime also falls closed to `NONE` for garbage, so no logging can ship regardless. The validator's mandate (per the finding) is the *absent* case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)