### PR TITLE
fix: single live Vega embed + in-flight update integrity

### DIFF
--- a/packages/app-core/src/features/visual-viewer/__tests__/embed-active.test.ts
+++ b/packages/app-core/src/features/visual-viewer/__tests__/embed-active.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { InterfaceType } from '../../../lib/interface';
+import { computeEmbedActive } from '../embed-active';
+
+/**
+ * Every interface mode in the union. If the union grows, this array must grow
+ * with it so the mutual-exclusion property below keeps covering all modes.
+ */
+const INTERFACE_TYPES: InterfaceType[] = ['viewer', 'editor'];
+
+describe('computeEmbedActive — truth table', () => {
+    it('standalone viewer instance is active only in viewer mode', () => {
+        expect(computeEmbedActive('viewer', false)).toBe(true);
+        expect(computeEmbedActive('editor', false)).toBe(false);
+    });
+
+    it('editor-embedded instance is active only in editor mode', () => {
+        expect(computeEmbedActive('editor', true)).toBe(true);
+        expect(computeEmbedActive('viewer', true)).toBe(false);
+    });
+});
+
+describe('computeEmbedActive — mutual exclusion (defect C1)', () => {
+    it('for every interface mode exactly one of the two instances is active', () => {
+        for (const type of INTERFACE_TYPES) {
+            const embedded = computeEmbedActive(type, true);
+            const standalone = computeEmbedActive(type, false);
+            // For the current viewer|editor union each mode activates exactly
+            // one instance, so the two results must differ. Should the union
+            // ever gain a mode where BOTH are inactive, relax this to assert
+            // `!(embedded && standalone)` (never both active) instead.
+            expect(embedded).not.toBe(standalone);
+        }
+    });
+
+    it('never activates both instances for any interface mode', () => {
+        for (const type of INTERFACE_TYPES) {
+            expect(
+                computeEmbedActive(type, true) &&
+                    computeEmbedActive(type, false)
+            ).toBe(false);
+        }
+    });
+});

--- a/packages/app-core/src/features/visual-viewer/__tests__/embed-window.test.ts
+++ b/packages/app-core/src/features/visual-viewer/__tests__/embed-window.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { shouldOpenEmbedWindow } from '../embed-window';
+
+describe('shouldOpenEmbedWindow (defect #7 follow-up: no window without a re-embed)', () => {
+    it('opens on the first non-null spec (no previous spec)', () => {
+        expect(shouldOpenEmbedWindow(null, { mark: 'bar' })).toBe(true);
+    });
+
+    it('never opens for a null next spec (nothing will embed)', () => {
+        expect(shouldOpenEmbedWindow(null, null)).toBe(false);
+        expect(shouldOpenEmbedWindow({ mark: 'bar' }, null)).toBe(false);
+    });
+
+    it('does NOT open for a new identity with deep-equal content (useVegaEmbed will skip the re-embed)', () => {
+        const previous = {
+            mark: 'bar',
+            data: { values: [{ a: 1 }, { a: 2 }] },
+            encoding: { x: { field: 'a' } }
+        };
+        const next = {
+            mark: 'bar',
+            data: { values: [{ a: 1 }, { a: 2 }] },
+            encoding: { x: { field: 'a' } }
+        };
+        expect(next).not.toBe(previous);
+        expect(shouldOpenEmbedWindow(previous, next)).toBe(false);
+    });
+
+    it('does not open for the identical object reference', () => {
+        const spec = { mark: 'line' };
+        expect(shouldOpenEmbedWindow(spec, spec)).toBe(false);
+    });
+
+    it('opens when the content genuinely differs (a re-embed will follow)', () => {
+        expect(
+            shouldOpenEmbedWindow(
+                { mark: 'bar', data: { values: [{ a: 1 }] } },
+                { mark: 'bar', data: { values: [{ a: 2 }] } }
+            )
+        ).toBe(true);
+    });
+
+    it('opens on a nested structural difference', () => {
+        expect(
+            shouldOpenEmbedWindow(
+                { encoding: { x: { field: 'a', type: 'ordinal' } } },
+                { encoding: { x: { field: 'a', type: 'quantitative' } } }
+            )
+        ).toBe(true);
+    });
+});

--- a/packages/app-core/src/features/visual-viewer/__tests__/incremental-update.test.ts
+++ b/packages/app-core/src/features/visual-viewer/__tests__/incremental-update.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 import type { View } from 'vega';
 import {
     performIncrementalUpdate,
-    resolveDataChangeAction
+    resolveDataChangeAction,
+    resolveDataChangeGate,
+    shouldAdvancePrevValues,
+    type DataChangeGate
 } from '../incremental-update';
 
 // incremental-update.ts imports only `logDebug` from this module.
@@ -249,5 +252,136 @@ describe('resolveDataChangeAction (L3 routing)', () => {
         expect(resolveDataChangeAction('present', true, 500, 500)).toBe(
             'incremental'
         );
+    });
+});
+
+describe('resolveDataChangeGate (defect C1 activation + defect #7 deferral)', () => {
+    const active = {
+        isActive: true,
+        viewReady: true,
+        hasView: true
+    };
+
+    it("returns 'initialize' on the first observation (null baseline)", () => {
+        expect(
+            resolveDataChangeGate({
+                prevValues: null,
+                values: [{ a: 1 }],
+                ...active
+            })
+        ).toBe('initialize');
+    });
+
+    it("returns 'unchanged' when the values reference is identical", () => {
+        const values = [{ a: 1 }];
+        expect(
+            resolveDataChangeGate({ prevValues: values, values, ...active })
+        ).toBe('unchanged');
+    });
+
+    it("returns 'inactive' when this instance is not the live one, even with a changed reference", () => {
+        expect(
+            resolveDataChangeGate({
+                prevValues: [{ a: 1 }],
+                values: [{ a: 2 }],
+                isActive: false,
+                viewReady: true,
+                hasView: true
+            })
+        ).toBe('inactive');
+    });
+
+    it("returns 'defer' when the view is mid-embed (viewReady false)", () => {
+        expect(
+            resolveDataChangeGate({
+                prevValues: [{ a: 1 }],
+                values: [{ a: 2 }],
+                isActive: true,
+                viewReady: false,
+                hasView: true
+            })
+        ).toBe('defer');
+    });
+
+    it("returns 'no-view' when active and ready but no view is bound", () => {
+        expect(
+            resolveDataChangeGate({
+                prevValues: [{ a: 1 }],
+                values: [{ a: 2 }],
+                isActive: true,
+                viewReady: true,
+                hasView: false
+            })
+        ).toBe('no-view');
+    });
+
+    it("returns 'act' when active, ready, bound, and the reference changed", () => {
+        expect(
+            resolveDataChangeGate({
+                prevValues: [{ a: 1 }],
+                values: [{ a: 2 }],
+                ...active
+            })
+        ).toBe('act');
+    });
+
+    it('an inactive instance never reaches an action (defect C1: no side effects)', () => {
+        const gate = resolveDataChangeGate({
+            prevValues: [{ a: 1 }],
+            values: [{ a: 2 }],
+            isActive: false,
+            viewReady: true,
+            hasView: true
+        });
+        expect(gate).toBe('inactive');
+        expect(shouldAdvancePrevValues(gate)).toBe(false);
+    });
+
+    it('an update landing mid-embed is deferred, then applied once viewReady flips (defect #7)', () => {
+        const prevValues = [{ a: 1 }];
+        const values = [{ a: 2 }];
+
+        // Update lands while the view is still embedding.
+        const deferred = resolveDataChangeGate({
+            prevValues,
+            values,
+            isActive: true,
+            viewReady: false,
+            hasView: true
+        });
+        expect(deferred).toBe('defer');
+        // Baseline is NOT advanced, so the SAME values are re-evaluated later.
+        expect(shouldAdvancePrevValues(deferred)).toBe(false);
+
+        // Embed completes -> viewReady flips true, effect re-runs with the
+        // unchanged baseline and the same values: now the update is applied.
+        const applied = resolveDataChangeGate({
+            prevValues,
+            values,
+            isActive: true,
+            viewReady: true,
+            hasView: true
+        });
+        expect(applied).toBe('act');
+        expect(shouldAdvancePrevValues(applied)).toBe(true);
+    });
+});
+
+describe('shouldAdvancePrevValues', () => {
+    const advancing: DataChangeGate[] = ['initialize', 'act'];
+    const notAdvancing: DataChangeGate[] = [
+        'unchanged',
+        'inactive',
+        'defer',
+        'no-view'
+    ];
+
+    it('advances the baseline only for initialize and act', () => {
+        for (const gate of advancing) {
+            expect(shouldAdvancePrevValues(gate)).toBe(true);
+        }
+        for (const gate of notAdvancing) {
+            expect(shouldAdvancePrevValues(gate)).toBe(false);
+        }
     });
 });

--- a/packages/app-core/src/features/visual-viewer/components/vega-embed.tsx
+++ b/packages/app-core/src/features/visual-viewer/components/vega-embed.tsx
@@ -16,6 +16,7 @@ import { useDenebState } from '../../../state';
 import { type ViewEventBinder } from '../../../components/deneb-platform';
 import { VEGA_EMBED_ROOT_STYLE } from './vega-embed-styles';
 import { getRestrictiveVegaLoader } from './restrictive-loader';
+import { shouldOpenEmbedWindow } from '../embed-window';
 
 type VegaEmbedProps = {
     /**
@@ -105,11 +106,11 @@ export const VegaEmbed: React.FC<VegaEmbedProps> = ({
             logDebug('VegaEmbed: New view created');
 
             // NOTE: `setViewReady(false)` is NOT called here. It is driven by a
-            // separate effect keyed on the memoized `spec` identity (below), so
-            // the false→true transition spans two renders and the in-flight
-            // window actually exists. Toggling false→true in this single
-            // synchronous callback batched into a no-op, erasing the window
-            // (defect #7).
+            // separate effect that deep-compares the memoized `spec` (below,
+            // mirroring `useVegaEmbed`'s re-embed semantics), so the false→true
+            // transition spans two renders and the in-flight window actually
+            // exists. Toggling false→true in this single synchronous callback
+            // batched into a no-op, erasing the window (defect #7).
 
             // Bind view to services singleton
             VegaViewServices.bind(result.view);
@@ -262,22 +263,50 @@ export const VegaEmbed: React.FC<VegaEmbedProps> = ({
     });
 
     /**
+     * The last spec for which this instance opened the embed-in-flight window.
+     * Compared DEEPLY against the next memoized spec (see below) so the window
+     * only opens when `useVegaEmbed` — which re-embeds on deep inequality — will
+     * actually re-embed. NOT reset to `null` on deactivation: see the
+     * reactivation reasoning in the effect below.
+     */
+    const lastEmbedWindowSpecRef = useRef<object | null>(null);
+
+    /**
      * Open the "embed in flight" window before a new spec embeds.
      *
-     * Keyed on the memoized `spec` identity: when a new non-null spec is about
-     * to embed, mark the view not-ready. `handleEmbed` flips it back to true
-     * once `runAsync()` completes. Because this runs in a separate render from
-     * `handleEmbed`, the false→true transition actually spans time (defect #7) —
-     * previously both calls happened in one synchronous callback and React
-     * batched them into a no-op, so the window never existed and updates landing
-     * mid-embed were dropped.
+     * When a genuinely different spec is about to embed, mark the view
+     * not-ready; `handleEmbed` flips it back to true once `runAsync()`
+     * completes. Because this runs in a separate render from `handleEmbed`, the
+     * false→true transition actually spans time (defect #7) — previously both
+     * calls happened in one synchronous callback and React batched them into a
+     * no-op, so the window never existed and updates landing mid-embed were
+     * dropped.
+     *
+     * The gate MUST mirror `useVegaEmbed`'s DEEP-compare semantics, not spec
+     * identity: `handleCompile` in the compilation slice creates a fresh result
+     * object on every `compile()` call even when the compiled content is
+     * unchanged, so the memo can yield a new-identity, deep-equal spec that
+     * `useVegaEmbed` will NOT re-embed. Opening the window on identity would set
+     * `viewReady = false` with no re-embed to ever set it true again,
+     * deadlocking every subsequent data update into 'defer'.
+     * `shouldOpenEmbedWindow` deep-compares, so the window opens exactly when a
+     * real re-embed will follow.
+     *
+     * Deactivation/reactivation: `lastEmbedWindowSpecRef` is deliberately NOT
+     * reset when `spec` goes `null`. After reactivation with deep-equal content
+     * this effect therefore does not fire — but `useVegaEmbed` WILL re-embed
+     * (its deep-compare deps saw `null` while inactive), and the window is
+     * already open because the deactivation-clear effect (or the other
+     * instance's deactivation) set `viewReady` false before this instance's
+     * spec became non-null. The re-embed's `handleEmbed` then closes it.
      *
      * Data-only changes do NOT recompute `spec` (its memo deps are
      * `[compilation, provider, isActive]`, not `values`), so this does not fire
      * on the incremental-update path.
      */
     useEffect(() => {
-        if (spec) {
+        if (shouldOpenEmbedWindow(lastEmbedWindowSpecRef.current, spec)) {
+            lastEmbedWindowSpecRef.current = spec;
             setViewReady(false);
         }
     }, [spec, setViewReady]);

--- a/packages/app-core/src/features/visual-viewer/components/vega-embed.tsx
+++ b/packages/app-core/src/features/visual-viewer/components/vega-embed.tsx
@@ -18,6 +18,12 @@ import { VEGA_EMBED_ROOT_STYLE } from './vega-embed-styles';
 import { getRestrictiveVegaLoader } from './restrictive-loader';
 
 type VegaEmbedProps = {
+    /**
+     * Whether this is the single live embed instance (defect C1). When false,
+     * the `spec` memo returns `null` so `useVegaEmbed` finalizes and clears the
+     * view, and this instance runs no view side effects.
+     */
+    isActive: boolean;
     onRenderingError?: (error: Error) => void;
     onRenderingFinished?: () => void;
     onRenderingStarted?: () => void;
@@ -45,6 +51,7 @@ const useVegaEmbedStyles = makeStyles({
  * VisualViewer triggers a re-compile for large datasets).
  */
 export const VegaEmbed: React.FC<VegaEmbedProps> = ({
+    isActive,
     onRenderingError,
     onRenderingFinished,
     onRenderingStarted,
@@ -62,6 +69,13 @@ export const VegaEmbed: React.FC<VegaEmbedProps> = ({
 
     // Track whether we've done the initial embed (to distinguish first render from updates)
     const hasEmbeddedRef = useRef(false);
+
+    // The view THIS instance last bound to the shared `VegaViewServices`
+    // singleton. Used as an ownership token: the deactivation-clear effect only
+    // wipes the singleton if it still points at this instance's own view, so an
+    // inactive/unmounting instance can never clear the OTHER instance's
+    // freshly-bound view (defect C1).
+    const ownViewRef = useRef<View | null>(null);
 
     const {
         compilation,
@@ -90,11 +104,19 @@ export const VegaEmbed: React.FC<VegaEmbedProps> = ({
         (result: { view: View; vgSpec?: object }) => {
             logDebug('VegaEmbed: New view created');
 
-            // Mark view as NOT ready - datasets/signals won't be populated until runAsync completes
-            setViewReady(false);
+            // NOTE: `setViewReady(false)` is NOT called here. It is driven by a
+            // separate effect keyed on the memoized `spec` identity (below), so
+            // the false→true transition spans two renders and the in-flight
+            // window actually exists. Toggling false→true in this single
+            // synchronous callback batched into a no-op, erasing the window
+            // (defect #7).
 
             // Bind view to services singleton
             VegaViewServices.bind(result.view);
+
+            // Record this instance's own view for the ownership-guarded
+            // deactivation clear (defect C1).
+            ownViewRef.current = result.view;
 
             // Update pattern fill services for dynamic pattern fills
             VegaPatternFillServices.update();
@@ -171,6 +193,13 @@ export const VegaEmbed: React.FC<VegaEmbedProps> = ({
      * via `view.data()` API. VegaEmbed only re-embeds when compilation changes.
      */
     const spec = useMemo(() => {
+        // Inactive instance embeds nothing (defect C1). A `null` spec makes
+        // `useVegaEmbed` finalize the current view, clear the container, and bump
+        // its generation token, so only the live instance holds a running view.
+        if (!isActive) {
+            return null;
+        }
+
         if (!compilation || compilation.status !== 'ready' || !provider) {
             return null;
         }
@@ -195,7 +224,7 @@ export const VegaEmbed: React.FC<VegaEmbedProps> = ({
         });
 
         return patchedSpec;
-    }, [compilation, provider]);
+    }, [compilation, provider, isActive]);
 
     /**
      * Get the embed options. Returns empty object if compilation not ready.
@@ -231,6 +260,54 @@ export const VegaEmbed: React.FC<VegaEmbedProps> = ({
         onEmbed: handleEmbed,
         onError: handleError
     });
+
+    /**
+     * Open the "embed in flight" window before a new spec embeds.
+     *
+     * Keyed on the memoized `spec` identity: when a new non-null spec is about
+     * to embed, mark the view not-ready. `handleEmbed` flips it back to true
+     * once `runAsync()` completes. Because this runs in a separate render from
+     * `handleEmbed`, the false→true transition actually spans time (defect #7) —
+     * previously both calls happened in one synchronous callback and React
+     * batched them into a no-op, so the window never existed and updates landing
+     * mid-embed were dropped.
+     *
+     * Data-only changes do NOT recompute `spec` (its memo deps are
+     * `[compilation, provider, isActive]`, not `values`), so this does not fire
+     * on the incremental-update path.
+     */
+    useEffect(() => {
+        if (spec) {
+            setViewReady(false);
+        }
+    }, [spec, setViewReady]);
+
+    /**
+     * Deactivation clear (defect C1). When this instance stops being the live
+     * one, its `spec` goes `null` and `useVegaEmbed` finalizes the view — but
+     * the shared `VegaViewServices` singleton and React view state still point
+     * at it. Clear them here so a single live view remains.
+     *
+     * Ownership guard: only clear if the singleton STILL points at the view this
+     * instance bound. Otherwise an inactive (or never-active) instance could
+     * wipe the OTHER instance's freshly-bound view. Skipped entirely when this
+     * instance never bound a view.
+     */
+    useEffect(() => {
+        if (isActive) return;
+        if (
+            ownViewRef.current &&
+            VegaViewServices.getView() === ownViewRef.current
+        ) {
+            logDebug('VegaEmbed: Deactivated - clearing owned view');
+            VegaViewServices.clearView();
+            setView(null);
+            setViewReady(false);
+        }
+        // Drop our reference either way: our view (if any) has been finalized by
+        // the `spec === null` path in `useVegaEmbed`.
+        ownViewRef.current = null;
+    }, [isActive, setView, setViewReady]);
 
     /**
      * Clear view state when compilation has errors (ensures stale view references don't persist when spec is invalid).

--- a/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
+++ b/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
@@ -280,7 +280,9 @@ export const VisualViewer = ({
         switch (gate) {
             case 'initialize':
                 logDebug(
-                    'VisualViewer: Initial values set, waiting for first embed'
+                    isActive
+                        ? 'VisualViewer: Initial values set, waiting for first embed'
+                        : 'VisualViewer: Initial values set (inactive instance, baseline recorded)'
                 );
                 return;
             case 'unchanged':

--- a/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
+++ b/packages/app-core/src/features/visual-viewer/components/visual-viewer.tsx
@@ -20,8 +20,11 @@ import { VegaEmbedErrorBoundary } from './vega-embed-error-boundary';
 import { VEGA_CONTAINER_ID } from '../constants';
 import {
     performIncrementalUpdate,
-    resolveDataChangeAction
+    resolveDataChangeAction,
+    resolveDataChangeGate,
+    shouldAdvancePrevValues
 } from '../incremental-update';
+import { computeEmbedActive } from '../embed-active';
 import { useDenebState } from '../../../state';
 import { useDenebPlatformProvider } from '../../../components/deneb-platform';
 import { INCREMENTAL_UPDATE_CONFIGURATION } from '../../../lib/vega/incremental-update-configuration';
@@ -39,13 +42,31 @@ const originalDevicePixelRatio = window.devicePixelRatio;
 
 /**
  * Module-level effective DPR, read by the devicePixelRatio getter override.
- * Updated synchronously during render by any VisualViewer instance.
+ * Updated synchronously during render by the active VisualViewer instance.
  */
 let effectiveDevicePixelRatio = originalDevicePixelRatio;
-Object.defineProperty(window, 'devicePixelRatio', {
-    get: () => effectiveDevicePixelRatio,
-    configurable: true
-});
+
+/**
+ * Whether the `window.devicePixelRatio` getter override has been installed.
+ * The override is installed lazily on the first VisualViewer mount rather than
+ * at import time, so merely importing this module never mutates global
+ * `window`. Guarded by this flag so repeated mounts (multiple instances,
+ * remounts) install it exactly once.
+ */
+let devicePixelRatioOverrideInstalled = false;
+
+/**
+ * Install the `window.devicePixelRatio` getter override, once. Idempotent: safe
+ * to call from every VisualViewer mount.
+ */
+const installDevicePixelRatioOverride = () => {
+    if (devicePixelRatioOverrideInstalled) return;
+    devicePixelRatioOverrideInstalled = true;
+    Object.defineProperty(window, 'devicePixelRatio', {
+        get: () => effectiveDevicePixelRatio,
+        configurable: true
+    });
+};
 
 type ScrollPosition = { scrollTop: number; scrollLeft: number };
 
@@ -128,6 +149,7 @@ export const VisualViewer = ({
         enableIncrementalDataUpdates,
         incrementalUpdateThreshold,
         viewReady,
+        interfaceType,
         logError,
         logDurableError,
         logDurableWarn,
@@ -159,6 +181,7 @@ export const VisualViewer = ({
         incrementalUpdateThreshold:
             state.compilation.incrementalUpdateThreshold,
         viewReady: state.compilation.viewReady,
+        interfaceType: state.interface.type,
         logError: state.compilation.logError,
         logDurableError: state.compilation.logDurableError,
         logDurableWarn: state.compilation.logDurableWarn,
@@ -179,6 +202,21 @@ export const VisualViewer = ({
         vegaLoader,
         viewEventBinders
     } = useDenebPlatformProvider();
+
+    // Whether THIS instance is the single live embed. The retained (hidden)
+    // editor instance and the standalone viewer instance can both be mounted at
+    // once; exactly one runs live, chosen by the current interface mode (defect
+    // C1). The inactive instance runs no compile/data/DPR side effects and
+    // renders a `null` spec (see `VegaEmbed`).
+    const isActive = computeEmbedActive(interfaceType, !!isEmbeddedInEditor);
+
+    // Install the devicePixelRatio getter override on first mount (idempotent),
+    // rather than at module import time. Installed unconditionally regardless of
+    // `isActive` — the getter merely reads `effectiveDevicePixelRatio`, which
+    // only the active instance writes.
+    useLayoutEffect(() => {
+        installDevicePixelRatioOverride();
+    }, []);
 
     const embedScaleFactor = useMemo(() => {
         if (!scaleToZoom || renderMode !== 'canvas') return undefined;
@@ -203,11 +241,15 @@ export const VisualViewer = ({
     // (scaleFactor in embed options only affects exports).
     // Uses useLayoutEffect to run synchronously after commit but before paint.
     useLayoutEffect(() => {
+        // Only the live instance writes the shared module-level DPR, so the two
+        // mounted instances never fight over `effectiveDevicePixelRatio` (defect
+        // C1).
+        if (!isActive) return;
         effectiveDevicePixelRatio =
             embedScaleFactor !== undefined
                 ? originalDevicePixelRatio * embedScaleFactor
                 : originalDevicePixelRatio;
-    }, [embedScaleFactor]);
+    }, [embedScaleFactor, isActive]);
 
     // Track previous values reference for incremental update detection
     const prevValuesRef = useRef<unknown[] | null>(null);
@@ -216,39 +258,50 @@ export const VisualViewer = ({
      * Handle data changes from host/'known' datasets.
      */
     useEffect(() => {
-        // Skip on initial mount - wait for first embed to complete
-        if (prevValuesRef.current === null) {
-            prevValuesRef.current = values;
-            logDebug(
-                'VisualViewer: Initial values set, waiting for first embed'
-            );
-            return;
-        }
-
-        // Skip if values reference hasn't changed
-        if (prevValuesRef.current === values) {
-            return;
-        }
-
-        // Update ref immediately
-        const previousValues = prevValuesRef.current;
-        prevValuesRef.current = values;
-
-        // Skip if view is not ready yet (runAsync() hasn't completed)
-        // This is critical - the view's datasets/signals are only populated AFTER runAsync() finishes
-        if (!viewReady) {
-            logDebug(
-                'VisualViewer: View not ready yet (runAsync in progress), skipping data change'
-            );
-            return;
-        }
-
-        // Get the current view
         const view = VegaViewServices.getView();
-        if (!view) {
-            logDebug('VisualViewer: No view yet, skipping data change');
-            return;
+        const previousValues = prevValuesRef.current;
+        const gate = resolveDataChangeGate({
+            prevValues: previousValues,
+            values,
+            isActive,
+            viewReady,
+            hasView: !!view
+        });
+
+        // Advance the baseline ONLY when an update is actually consumed
+        // ('initialize' records the first baseline; 'act' consumes a change).
+        // Critically, 'defer' (view mid-embed) does NOT advance — so when
+        // `viewReady` (a dependency of this effect) flips true, the effect
+        // re-runs and applies the update instead of dropping it (defect #7).
+        if (shouldAdvancePrevValues(gate)) {
+            prevValuesRef.current = values;
         }
+
+        switch (gate) {
+            case 'initialize':
+                logDebug(
+                    'VisualViewer: Initial values set, waiting for first embed'
+                );
+                return;
+            case 'unchanged':
+                return;
+            case 'inactive':
+                // Not the single live instance (defect C1): run no side effects.
+                return;
+            case 'defer':
+                logDebug(
+                    'VisualViewer: View not ready yet (runAsync in progress), skipping data change'
+                );
+                return;
+            case 'no-view':
+                logDebug('VisualViewer: No view yet, skipping data change');
+                return;
+        }
+
+        // gate === 'act': an active, ready, view-bound instance is consuming a
+        // data change. `view` is guaranteed non-null here (the 'no-view' gate
+        // covers the null case); this guard only narrows the type.
+        if (!view) return;
 
         // Do "recompile threshold" checks
         const effectiveThreshold = Math.min(
@@ -317,7 +370,7 @@ export const VisualViewer = ({
             {
                 datasetName: DATASET_DEFAULT_NAME,
                 rowCount: values.length,
-                previousCount: previousValues.length
+                previousCount: previousValues?.length ?? 0
             }
         );
 
@@ -390,6 +443,7 @@ export const VisualViewer = ({
     }, [
         values,
         viewReady,
+        isActive,
         enableIncrementalDataUpdates,
         incrementalUpdateThreshold,
         spec,
@@ -431,6 +485,11 @@ export const VisualViewer = ({
      * existing view without triggering a full re-compile/re-embed.
      */
     useEffect(() => {
+        // Only the single live instance compiles (defect C1). When this instance
+        // becomes active, `isActive` flips true and the effect re-fires,
+        // producing the instance-appropriate scaleFactor from `embedScaleFactor`.
+        if (!isActive) return;
+
         logDebug('VisualViewer: Triggering compilation', {
             hasSpec: !!spec,
             hasConfig: !!config,
@@ -465,7 +524,8 @@ export const VisualViewer = ({
         logLevel,
         renderMode,
         embedScaleFactor,
-        schemaValidator
+        schemaValidator,
+        isActive
     ]);
 
     /**
@@ -475,6 +535,7 @@ export const VisualViewer = ({
         () => (
             <VegaEmbedErrorBoundary onError={onRenderingError}>
                 <VegaEmbed
+                    isActive={isActive}
                     onRenderingError={onRenderingError}
                     onRenderingFinished={onRenderingFinished}
                     onRenderingStarted={onRenderingStarted}
@@ -487,6 +548,7 @@ export const VisualViewer = ({
             </VegaEmbedErrorBoundary>
         ),
         [
+            isActive,
             onRenderingError,
             onRenderingFinished,
             onRenderingStarted,

--- a/packages/app-core/src/features/visual-viewer/embed-active.ts
+++ b/packages/app-core/src/features/visual-viewer/embed-active.ts
@@ -1,0 +1,28 @@
+import { type InterfaceType } from '../../lib/interface';
+
+/**
+ * Decide whether THIS Vega embed instance should be the single live one.
+ *
+ * Two `VisualViewer`/`VegaEmbed` instances can be mounted at once: the retained
+ * (hidden) editor instance and the standalone viewer instance. Exactly one must
+ * run live at any time — running both simultaneously doubles data-change
+ * effects, races the shared `VegaViewServices` binding, and emits duplicate host
+ * rendering events (defect C1).
+ *
+ * The active instance is selected by the current interface mode:
+ *
+ * - The editor-embedded instance (`isEmbeddedInEditor === true`) is live only in
+ *   `'editor'` mode.
+ * - The standalone viewer instance (`isEmbeddedInEditor === false`) is live only
+ *   in `'viewer'` mode.
+ *
+ * The two conditions are mutually exclusive for every interface mode, so at most
+ * one instance is ever active.
+ */
+export const computeEmbedActive = (
+    interfaceType: InterfaceType,
+    isEmbeddedInEditor: boolean
+): boolean =>
+    isEmbeddedInEditor
+        ? interfaceType === 'editor'
+        : interfaceType === 'viewer';

--- a/packages/app-core/src/features/visual-viewer/embed-window.ts
+++ b/packages/app-core/src/features/visual-viewer/embed-window.ts
@@ -1,0 +1,30 @@
+import { deepEqual } from 'fast-equals';
+
+/**
+ * Decide whether the "embed in flight" window should open (`viewReady` set
+ * false) for a newly memoized spec.
+ *
+ * `useVegaEmbed` re-embeds on DEEP inequality of its spec (it uses
+ * `useDeepCompareEffect`), but the spec memo in `VegaEmbed` recomputes — and
+ * produces a NEW object — whenever the compilation result's identity changes,
+ * and `handleCompile` in the compilation slice creates a fresh result object on
+ * EVERY `compile()` call, even when the compiled content is unchanged (e.g. a
+ * JSONC comment/whitespace edit). Opening the window on spec IDENTITY change
+ * would therefore set `viewReady = false` for a deep-equal spec that
+ * `useVegaEmbed` never re-embeds — and nothing would ever flip `viewReady` back
+ * to true, deadlocking every subsequent data update into 'defer'.
+ *
+ * This predicate mirrors `useVegaEmbed`'s deep-compare semantics so the window
+ * opens exactly when a real re-embed will follow:
+ *
+ * - `nextSpec === null` never opens the window (nothing will embed).
+ * - A deep-equal spec (new identity, same content) never opens the window
+ *   (`useVegaEmbed` will skip the re-embed).
+ * - Only a genuinely different spec opens it — and a spec deep-change is
+ *   guaranteed to re-embed, whose completion closes the window via
+ *   `setViewReady(true)`.
+ */
+export const shouldOpenEmbedWindow = (
+    previousSpec: object | null,
+    nextSpec: object | null
+): boolean => nextSpec !== null && !deepEqual(previousSpec, nextSpec);

--- a/packages/app-core/src/features/visual-viewer/incremental-update.ts
+++ b/packages/app-core/src/features/visual-viewer/incremental-update.ts
@@ -215,3 +215,65 @@ export const resolveDataChangeAction = (
     }
     return 'incremental';
 };
+
+/**
+ * How the data-change effect should treat one host data update, decided BEFORE
+ * it works out how to apply the change (that second decision is
+ * `resolveDataChangeAction`).
+ *
+ * - `'initialize'` — first observation: record the baseline values and take no
+ *   action (there is nothing yet to diff against).
+ * - `'unchanged'`  — the values reference is identical to the last one seen;
+ *   nothing to do.
+ * - `'inactive'`   — this embed instance is not the single live one (defect C1);
+ *   it must run no side effects.
+ * - `'defer'`      — the view is mid-embed (`viewReady` is false). The update is
+ *   NOT consumed and the baseline is NOT advanced; because `viewReady` is a
+ *   dependency of the effect, it re-runs and applies the update once the embed
+ *   completes, so a change that lands during an in-flight embed is not dropped
+ *   (defect #7).
+ * - `'no-view'`    — no Vega view is bound yet; nothing to update.
+ * - `'act'`        — apply the data change (the ignore/recompile/incremental
+ *   choice is resolved downstream by `resolveDataChangeAction`).
+ */
+export type DataChangeGate =
+    | 'initialize'
+    | 'unchanged'
+    | 'inactive'
+    | 'defer'
+    | 'no-view'
+    | 'act';
+
+/**
+ * Decide how the data-change effect should treat a host data update.
+ *
+ * The ordering is deliberate. `'inactive'` and `'defer'` are checked before any
+ * action is taken, and both leave the previous-values baseline untouched (see
+ * `shouldAdvancePrevValues`). Leaving the baseline untouched on `'defer'` is the
+ * crux of defect #7: an update that arrives while the view is mid-embed is
+ * re-evaluated — not swallowed — when `viewReady` flips true.
+ */
+export const resolveDataChangeGate = (params: {
+    prevValues: readonly unknown[] | null;
+    values: readonly unknown[];
+    isActive: boolean;
+    viewReady: boolean;
+    hasView: boolean;
+}): DataChangeGate => {
+    const { prevValues, values, isActive, viewReady, hasView } = params;
+    if (prevValues === null) return 'initialize';
+    if (prevValues === values) return 'unchanged';
+    if (!isActive) return 'inactive';
+    if (!viewReady) return 'defer';
+    if (!hasView) return 'no-view';
+    return 'act';
+};
+
+/**
+ * Whether the data-change effect should advance its previous-values baseline for
+ * a given gate. Only `'initialize'` (record the first baseline) and `'act'` (an
+ * update was consumed) advance it; every "did not apply" gate leaves the
+ * baseline untouched so the update can be re-evaluated on a later effect run.
+ */
+export const shouldAdvancePrevValues = (gate: DataChangeGate): boolean =>
+    gate === 'initialize' || gate === 'act';

--- a/packages/app-core/src/features/visual-viewer/index.ts
+++ b/packages/app-core/src/features/visual-viewer/index.ts
@@ -1,1 +1,2 @@
 export { VisualViewer } from './components/visual-viewer';
+export { computeEmbedActive } from './embed-active';


### PR DESCRIPTION
Fixes **Critical C1** and **Important #7** from the 2.0 pre-merge review (WP5).

## What
- **C1 — exactly one live Vega embed.** After the editor was opened once, the retained (hidden) editor's `VisualViewer` and the visible viewer's instance both ran live — doubling data-change effects (tripping the incremental-update WeakSet guard → durable warning spam + forced recompiles), racing `VegaViewServices` binds (cross-filter could target the hidden view), and doubling host rendering events. Now a pure `computeEmbedActive(interfaceType, isEmbeddedInEditor)` selects the single live instance; the inactive instance embeds `null` (finalized by `useVegaEmbed`), runs no compile/data/DPR side effects, and clears the view singleton **only when it owns it** (ownership guard prevents wiping the other instance's fresh bind).
- **#7 — updates landing mid-embed are no longer dropped.** The data-change effect advances its previous-values baseline only when an update is actually consumed (pure `resolveDataChangeGate`/`shouldAdvancePrevValues`), so a change deferred during an in-flight embed re-applies when `viewReady` flips true. The embed-in-flight window is now real: `setViewReady(false)` moved out of `handleEmbed` (where the same-tick false→true pair batched to a no-op) into a deep-compare-gated effect (`shouldOpenEmbedWindow`, mirroring `useVegaEmbed`'s re-embed semantics) so the window opens exactly when a re-embed will follow — never deadlocks on identity-only spec churn.
- **DPR override** installs idempotently on first mount instead of import time; only the active instance writes the effective ratio.

## Notes
- Mount graph untouched: no changes to `retained-deneb-editor`, `editor-content`, `gated-deneb-viewer`, or `app.tsx` — Monaco retention and the viewport-match gate machinery are preserved.
- Known benign edge: on reactivation after data changed while inactive, one redundant incremental update fires (same values; one extra rendering pair). Strictly better than pre-fix behavior.
- `npm run ci:local`: ALL CHECKS PASSED. New pure tests: `embed-active` truth table + mutual exclusion, `embed-window` (incl. new-identity/deep-equal no-open), 12 data-change gate cases.

## Manual verification checklist
1. Open editor once → back to viewer: cross-filter/host updates change the **visible** chart.
2. After an editor session, data changes produce **no durable warning spam**.
3. One `renderingStarted`/`renderingFinished` pair per steady-state update (dev overlay).
4. Repeated viewer↔editor switches: no blank view, no doubled rendering.
5. Update arriving during a slow embed is applied once ready (not dropped).
6. Editor zoom / viewer scaling stays crisp (DPR override still active).
7. No-op spec edit (JSONC comment) + apply: subsequent data updates continue to apply (no permanent defer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)