### PR TITLE
fix(build): package-contract fixes + invariant canary pack (U11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18578,8 +18578,6 @@
                 "@deneb-viz/json-processing": "*",
                 "@deneb-viz/template-usermeta": "*",
                 "@deneb-viz/utils": "*",
-                "@deneb-viz/vega-react": "*",
-                "@deneb-viz/vega-runtime": "*",
                 "@fabric-msft/svg-icons": "^7.0.0",
                 "@monaco-editor/react": "^4.6.0",
                 "@uidotdev/usehooks": "^2.4.1",
@@ -18808,17 +18806,19 @@
             "version": "2.0.0",
             "license": "MIT",
             "devDependencies": {
-                "@deneb-viz/data-core": "*",
                 "@deneb-viz/eslint-config": "*",
-                "@deneb-viz/powerbi-compat": "*",
                 "@deneb-viz/typescript-config": "*",
-                "@deneb-viz/vega-runtime": "*",
                 "@types/node": "^22.15.33",
                 "concurrently": "^9.2.1",
                 "ts-json-schema-generator": "^2.4.0",
                 "tsx": "^4.20.3",
                 "typescript": "^5.6.2",
                 "vitest": "^3.2.4"
+            },
+            "peerDependencies": {
+                "@deneb-viz/data-core": "*",
+                "@deneb-viz/powerbi-compat": "*",
+                "@deneb-viz/vega-runtime": "*"
             }
         },
         "packages/typescript-config": {
@@ -18850,6 +18850,7 @@
                 "use-deep-compare-effect": "^1.8.1"
             },
             "devDependencies": {
+                "@deneb-viz/eslint-config": "*",
                 "@deneb-viz/typescript-config": "*",
                 "@testing-library/dom": "^10.4.0",
                 "@testing-library/jest-dom": "^6.6.3",

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -58,8 +58,6 @@
         "@deneb-viz/json-processing": "*",
         "@deneb-viz/template-usermeta": "*",
         "@deneb-viz/utils": "*",
-        "@deneb-viz/vega-react": "*",
-        "@deneb-viz/vega-runtime": "*",
         "@fabric-msft/svg-icons": "^7.0.0",
         "@monaco-editor/react": "^4.6.0",
         "@uidotdev/usehooks": "^2.4.1",

--- a/packages/template-usermeta/package.json
+++ b/packages/template-usermeta/package.json
@@ -32,16 +32,18 @@
         "eslint": "node ../../bin/workspace-eslint.js"
     },
     "devDependencies": {
-        "@deneb-viz/data-core": "*",
         "@deneb-viz/eslint-config": "*",
-        "@deneb-viz/powerbi-compat": "*",
         "@deneb-viz/typescript-config": "*",
-        "@deneb-viz/vega-runtime": "*",
         "@types/node": "^22.15.33",
         "concurrently": "^9.2.1",
         "ts-json-schema-generator": "^2.4.0",
         "tsx": "^4.20.3",
         "typescript": "^5.6.2",
         "vitest": "^3.2.4"
+    },
+    "peerDependencies": {
+        "@deneb-viz/data-core": "*",
+        "@deneb-viz/powerbi-compat": "*",
+        "@deneb-viz/vega-runtime": "*"
     }
 }

--- a/packages/vega-react/eslint.config.js
+++ b/packages/vega-react/eslint.config.js
@@ -1,0 +1,4 @@
+import { config } from '@deneb-viz/eslint-config/base.js';
+
+/** @type {import("eslint").Linter.Config} */
+export default [...config];

--- a/packages/vega-react/package.json
+++ b/packages/vega-react/package.json
@@ -21,7 +21,8 @@
         "clean": "rimraf dist",
         "test": "vitest run --coverage",
         "test:watch": "vitest",
-        "typecheck": "tsc --noEmit"
+        "typecheck": "tsc --noEmit",
+        "eslint": "node ../../bin/workspace-eslint.js"
     },
     "peerDependencies": {
         "@deneb-viz/vega-runtime": "*",
@@ -34,6 +35,7 @@
         "use-deep-compare-effect": "^1.8.1"
     },
     "devDependencies": {
+        "@deneb-viz/eslint-config": "*",
         "@deneb-viz/typescript-config": "*",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.1.0",

--- a/src/__test__/invariants/_packages.ts
+++ b/src/__test__/invariants/_packages.ts
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Shared helpers for the invariant-canary suites. These read the monorepo's
+ * manifests/config off disk so documented package contracts can be asserted as
+ * CI failures rather than trusted as prose.
+ */
+
+/** Absolute path to the repository root (this file lives at src/__test__/invariants). */
+export const REPO_ROOT = join(__dirname, '..', '..', '..');
+
+/** Absolute path to the workspace `packages/` directory. */
+export const PACKAGES_DIR = join(REPO_ROOT, 'packages');
+
+interface Manifest {
+    name?: string;
+    scripts?: Record<string, string>;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+}
+
+export interface WorkspacePackage {
+    /** Directory name under packages/ (e.g. "vega-react"). */
+    dir: string;
+    /** Absolute path to the package directory. */
+    path: string;
+    /** Parsed package.json. */
+    manifest: Manifest;
+}
+
+/** Every immediate `packages/*` directory that contains a package.json. */
+export const listWorkspacePackages = (): WorkspacePackage[] =>
+    readdirSync(PACKAGES_DIR)
+        .map((dir) => ({ dir, path: join(PACKAGES_DIR, dir) }))
+        .filter(({ path }) => existsSync(join(path, 'package.json')))
+        .map(({ dir, path }) => ({
+            dir,
+            path,
+            manifest: JSON.parse(
+                readFileSync(join(path, 'package.json'), 'utf8')
+            ) as Manifest
+        }));
+
+/**
+ * A package ships code (as opposed to being a tooling/config-only package such
+ * as eslint-config or typescript-config) when it declares a `build` script.
+ */
+export const isCodePackage = (pkg: WorkspacePackage): boolean =>
+    Boolean(pkg.manifest.scripts?.build);

--- a/src/__test__/invariants/certification-and-build-invariants.test.ts
+++ b/src/__test__/invariants/certification-and-build-invariants.test.ts
@@ -29,6 +29,12 @@ describe('production `package` script ordering (audit R9)', () => {
             scripts: Record<string, string>;
         }
     ).scripts.package;
+    // Fail loud if the script is renamed/removed rather than let the indexOf
+    // checks below throw an opaque TypeError (mirrors the SAFETY_NET_BOUND_MS
+    // guard above).
+    if (!pkgScript) {
+        throw new Error('scripts.package not found in package.json');
+    }
 
     it('builds packages before running webpack', () => {
         expect(pkgScript.indexOf('build:package')).toBeGreaterThanOrEqual(0);

--- a/src/__test__/invariants/certification-and-build-invariants.test.ts
+++ b/src/__test__/invariants/certification-and-build-invariants.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { REPO_ROOT } from './_packages';
+
+/**
+ * Canary: certification and build-orchestration invariants that exist only as
+ * prose or as load-bearing strings inside scripts, where a well-meaning edit
+ * could silently break them (audit R6/R9).
+ */
+
+describe('safety-net bound is the certification ceiling', () => {
+    it('SAFETY_NET_BOUND_MS is present and <= 10_000ms', () => {
+        const source = readFileSync(join(REPO_ROOT, 'src', 'index.ts'), 'utf8');
+        const match = source.match(/SAFETY_NET_BOUND_MS\s*=\s*([\d_]+)/);
+        // Fail loud if the constant is renamed/removed rather than pass vacuously.
+        if (!match) {
+            throw new Error('SAFETY_NET_BOUND_MS not found in src/index.ts');
+        }
+        const value = Number(match[1].replace(/_/g, ''));
+        expect(value).toBeLessThanOrEqual(10_000);
+    });
+});
+
+describe('production `package` script ordering (audit R9)', () => {
+    const pkgScript = (
+        JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')) as {
+            scripts: Record<string, string>;
+        }
+    ).scripts.package;
+
+    it('builds packages before running webpack', () => {
+        expect(pkgScript.indexOf('build:package')).toBeGreaterThanOrEqual(0);
+        expect(pkgScript.indexOf('webpack:package')).toBeGreaterThan(
+            pkgScript.indexOf('build:package')
+        );
+    });
+
+    it('validates certification config before packaging', () => {
+        expect(pkgScript).toContain('validate-config-for-commit');
+        expect(pkgScript.indexOf('validate-config-for-commit')).toBeLessThan(
+            pkgScript.indexOf('webpack:package')
+        );
+    });
+});
+
+describe('dev-with-prime resets .tmp and drives turbo (audit R6)', () => {
+    const source = readFileSync(
+        join(REPO_ROOT, 'bin', 'dev-with-prime.js'),
+        'utf8'
+    );
+
+    it('wipes .tmp for a predictable dev start', () => {
+        expect(source).toMatch(/rmSync/);
+        expect(source).toContain('.tmp');
+    });
+
+    it('invokes turbo via `npx --no` so resolution is PATH-independent', () => {
+        expect(source).toContain('npx --no turbo');
+    });
+});

--- a/src/__test__/invariants/package-lint-coverage.test.ts
+++ b/src/__test__/invariants/package-lint-coverage.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { isCodePackage, listWorkspacePackages } from './_packages';
+
+/**
+ * Canary: every workspace package that ships code (has a `build` script) must
+ * be linted in CI. `turbo run eslint` only runs the task in packages that
+ * define it, so a package missing its `eslint` script or `eslint.config.js`
+ * silently drops out of the lint gate — exactly how @deneb-viz/vega-react went
+ * unlinted (audit U6 finding / handoff fact #9).
+ */
+const codePackages = listWorkspacePackages().filter(isCodePackage);
+
+describe('lint coverage', () => {
+    it('finds code packages (guards against a vacuous canary)', () => {
+        expect(codePackages.length).toBeGreaterThan(0);
+    });
+
+    it.each(codePackages)('$dir has an eslint script', (pkg) => {
+        expect(pkg.manifest.scripts?.eslint).toBeDefined();
+    });
+
+    it.each(codePackages)('$dir has an eslint.config.js', (pkg) => {
+        expect(existsSync(join(pkg.path, 'eslint.config.js'))).toBe(true);
+    });
+});

--- a/src/__test__/invariants/package-singleton-contract.test.ts
+++ b/src/__test__/invariants/package-singleton-contract.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { listWorkspacePackages } from './_packages';
+
+/**
+ * Canary: the `@deneb-viz/powerbi-compat` singleton contract (audit M15/L17).
+ *
+ * powerbi-compat must remain a single shared runtime instance (CLAUDE.md).
+ * Every workspace package that depends on it therefore declares it as a
+ * peerDependency — never a regular or dev dependency, which would let the
+ * package own a private copy — and every tsup-bundled consumer additionally
+ * lists it in `external` so esbuild does not inline it (tsup #998: peerDeps
+ * alone do not prevent bundling).
+ *
+ * Both halves broke silently in the wild: M15 (template-usermeta declared it as
+ * a devDependency) and L17 (app-core double-declared shared packages). This
+ * canary converts that class of drift into a CI failure.
+ */
+const SINGLETON = '@deneb-viz/powerbi-compat';
+
+const packages = listWorkspacePackages();
+
+// Packages that depend on powerbi-compat in any dependency map — the contract
+// applies to each. powerbi-compat itself is excluded (it can't peer-depend on
+// itself).
+const consumers = packages.filter(
+    (pkg) =>
+        pkg.manifest.name !== SINGLETON &&
+        [
+            pkg.manifest.dependencies,
+            pkg.manifest.devDependencies,
+            pkg.manifest.peerDependencies
+        ].some((deps) => deps && SINGLETON in deps)
+);
+
+describe('powerbi-compat singleton contract', () => {
+    it('is depended on by at least one package (guards against a vacuous canary)', () => {
+        expect(consumers.length).toBeGreaterThan(0);
+    });
+
+    it.each(consumers)(
+        '$dir declares powerbi-compat as a peerDependency only',
+        (pkg) => {
+            expect(pkg.manifest.peerDependencies?.[SINGLETON]).toBeDefined();
+            expect(pkg.manifest.dependencies?.[SINGLETON]).toBeUndefined();
+            expect(pkg.manifest.devDependencies?.[SINGLETON]).toBeUndefined();
+        }
+    );
+
+    it.each(
+        consumers.filter((pkg) => existsSync(join(pkg.path, 'tsup.config.ts')))
+    )('$dir (tsup-bundled) externalizes powerbi-compat', (pkg) => {
+        const tsup = readFileSync(join(pkg.path, 'tsup.config.ts'), 'utf8');
+        expect(tsup).toContain(`'${SINGLETON}'`);
+        expect(tsup).toContain(`'${SINGLETON}/*'`);
+    });
+});
+
+describe('no @deneb-viz package is double-declared (audit L17)', () => {
+    it.each(packages)(
+        '$dir lists no package in both dependencies and peerDependencies',
+        (pkg) => {
+            const deps = Object.keys(pkg.manifest.dependencies ?? {});
+            const peers = new Set(
+                Object.keys(pkg.manifest.peerDependencies ?? {})
+            );
+            expect(deps.filter((d) => peers.has(d))).toEqual([]);
+        }
+    );
+});

--- a/src/__test__/invariants/package-singleton-contract.test.ts
+++ b/src/__test__/invariants/package-singleton-contract.test.ts
@@ -53,8 +53,15 @@ describe('powerbi-compat singleton contract', () => {
         consumers.filter((pkg) => existsSync(join(pkg.path, 'tsup.config.ts')))
     )('$dir (tsup-bundled) externalizes powerbi-compat', (pkg) => {
         const tsup = readFileSync(join(pkg.path, 'tsup.config.ts'), 'utf8');
-        expect(tsup).toContain(`'${SINGLETON}'`);
-        expect(tsup).toContain(`'${SINGLETON}/*'`);
+        // Anchor to the `external` array and accept either quote style, so the
+        // check verifies placement (not a bare substring that a comment could
+        // satisfy) and survives a reformat between single/double quotes.
+        expect(tsup).toMatch(
+            /external\s*:\s*\[[\s\S]*?['"]@deneb-viz\/powerbi-compat['"]/
+        );
+        expect(tsup).toMatch(
+            /external\s*:\s*\[[\s\S]*?['"]@deneb-viz\/powerbi-compat\/\*['"]/
+        );
     });
 });
 


### PR DESCRIPTION
## U11 — Package-contract fixes + invariant canary pack

Converts the documented package contracts that had drifted silently (or existed only as prose) into CI failures, and closes the two manifest defects the audit found in the wild.

### Manifest fixes
- **M15** — `@deneb-viz/template-usermeta` declared `@deneb-viz/powerbi-compat` (which it imports) as a **devDependency**, letting it own a private copy of the singleton. Moved it — plus the other two type-only workspace imports it references (`data-core`, `vega-runtime`) — to `peerDependencies`, matching the peer-only pattern the other consumers already use.
- **L17** — `@deneb-viz/app-core` listed `vega-react` and `vega-runtime` in **both** `dependencies` and `peerDependencies`, contradicting the shared-instance intent. Kept only the peer entries.

### vega-react lint gap (handoff fact #9)
`@deneb-viz/vega-react` had no `eslint` script and no `eslint.config.js`, so `turbo run eslint` silently skipped it. Added both (mirroring `vega-runtime`); it now lints in CI. Findings surface as informational warnings via `eslint-plugin-only-warn` — 22 in one pre-existing test file, none in source — so CI stays green.

### Invariant canary pack (`src/__test__/invariants/`, run by `test:root`)
Follows the `architecture-boundaries.test.ts` precedent — each converts a contract into a CI-enforced assertion:

- **`package-singleton-contract.test.ts`** — powerbi-compat is `peerDependency`-only for every consumer, externalized in every tsup-bundled consumer (tsup #998: peerDeps alone don't prevent inlining), and no `@deneb-viz` package is double-declared across deps/peerDeps.
- **`certification-and-build-invariants.test.ts`** — `SAFETY_NET_BOUND_MS` is present and `<= 10_000` (certification ceiling); the production `package` script builds before webpack and validates config before packaging; `dev-with-prime.js` wipes `.tmp` and drives turbo via `npx --no`.
- **`package-lint-coverage.test.ts`** — every code package (one with a `build` script) has an `eslint` script + `eslint.config.js` — the drift that let vega-react go unlinted.

### Verification
- **Mutation-tested**: reverting each fix in turn (powerbi-compat → devDep, drop a tsup `external`, re-add a double-declare, bump the bound to 10_001, drop `build:package` from the package script, drop `npx --no turbo`, remove vega-react's eslint script) failed exactly the corresponding canary — 7/7 fired, then reverted.
- `npm install` resolves cleanly; `syncpack lint` clean; **`ci:local` green end-to-end** (build, validate-packages-sync, validate-config, eslint, prettier, test, certified package build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
