### PR TITLE
fix(dataset): guard mixed-highlight dataviews + undefined cells (U13)

### DIFF
--- a/packages/data-core/src/lib/value/__tests__/highlight.test.ts
+++ b/packages/data-core/src/lib/value/__tests__/highlight.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+    getHighlightComparatorValue,
+    getHighlightStatusValue
+} from '../highlight';
+import type { PrimitiveValue } from '../types';
+
+// Power BI can supply values outside the declared PrimitiveValue union at
+// runtime — `null` for an un-highlighted row, or `undefined` from an
+// out-of-bounds read of a short highlights array. Cast at the call site so the
+// tests can exercise those runtime shapes.
+const asValue = (v: unknown) => v as PrimitiveValue;
+
+describe('getHighlightStatusValue', () => {
+    it('is neutral when there are no highlights', () => {
+        expect(
+            getHighlightStatusValue(false, asValue(100), asValue(100))
+        ).toBe('neutral');
+    });
+
+    it('is on when the row carries a highlight comparator', () => {
+        expect(getHighlightStatusValue(true, asValue(100), asValue(75))).toBe(
+            'on'
+        );
+    });
+
+    it('keeps the null-field / present-comparator off case', () => {
+        expect(
+            getHighlightStatusValue(true, asValue(null), asValue(75))
+        ).toBe('off');
+    });
+
+    // Audit L13: a highlights array shorter than values yields an undefined
+    // comparator via an out-of-bounds read; it must not be reported as 'on'.
+    it('is off (not on) for an undefined out-of-bounds comparator', () => {
+        expect(
+            getHighlightStatusValue(true, asValue(100), asValue(undefined))
+        ).toBe('off');
+    });
+});
+
+describe('getHighlightComparatorValue', () => {
+    it('classifies the comparator against the base value', () => {
+        expect(getHighlightComparatorValue(asValue(100), asValue(75))).toBe(
+            'lt'
+        );
+        expect(getHighlightComparatorValue(asValue(100), asValue(100))).toBe(
+            'eq'
+        );
+        expect(getHighlightComparatorValue(asValue(100), asValue(125))).toBe(
+            'gt'
+        );
+    });
+});

--- a/packages/data-core/src/lib/value/__tests__/highlight.test.ts
+++ b/packages/data-core/src/lib/value/__tests__/highlight.test.ts
@@ -51,4 +51,13 @@ describe('getHighlightComparatorValue', () => {
             'gt'
         );
     });
+
+    // L13 symmetry: an absent (undefined) comparator has no value to compare
+    // against; 'neq' is the deliberate fallback (there is no 'absent' member),
+    // mirroring getHighlightStatusValue's undefined → 'off' guard.
+    it('returns neq for an undefined out-of-bounds comparator', () => {
+        expect(
+            getHighlightComparatorValue(asValue(100), asValue(undefined))
+        ).toBe('neq');
+    });
 });

--- a/packages/data-core/src/lib/value/highlight.ts
+++ b/packages/data-core/src/lib/value/highlight.ts
@@ -34,6 +34,13 @@ export const getHighlightStatusValue = (
     switch (true) {
         case !hasHighlights:
             return 'neutral';
+        // Defensive (audit L13): Power BI supplies a highlights array that is
+        // row-length and null-padded, so an `undefined` comparator can only
+        // arise from an out-of-bounds read (a highlights array shorter than
+        // values — a contract we could not verify). Treat it as "not
+        // highlighted" so a row with no highlight datum is never reported 'on'.
+        case comparatorValue === undefined:
+            return 'off';
         case hasHighlights && fieldValue === null && comparatorValue !== null:
             return 'off';
         default:

--- a/packages/data-core/src/lib/value/highlight.ts
+++ b/packages/data-core/src/lib/value/highlight.ts
@@ -12,6 +12,13 @@ export const getHighlightComparatorValue = (
     comparatorValue: PrimitiveValue
 ): DataPointHighlightComparator => {
     switch (true) {
+        // Symmetric with getHighlightStatusValue's L13 guard: an `undefined`
+        // comparator (an out-of-bounds read of a short highlights array) has no
+        // value to compare against. DataPointHighlightComparator has no
+        // "absent" member, so it deliberately resolves to 'neq' — the paired
+        // __highlight_status__ field carries the on/off distinction.
+        case comparatorValue === undefined:
+            return 'neq';
         case fieldValue == comparatorValue:
             return 'eq';
         case comparatorValue < fieldValue:

--- a/src/lib/dataset/__test__/values.test.ts
+++ b/src/lib/dataset/__test__/values.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type powerbi from 'powerbi-visuals-api';
+
+// values.ts transitively pulls the Power BI runtime graph (logging,
+// powerbi-compat formatting, the interactivity barrel). Stub those so the unit
+// under test loads without standing up the visual (handoff fact #10 — the
+// interactivity barrel + powerbi-compat/formatting reach the extensionless
+// powerbi-visuals-utils-typeutils ESM that CI's Node rejects).
+vi.mock('@deneb-viz/utils/logging', () => ({
+    logTimeStart: vi.fn(),
+    logTimeEnd: vi.fn()
+}));
+vi.mock('powerbi-visuals-api', () => ({}));
+vi.mock('@deneb-viz/powerbi-compat/formatting', () => ({
+    getFormattedValue: vi.fn((v) => v)
+}));
+
+const isCrossHighlightPropSet = vi.fn(() => false);
+vi.mock('../../interactivity', () => ({
+    isCrossHighlightPropSet: () => isCrossHighlightPropSet()
+}));
+
+const doesDataViewHaveHighlights = vi.fn(() => true);
+vi.mock('../data-view', () => ({
+    doesDataViewHaveHighlights: () => doesDataViewHaveHighlights()
+}));
+
+// Keep the formatting-string branch out of these fixtures.
+vi.mock('../fields', () => ({
+    isFieldEligibleForFormatting: vi.fn(() => false)
+}));
+
+import {
+    getCastedPrimitiveValue,
+    getDatumValueEntriesFromDataview
+} from '../values';
+import type { AugmentedMetadataField } from '../types';
+
+const col = (values: unknown[], highlights?: unknown[]) =>
+    ({ values, highlights }) as unknown as powerbi.DataViewValueColumn;
+
+const cols = (...columns: powerbi.DataViewValueColumn[]) =>
+    columns as unknown as powerbi.DataViewValueColumns;
+
+const cell = (v: unknown) => v as powerbi.PrimitiveValue;
+
+describe('getDatumValueEntriesFromDataview — mixed highlights (M9)', () => {
+    beforeEach(() => {
+        isCrossHighlightPropSet.mockReturnValue(false);
+        doesDataViewHaveHighlights.mockReturnValue(true);
+    });
+
+    it('falls back to a column’s own values when it has no highlights (auto-substitution path)', () => {
+        // Column A carries highlights, column B does not — the exact mixed
+        // dataview that produced `undefined` entries and dropped the dataset.
+        const values = cols(col([10, 20], [10, null]), col([30, 40]));
+
+        const entries = getDatumValueEntriesFromDataview([], values, 'en-US');
+
+        expect(entries.every((e) => Array.isArray(e))).toBe(true);
+        expect(entries).toContainEqual([30, 40]);
+    });
+
+    it('falls back per-column on the cross-highlight path too', () => {
+        isCrossHighlightPropSet.mockReturnValue(true);
+        const values = cols(col([10, 20], [10, null]), col([30, 40]));
+
+        const entries = getDatumValueEntriesFromDataview([], values, 'en-US');
+
+        expect(entries.every((e) => Array.isArray(e))).toBe(true);
+    });
+
+    it('is unchanged for an all-values (no-highlight) dataview', () => {
+        doesDataViewHaveHighlights.mockReturnValue(false);
+        const values = cols(col([10, 20]), col([30, 40]));
+
+        const entries = getDatumValueEntriesFromDataview([], values, 'en-US');
+
+        expect(entries).toEqual([
+            [10, 20],
+            [30, 40]
+        ]);
+    });
+});
+
+describe('getCastedPrimitiveValue — undefined dateTime cell (L14)', () => {
+    const dateField = {
+        column: { type: { dateTime: true } }
+    } as unknown as AugmentedMetadataField;
+
+    it('passes undefined through instead of producing an Invalid Date', () => {
+        expect(
+            getCastedPrimitiveValue(dateField, cell(undefined))
+        ).toBeUndefined();
+    });
+
+    it('passes null through', () => {
+        expect(getCastedPrimitiveValue(dateField, cell(null))).toBeNull();
+    });
+
+    it('still casts a real dateTime value to a valid Date', () => {
+        const result = getCastedPrimitiveValue(dateField, '2020-01-01') as Date;
+        expect(result instanceof Date).toBe(true);
+        expect(Number.isNaN(result.getTime())).toBe(false);
+    });
+
+    it('leaves non-dateTime values untouched', () => {
+        const numField = {
+            column: { type: {} }
+        } as unknown as AugmentedMetadataField;
+        expect(getCastedPrimitiveValue(numField, 42)).toBe(42);
+    });
+});

--- a/src/lib/dataset/values.ts
+++ b/src/lib/dataset/values.ts
@@ -14,8 +14,8 @@ export const getCastedPrimitiveValue = (
     field: AugmentedMetadataField,
     value: powerbi.PrimitiveValue
 ) =>
-    field?.column?.type?.dateTime && value !== null
-        ? new Date(value?.toString())
+    field?.column?.type?.dateTime && value != null
+        ? new Date(value.toString())
         : value;
 
 /**
@@ -84,11 +84,11 @@ const getFormattingStringValueEntries = (
 const getFormatStringForValueByIndex = (
     valueColumn: powerbi.DataViewValueColumn,
     index: number
-): string =>
-    <string>(
-        (valueColumn?.source?.format ??
-            valueColumn?.objects?.[index]?.general?.formatString)
-    );
+): string | undefined =>
+    valueColumn?.source?.format ??
+    (valueColumn?.objects?.[index]?.general?.formatString as
+        | string
+        | undefined);
 
 /**
  * If we're using cross-highlight functionality, we need to get/set the highlight entries accordingly. If no highlights
@@ -98,11 +98,17 @@ const getHighlightValueEntries = (
     values: powerbi.DataViewValueColumns
 ): powerbi.PrimitiveValue[][] => {
     logTimeStart('getHighlightValueEntries');
-    const entries = (values?.map((v) =>
-        isCrossHighlightPropSet() && doesDataViewHaveHighlights(values)
-            ? v.highlights
-            : v.values
-    ) || []) as powerbi.PrimitiveValue[][];
+    // Per-column highlight fallback (M9): a mixed-highlight dataview can have
+    // some value columns with a `highlights` array and some without. A column
+    // without highlights yields `undefined` here, which becomes an undefined
+    // entry that crashes row building and silently drops the whole dataset.
+    // Fall back to that column's own values so it still contributes a row.
+    const entries =
+        values?.map((v) =>
+            isCrossHighlightPropSet() && doesDataViewHaveHighlights(values)
+                ? (v.highlights ?? v.values)
+                : v.values
+        ) || [];
     logTimeEnd('getHighlightValueEntries');
     return entries;
 };
@@ -116,11 +122,18 @@ const getMeasureValueEntries = (
     values: powerbi.DataViewValueColumns
 ): powerbi.PrimitiveValue[][] => {
     logTimeStart('getMeasureValueEntries');
-    const entries = (values?.map((v) => {
-        const useHighlights =
-            doesDataViewHaveHighlights(values) && !isCrossHighlightPropSet();
-        return useHighlights ? v.highlights : v.values;
-    }) || []) as powerbi.PrimitiveValue[][];
+    // Per-column highlight fallback (M9): see getHighlightValueEntries. When
+    // Power BI supplies highlights but the creator hasn't opted into
+    // cross-highlighting, we substitute highlight values — but a column that
+    // has no highlights would otherwise inject `undefined` and drop the
+    // dataset, so fall back to that column's values.
+    const entries =
+        values?.map((v) => {
+            const useHighlights =
+                doesDataViewHaveHighlights(values) &&
+                !isCrossHighlightPropSet();
+            return useHighlights ? (v.highlights ?? v.values) : v.values;
+        }) || [];
     logTimeEnd('getMeasureValueEntries');
     return entries;
 };


### PR DESCRIPTION
## U13 — Dataset value guards: mixed highlights, undefined cells, honest signatures

Closes the M9 correctness bug plus the L13/L14/L15 value-handling findings.

### M9 (the headline fix)
A **mixed-highlight dataview** — some value columns carry a Power BI `highlights` array, some don't — produced an `undefined` value-entry for the un-highlighted columns. That `undefined` crashed row building and **silently blanked the entire visual**. Both entry builders in `values.ts` now fall back per-column with `v.highlights ?? v.values`.

The `as PrimitiveValue[][]` casts that turned this from a compile error into a runtime crash are **removed**, so the compiler now enforces the honest shape (that's L15's cast finding).

### L14 — undefined dateTime cell → Invalid Date
`getCastedPrimitiveValue` guarded `!== null` but not `undefined`, so an undefined cell (reachable via an OOB read or via M9) produced `new Date(undefined)` = Invalid Date. Changed to `!= null`.

### L15 — honest signature
`getFormatStringForValueByIndex` was declared `: string` behind a `<string>` cast hiding a possible `undefined`. Now `string | undefined` (the call site `getFormattedValue` already accepts `string | undefined | null`).

### L13 — short-highlights-array (defensive)
`getHighlightStatusValue` reported `'on'` for an `undefined` comparator, which is only reachable via an out-of-bounds read of a highlights array shorter than values — a Power BI contract we could **not** verify (its arrays are normally row-length, null-padded). Added a guard so an `undefined` comparator is `'off'` (never highlighted), documented as defensive. Existing behaviour is otherwise untouched.

### Scope note
`support-field-provider.ts` (the newer data-core processing engine) **already** guards highlights per-column (`if (!highlights) return baseValue`) and already casts formatString to `string | undefined`, so no change was needed there — the bug lives in the legacy `values.ts` flat-entries path that `processing.ts` still uses.

### Tests
- `values.test.ts` — M9 (mixed / cross-highlight / no-highlight paths) + L14 (undefined / null / real date / non-date). The M9 fixture is **mutation-verified**: it fails on the pre-fix builder (`undefined` entry) and passes with the fallback.
- `highlight.test.ts` — L13 (undefined comparator → `'off'`) + status/comparator regressions.
- `ci:local` green end-to-end (build, eslint, prettier, full test suite, certified package). Existing data-core suite (158 tests incl. build-data-row) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
