### PR TITLE
refactor(utils): hoist JSONC parse-with-result core into utils (U15/M16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18832,6 +18832,7 @@
             "license": "MIT",
             "dependencies": {
                 "json-stringify-pretty-compact": "^4.0.0",
+                "jsonc-parser": "^3.3.1",
                 "simple-sha1": "^3.1.0"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18885,7 +18885,6 @@
                 "@deneb-viz/utils": "*",
                 "d3-interpolate": "^3.0.1",
                 "d3-selection": "^3.0.0",
-                "jsonc-parser": "^3.3.1",
                 "mergician": "^2.0.2",
                 "powerbi-visuals-utils-formattingutils": "^6.1.2"
             },

--- a/packages/json-processing/src/index.ts
+++ b/packages/json-processing/src/index.ts
@@ -9,7 +9,6 @@ export {
     getJsoncStringAsObject,
     getJsoncTree,
     getModifiedJsoncByPath,
-    getParsedJsonWithResult,
     getTextFormattedAsJsonC
 } from './processing';
 export { areAllCreateDataRequirementsMet } from './template-dataset';

--- a/packages/json-processing/src/processing.ts
+++ b/packages/json-processing/src/processing.ts
@@ -4,16 +4,10 @@ import {
     getNodeValue,
     modify,
     parseTree,
-    stripComments,
     Node
 } from 'jsonc-parser';
 import { JSONPath } from 'vscode-json-languageservice';
-import { type IJsonParseResult } from './lib/spec-processing';
-
-/**
- * When converting JSONC to JSON, this is the character to replace comments with.
- */
-const JSONC_TO_JSON_COMMENT_REPLACE_CHAR = ' ';
+import { stripJsoncComments } from '@deneb-viz/utils/jsonc';
 
 /**
  * For the supplied JSONC tree, return the JavaScript object value of the node.
@@ -53,8 +47,8 @@ export const getJsoncTree = (content: string) => parseTree(content) as Node;
  */
 export const getJsonPureString = (
     content: string | undefined | null,
-    replaceCh: string = JSONC_TO_JSON_COMMENT_REPLACE_CHAR
-) => stripComments(content || '{}', replaceCh);
+    replaceCh?: string
+) => stripJsoncComments(content, replaceCh);
 
 /**
  * For the supplied content, JSONPath, and value, return the modified JSONC string as of that location.
@@ -66,22 +60,6 @@ export const getModifiedJsoncByPath = (
 ) => {
     const edits = modify(content, path, value, {});
     return applyEdits(content, edits);
-};
-
-/**
- * Intended to be used as a substitute for `JSON.parse`; will ensure that any supplied `content` is tested as JSONC.
- * Any parsing issues are included in the returned `errors` array.
- */
-export const getParsedJsonWithResult = (
-    content: string,
-    fallback?: string
-): IJsonParseResult => {
-    try {
-        return { result: JSON.parse(getJsonPureString(content)), errors: [] };
-    } catch (e: unknown) {
-        if (!fallback) return { result: null, errors: [(<Error>e).message] };
-        return { result: JSON.parse(fallback), errors: [] };
-    }
 };
 
 /**

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,6 +37,10 @@
             "types": "./dist/lib/inspection.d.ts",
             "default": "./dist/lib/inspection.js"
         },
+        "./jsonc": {
+            "types": "./dist/lib/jsonc.d.ts",
+            "default": "./dist/lib/jsonc.js"
+        },
         "./logging": {
             "types": "./dist/lib/logging.d.ts",
             "default": "./dist/lib/logging.js"
@@ -77,6 +81,7 @@
     },
     "dependencies": {
         "json-stringify-pretty-compact": "^4.0.0",
+        "jsonc-parser": "^3.3.1",
         "simple-sha1": "^3.1.0"
     }
 }

--- a/packages/utils/src/lib/__tests__/jsonc.test.ts
+++ b/packages/utils/src/lib/__tests__/jsonc.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { parseJsoncWithResult, stripJsoncComments } from '../jsonc';
+
+describe('stripJsoncComments', () => {
+    it('replaces comments so line numbers are preserved', () => {
+        const content = '{\n  // a comment\n  "a": 1\n}';
+        const stripped = stripJsoncComments(content);
+        expect(stripped).not.toContain('//');
+        // Newlines are preserved, so parse-error line numbers stay aligned.
+        const newlines = (s: string) => (s.match(/\n/g) ?? []).length;
+        expect(newlines(stripped)).toBe(newlines(content));
+        expect(JSON.parse(stripped)).toEqual({ a: 1 });
+    });
+
+    it('defaults empty/nullish content to an empty object literal', () => {
+        expect(stripJsoncComments('')).toBe('{}');
+        expect(stripJsoncComments(undefined)).toBe('{}');
+        expect(stripJsoncComments(null)).toBe('{}');
+    });
+
+    it('honours a custom replacement character', () => {
+        const stripped = stripJsoncComments('{"a":1} // c', '*');
+        expect(stripped).not.toContain('//');
+        expect(stripped).toContain('*');
+    });
+});
+
+describe('parseJsoncWithResult', () => {
+    it('parses valid JSONC (comments stripped) with no errors', () => {
+        expect(parseJsoncWithResult('{ "a": 1 /* inline */ }')).toEqual({
+            result: { a: 1 },
+            errors: []
+        });
+    });
+
+    it('parses empty/nullish content as an empty object', () => {
+        expect(parseJsoncWithResult('')).toEqual({ result: {}, errors: [] });
+        expect(parseJsoncWithResult(undefined)).toEqual({
+            result: {},
+            errors: []
+        });
+    });
+
+    it('returns the raw parse-error message (no enrichment) on malformed JSON', () => {
+        const result = parseJsoncWithResult('{ "a": }');
+        expect(result.result).toBeNull();
+        expect(result.errors).toHaveLength(1);
+        expect(typeof result.errors[0]).toBe('string');
+        // The core does not add line numbers — that is the caller's decoration.
+        expect(result.errors[0]).not.toMatch(/ at line \d+/);
+    });
+});

--- a/packages/utils/src/lib/jsonc.ts
+++ b/packages/utils/src/lib/jsonc.ts
@@ -17,7 +17,7 @@ const JSONC_EMPTY_OBJECT = '{}';
  */
 export interface JsoncParseResult {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result: any | null;
+    result: any;
     errors: string[];
 }
 

--- a/packages/utils/src/lib/jsonc.ts
+++ b/packages/utils/src/lib/jsonc.ts
@@ -1,0 +1,54 @@
+import { stripComments } from 'jsonc-parser';
+
+/**
+ * Character used to replace stripped JSONC comments. A space preserves the
+ * original character offsets, so downstream parse errors still point at the
+ * right line.
+ */
+const JSONC_COMMENT_REPLACE_CHAR = ' ';
+
+/** Empty-object fallback for empty/nullish content. */
+const JSONC_EMPTY_OBJECT = '{}';
+
+/**
+ * Result of parsing JSONC content: the parsed value, or `null` with the raw
+ * parse-error message(s). Callers decorate the errors as needed (line numbers,
+ * a fallback string, redaction).
+ */
+export interface JsoncParseResult {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    result: any | null;
+    errors: string[];
+}
+
+/**
+ * Strip comments from JSONC content, replacing them with `replaceChar` (a space
+ * by default, which preserves line numbers). Empty/nullish content becomes an
+ * empty object literal (`{}`).
+ */
+export const stripJsoncComments = (
+    content: string | undefined | null,
+    replaceChar: string = JSONC_COMMENT_REPLACE_CHAR
+): string => stripComments(content || JSONC_EMPTY_OBJECT, replaceChar);
+
+/**
+ * Parse JSONC (JSON with comments) into a `{ result, errors }` shape. Comments
+ * are stripped (line numbers preserved) before `JSON.parse`. On failure,
+ * `result` is `null` and `errors` carries the raw parse-error message; callers
+ * add their own enrichment (e.g. a line number or a fallback).
+ *
+ * Shared core behind vega-runtime's `parseJsonWithResult` and json-processing's
+ * JSONC string helpers (audit M16).
+ */
+export const parseJsoncWithResult = (
+    content: string | undefined | null
+): JsoncParseResult => {
+    try {
+        return { result: JSON.parse(stripJsoncComments(content)), errors: [] };
+    } catch (e) {
+        return {
+            result: null,
+            errors: [e instanceof Error ? e.message : String(e)]
+        };
+    }
+};

--- a/packages/vega-runtime/package.json
+++ b/packages/vega-runtime/package.json
@@ -70,7 +70,6 @@
         "@deneb-viz/utils": "*",
         "d3-interpolate": "^3.0.1",
         "d3-selection": "^3.0.0",
-        "jsonc-parser": "^3.3.1",
         "mergician": "^2.0.2",
         "powerbi-visuals-utils-formattingutils": "^6.1.2"
     },

--- a/packages/vega-runtime/src/lib/spec-processing/json.ts
+++ b/packages/vega-runtime/src/lib/spec-processing/json.ts
@@ -1,45 +1,22 @@
-import { stripComments } from 'jsonc-parser';
+import { parseJsoncWithResult } from '@deneb-viz/utils/jsonc';
 import type { ContentPatchResult } from './types';
 
 /**
- * Character to replace comments with when stripping them from JSONC.
- * Using space preserves line numbers for error reporting.
- */
-const JSONC_COMMENT_REPLACE_CHAR = ' ';
-
-/**
- * Empty JSON object string used as fallback when input is empty.
- */
-const JSONC_EMPTY_OBJECT = '{}';
-
-/**
- * Parse JSONC (JSON with Comments) with error handling and line number extraction.
- * Returns a result object with the parsed content or error messages.
- *
- * Comments are stripped before parsing, with line numbers preserved.
+ * Parse JSONC (JSON with Comments) with error handling and line-number
+ * enrichment. Thin decorator over the shared `parseJsoncWithResult` core
+ * (`@deneb-viz/utils`); the only local behaviour is enriching parse-error
+ * messages with a line number.
  *
  * @param content JSONC string to parse
  * @returns Parsed result or error information
  */
 export const parseJsonWithResult = (content: string): ContentPatchResult => {
-    try {
-        // Strip comments while preserving line numbers (replace with spaces)
-        const pureJson = stripComments(
-            content || JSONC_EMPTY_OBJECT,
-            JSONC_COMMENT_REPLACE_CHAR
-        );
-        const parsed = JSON.parse(pureJson);
-        return {
-            result: parsed,
-            errors: []
-        };
-    } catch (e) {
-        const message = e instanceof Error ? e.message : String(e);
-        return {
-            result: null,
-            errors: [getErrorLine(content, message)]
-        };
-    }
+    const { result, errors } = parseJsoncWithResult(content);
+    if (errors.length === 0) return { result, errors };
+    return {
+        result: null,
+        errors: errors.map((message) => getErrorLine(content, message))
+    };
 };
 
 /**


### PR DESCRIPTION
## U15 — JSONC parse-with-result deduplication (M16)

The strip-comments + parse-with-result algorithm was implemented **twice**, differing only in their error tails:
- `parseJsonWithResult` — `packages/vega-runtime/src/lib/spec-processing/json.ts`
- `getParsedJsonWithResult` + `getJsonPureString` — `packages/json-processing/src/processing.ts`

### Change
Extract the shared core to a new **`@deneb-viz/utils/jsonc`** module — `stripJsoncComments`, `parseJsoncWithResult`, and the `JsoncParseResult` type. utils sits below both callers in the dependency graph, so the extraction moves the core **down** rather than consolidating into json-processing (which is [slated for eventual dissolution](https://github.com/deneb-viz/deneb) — code moves *out* of it, never in).

The two callers become thin decorators; each keeps its own local tail:
- **vega-runtime** `parseJsonWithResult` → core + line-number enrichment (`getErrorLine`).
- **json-processing** `getJsonPureString` → delegates to `stripJsoncComments`.

### Dead code removed (P5-E5)
`getParsedJsonWithResult` was referenced only by json-processing's own barrel — the app consumes the vega-runtime copy. Deleted and un-exported, along with its now-unused `IJsonParseResult` import.

### Verification
Behaviour unchanged — both packages' existing parse suites stay green (**vega-runtime `json.test.ts` 27**, **json-processing `processing.test.ts` 17**), a new **`utils/jsonc.test.ts` (6)** locks the core contract (comment stripping preserves line numbers, empty→`{}`, malformed→raw error with no enrichment), and the duplicate bodies are gone. `syncpack` clean; `ci:local` green end-to-end.

### Follow-up
`IJsonParseResult` (json-processing `lib/spec-processing`) is now dead after this removal — flagged for the **U16** dead-export sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
