### PR TITLE
perf(dataset): reuse Power BI value formatters per format string

### DIFF
--- a/packages/powerbi-compat/src/lib/formatting/index.ts
+++ b/packages/powerbi-compat/src/lib/formatting/index.ts
@@ -3,10 +3,6 @@ import type powerbi from 'powerbi-visuals-api';
 import type { ValueFormatterOptions } from 'powerbi-visuals-utils-formattingutils/lib/src/valueFormatter';
 
 /**
- * Convenience function that creates a Power BI `valueFormatter.IValueFormatter` using the supplied format string, with
- * optional overrides. This helper is host-agnostic and can be safely used outside of Power BI (types only).
- */
-/**
  * Create a Power BI `valueFormatter.IValueFormatter` for the supplied format
  * string. Exposed so hot paths that format many values sharing one format
  * string can create the formatter once and reuse it, rather than paying

--- a/packages/powerbi-compat/src/lib/formatting/index.ts
+++ b/packages/powerbi-compat/src/lib/formatting/index.ts
@@ -6,22 +6,29 @@ import type { ValueFormatterOptions } from 'powerbi-visuals-utils-formattingutil
  * Convenience function that creates a Power BI `valueFormatter.IValueFormatter` using the supplied format string, with
  * optional overrides. This helper is host-agnostic and can be safely used outside of Power BI (types only).
  */
-const createFormatterFromString = (
+/**
+ * Create a Power BI `valueFormatter.IValueFormatter` for the supplied format
+ * string. Exposed so hot paths that format many values sharing one format
+ * string can create the formatter once and reuse it, rather than paying
+ * `valueFormatter.create()` for every value.
+ */
+export const getValueFormatter = (
     format: string | undefined | null,
-    options: ValueFormatterOptions
-) => {
-    const formatOptions: ValueFormatterOptions = {
+    options: ValueFormatterOptions = {}
+) =>
+    valueFormatter.create({
         format: format || '',
         ...options
-    };
-    return valueFormatter.create(formatOptions);
-};
+    });
 
 /**
  * For the supplied value and Power BI format string, attempt to format it.
+ * Convenience wrapper around {@link getValueFormatter} that creates a formatter
+ * per call — prefer reusing a `getValueFormatter` result when formatting many
+ * values with the same format string.
  */
 export const getFormattedValue = (
     value: powerbi.PrimitiveValue | undefined | null,
     format: string | undefined | null,
     options: ValueFormatterOptions = {}
-) => createFormatterFromString(format, options).format(value);
+) => getValueFormatter(format, options).format(value);

--- a/src/lib/dataset/__test__/values.test.ts
+++ b/src/lib/dataset/__test__/values.test.ts
@@ -12,7 +12,12 @@ vi.mock('@deneb-viz/utils/logging', () => ({
     logTimeEnd: vi.fn()
 }));
 vi.mock('powerbi-visuals-api', () => ({}));
+const getValueFormatter = vi.fn(() => ({
+    format: vi.fn((v: unknown) => `f(${v})`)
+}));
 vi.mock('@deneb-viz/powerbi-compat/formatting', () => ({
+    getValueFormatter: (format?: string, options?: unknown) =>
+        getValueFormatter(format, options),
     getFormattedValue: vi.fn((v) => v)
 }));
 
@@ -26,9 +31,12 @@ vi.mock('../data-view', () => ({
     doesDataViewHaveHighlights: () => doesDataViewHaveHighlights()
 }));
 
-// Keep the formatting-string branch out of these fixtures.
+// Formatting-string branch: default off for the highlight fixtures, toggled on
+// for the formatter-reuse tests.
+const isFieldEligibleForFormatting = vi.fn((_v: unknown) => false);
 vi.mock('../fields', () => ({
-    isFieldEligibleForFormatting: vi.fn(() => false)
+    isFieldEligibleForFormatting: (v: unknown) =>
+        isFieldEligibleForFormatting(v)
 }));
 
 import {
@@ -45,10 +53,23 @@ const cols = (...columns: powerbi.DataViewValueColumn[]) =>
 
 const cell = (v: unknown) => v as powerbi.PrimitiveValue;
 
+const colFmt = (values: unknown[], format: string) =>
+    ({ values, source: { format } }) as unknown as powerbi.DataViewValueColumn;
+
+const colDynamic = (values: unknown[], perRowFormats: string[]) =>
+    ({
+        values,
+        source: {},
+        objects: perRowFormats.map((formatString) => ({
+            general: { formatString }
+        }))
+    }) as unknown as powerbi.DataViewValueColumn;
+
 describe('getDatumValueEntriesFromDataview — mixed highlights (M9)', () => {
     beforeEach(() => {
         isCrossHighlightPropSet.mockReturnValue(false);
         doesDataViewHaveHighlights.mockReturnValue(true);
+        isFieldEligibleForFormatting.mockReturnValue(false);
     });
 
     it('falls back to a column’s own values when it has no highlights (auto-substitution path)', () => {
@@ -110,5 +131,37 @@ describe('getCastedPrimitiveValue — undefined dateTime cell (L14)', () => {
             column: { type: {} }
         } as unknown as AugmentedMetadataField;
         expect(getCastedPrimitiveValue(numField, 42)).toBe(42);
+    });
+});
+
+describe('getFormattingStringValueEntries — formatter reuse (perf)', () => {
+    beforeEach(() => {
+        isCrossHighlightPropSet.mockReturnValue(false);
+        doesDataViewHaveHighlights.mockReturnValue(false);
+        isFieldEligibleForFormatting.mockReturnValue(true);
+        getValueFormatter.mockClear();
+    });
+
+    it('creates one formatter for a column with a constant format string', () => {
+        const values = cols(colFmt([1, 2, 3, 4], '#,##0'));
+
+        const entries = getDatumValueEntriesFromDataview([], values, 'en-US');
+
+        // One formatter for the four same-format rows, not four.
+        expect(getValueFormatter).toHaveBeenCalledTimes(1);
+        // Format strings + formatted values are still emitted per row.
+        expect(entries).toContainEqual(['#,##0', '#,##0', '#,##0', '#,##0']);
+        expect(entries).toContainEqual(['f(1)', 'f(2)', 'f(3)', 'f(4)']);
+    });
+
+    it('creates one formatter per distinct dynamic format string', () => {
+        const values = cols(
+            colDynamic([10, 20, 30], ['#,##0', '0.00', '#,##0'])
+        );
+
+        getDatumValueEntriesFromDataview([], values, 'en-US');
+
+        // Two distinct format strings across three rows → two formatters.
+        expect(getValueFormatter).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/lib/dataset/values.ts
+++ b/src/lib/dataset/values.ts
@@ -1,7 +1,7 @@
 import powerbi from 'powerbi-visuals-api';
 
 import { logTimeEnd, logTimeStart } from '@deneb-viz/utils/logging';
-import { getFormattedValue } from '@deneb-viz/powerbi-compat/formatting';
+import { getValueFormatter } from '@deneb-viz/powerbi-compat/formatting';
 import { doesDataViewHaveHighlights } from './data-view';
 import type { AugmentedMetadataField } from './types';
 import { isFieldEligibleForFormatting } from './fields';
@@ -56,17 +56,35 @@ const getFormattingStringValueEntries = (
     locale: string
 ): powerbi.PrimitiveValue[][] => {
     logTimeStart('getFormattingStringEntries');
+    // Reuse one formatter per distinct format string across the whole dataview.
+    // getFormattedValue creates a new Power BI valueFormatter on every call, so
+    // formatting N rows naively costs N heavyweight create() calls even though a
+    // column's format string is usually constant. Memoise by the resolved
+    // format string (which still varies per row for dynamic format strings) so
+    // identical strings share a formatter — turning ~rows creations into
+    // ~distinct-format-strings.
+    const formatterByString = new Map<
+        string,
+        ReturnType<typeof getValueFormatter>
+    >();
+    const formatterFor = (format: string | undefined) => {
+        const key = format ?? '';
+        let formatter = formatterByString.get(key);
+        if (!formatter) {
+            formatter = getValueFormatter(format, { cultureSelector: locale });
+            formatterByString.set(key, formatter);
+        }
+        return formatter;
+    };
     const entries =
         values?.reduce<powerbi.PrimitiveValue[][]>((acc, v) => {
             if (isFieldEligibleForFormatting(v)) {
-                const values = v.values;
-                const formatStrings = values.map((vv, vvi) =>
+                const columnValues = v.values;
+                const formatStrings = columnValues.map((vv, vvi) =>
                     getFormatStringForValueByIndex(v, vvi)
                 );
-                const formattedValues = values.map((vv, vvi) =>
-                    getFormattedValue(vv, formatStrings[vvi], {
-                        cultureSelector: locale
-                    })
+                const formattedValues = columnValues.map((vv, vvi) =>
+                    formatterFor(formatStrings[vvi]).format(vv)
                 );
                 acc.push(formatStrings);
                 acc.push(formattedValues);


### PR DESCRIPTION
## perf: reuse Power BI value formatters per format string

A follow-on to the U13 data-guards work — a genuine row-bound hot path spotted while reviewing `values.ts`.

### The problem
`getFormattingStringValueEntries` formats **every row** of every numeric/dateTime value column (`isFieldEligibleForFormatting` = essentially every measure). Each row went through `getFormattedValue`, which does:

```
getFormattedValue → valueFormatter.create(...)   // a fresh formatter, every call
```

So at the U6-raised **30k-row** window with a few measures, that's on the order of **rows × eligible-columns `valueFormatter.create()` calls per dataset build** (e.g. ~90k for 3 measures) — even though a column's format string is almost always constant, so the created formatters are identical.

### The fix
- Expose `getValueFormatter` from `@deneb-viz/powerbi-compat/formatting` (returns the formatter; `getFormattedValue` now delegates to it).
- Memoise formatters by **resolved format string** inside the row loop. Identical strings share one formatter; dynamic per-row format strings (`objects[i].general.formatString`) still get one each.

Result: **~rows creations → ~distinct-format-strings** (one per column in the common case). Output is byte-identical — same formatter config, just reused.

### Why this and not the highlight builders
The `getHighlightValueEntries` / `getMeasureValueEntries` builders you also flagged are **column-bound** (their `doesDataViewHaveHighlights` / `isCrossHighlightPropSet` calls iterate the small columns array, never rows) — microseconds regardless of dataset size, so left as-is. Only this function scales with row count.

### Tests
`values.test.ts` asserts one formatter is created for a constant-format column (not one per row) and one per distinct dynamic format string. **Mutation-verified** — both fail if the cache is removed. `ci:local` green end-to-end (build, eslint, prettier, full test suite, certified package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
