### PR TITLE
fix: certification guards for local Vega overrides + test-guard hardening

### DIFF
--- a/bin/__test__/config-validation.test.ts
+++ b/bin/__test__/config-validation.test.ts
@@ -83,3 +83,38 @@ describe('collectConfigErrors — dev toggles and external URIs', () => {
         ).toBe(false);
     });
 });
+
+describe('collectConfigErrors — local Vega/Vega-Lite build overrides (C2)', () => {
+    const safe = { LOG_LEVEL: '0' };
+
+    it('errors when VEGA_LOCAL_PATH is set', () => {
+        expect(
+            collectConfigErrors(
+                env({ ...safe, VEGA_LOCAL_PATH: 'C:/builds/vega/vega.js' })
+            ).some((e) => /VEGA_LOCAL_PATH/.test(e))
+        ).toBe(true);
+    });
+
+    it('errors when VEGA_LITE_LOCAL_PATH is set', () => {
+        expect(
+            collectConfigErrors(
+                env({
+                    ...safe,
+                    VEGA_LITE_LOCAL_PATH: 'C:/builds/vega-lite/vega-lite.js'
+                })
+            ).some((e) => /VEGA_LITE_LOCAL_PATH/.test(e))
+        ).toBe(true);
+    });
+
+    it('passes when VEGA_LOCAL_PATH / VEGA_LITE_LOCAL_PATH are empty or whitespace', () => {
+        expect(
+            collectConfigErrors(
+                env({
+                    ...safe,
+                    VEGA_LOCAL_PATH: '',
+                    VEGA_LITE_LOCAL_PATH: '   '
+                })
+            ).some((e) => /VEGA_LOCAL_PATH|VEGA_LITE_LOCAL_PATH/.test(e))
+        ).toBe(false);
+    });
+});

--- a/bin/ci-local.js
+++ b/bin/ci-local.js
@@ -34,6 +34,10 @@ const steps = [
     },
     { name: 'Tests', cmd: 'npm run test' },
     {
+        name: 'Tests (benchmarks compare script)',
+        cmd: 'npm run test:benchmarks'
+    },
+    {
         name: 'Confirm pbiviz package (AppSource Version)',
         cmd: 'npm run package'
     }

--- a/bin/config-validation.ts
+++ b/bin/config-validation.ts
@@ -69,5 +69,16 @@ export const collectConfigErrors = (env: NodeJS.ProcessEnv): string[] => {
         );
     }
 
+    // Local Vega/Vega-Lite build overrides (webpack.common.config.js) must never
+    // reach a committed or packaged build — a certified .pbiviz would silently
+    // bundle unvetted library code.
+    for (const key of ['VEGA_LOCAL_PATH', 'VEGA_LITE_LOCAL_PATH'] as const) {
+        if (env[key]?.trim()) {
+            errors.push(
+                `❌ .env ${key} is set ('${env[key]}'). Local Vega build overrides must be unset for committed/packaged builds.`
+            );
+        }
+    }
+
     return errors;
 };

--- a/src/__test__/harness/update-cycle-driver.ts
+++ b/src/__test__/harness/update-cycle-driver.ts
@@ -323,10 +323,6 @@ export const createUpdateCycleDriver = (
         options: powerbi.extensibility.visual.VisualUpdateOptions
     ): void => {
         const categorical = getCategoricalDataViewFromOptions(options);
-        if (!categorical) {
-            coordinator.closeCurrent();
-            return;
-        }
         const canFetchMore = canFetchMoreFromDataview(
             settings,
             options?.dataViews?.[0]?.metadata as powerbi.DataViewMetadata

--- a/src/__test__/invariants/certification-and-build-invariants.test.ts
+++ b/src/__test__/invariants/certification-and-build-invariants.test.ts
@@ -13,7 +13,7 @@ import { REPO_ROOT } from './_packages';
 describe('safety-net bound is the certification ceiling', () => {
     it('SAFETY_NET_BOUND_MS is present and <= 10_000ms', () => {
         const source = readFileSync(join(REPO_ROOT, 'src', 'index.ts'), 'utf8');
-        const match = source.match(/SAFETY_NET_BOUND_MS\s*=\s*([\d_]+)/);
+        const match = source.match(/SAFETY_NET_BOUND_MS\s*=\s*([\d_]+)\s*;/);
         // Fail loud if the constant is renamed/removed rather than pass vacuously.
         if (!match) {
             throw new Error('SAFETY_NET_BOUND_MS not found in src/index.ts');


### PR DESCRIPTION
- **C2 — local-Vega validation guard**: `collectConfigErrors` now fails when `VEGA_LOCAL_PATH`/`VEGA_LITE_LOCAL_PATH` are set, so a leftover `.env` override can no longer bake unvetted local library bundles into a certified `.pbiviz`.
- **ci:local benchmarks step**: `bin/ci-local.js` now runs `npm run test:benchmarks` in the same position as CI, so a green `ci:local` once again implies a green CI run.
- **Safety-net invariant regex anchor**: the `SAFETY_NET_BOUND_MS <= 10_000` invariant test now anchors the full initializer (`...\s*;`), so expressions like `10_000 * 3` fail loud instead of false-passing on the captured first operand.
- **Harness no-categorical branch removal**: deleted a `if (!categorical) closeCurrent()` branch in the update-cycle driver that had no counterpart in production `Deneb.resolveDataset` (which is null-tolerant and always runs the full decision), restoring the harness's mirror-fidelity rule.

Part of the 2.0 pre-merge review remediation (WP1). `npm run ci:local`: ALL CHECKS PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)