### PR TITLE
fix: 2.0 migration correctness (context menu remap, consolidate stamp)

### DIFF
--- a/src/lib/dataset/__test__/processing-migration.test.ts
+++ b/src/lib/dataset/__test__/processing-migration.test.ts
@@ -251,6 +251,41 @@ describe('getMappedDataset — legacy support-field migration integrity (U3)', (
             expect(stamp.denebMetaVersion).toBe(2);
         });
 
+        it('preserves the user-chosen consolidateFieldParameters=true in the stamp (partial-persist recovery)', () => {
+            mockProject = makeProject({
+                denebMetaVersion: 0,
+                supportFieldConfiguration: {
+                    Category: USER_EDIT_CATEGORY,
+                    Sales: USER_EDIT_SALES
+                },
+                consolidateFieldParameters: true
+            });
+
+            getMappedDataset(CATEGORICAL, 'en-US');
+
+            const stamp = mockApplySupportFieldMigrationStamp.mock.calls[0][0];
+            // Processing used consolidateFieldParameters=true for this pass
+            // (non-legacy, existing config present) — the stamp must carry
+            // the same value, not unconditionally false.
+            expect(stamp.consolidateFieldParameters).toBe(true);
+        });
+
+        it('stamps consolidateFieldParameters=false when the user had it off (partial-persist recovery)', () => {
+            mockProject = makeProject({
+                denebMetaVersion: 0,
+                supportFieldConfiguration: {
+                    Category: USER_EDIT_CATEGORY,
+                    Sales: USER_EDIT_SALES
+                },
+                consolidateFieldParameters: false
+            });
+
+            getMappedDataset(CATEGORICAL, 'en-US');
+
+            const stamp = mockApplySupportFieldMigrationStamp.mock.calls[0][0];
+            expect(stamp.consolidateFieldParameters).toBe(false);
+        });
+
         it('treats a non-empty persisted configuration as non-legacy evidence: unconfigured fields get new-spec defaults', () => {
             getMappedDataset(CATEGORICAL, 'en-US');
 

--- a/src/lib/dataset/processing.ts
+++ b/src/lib/dataset/processing.ts
@@ -315,7 +315,15 @@ export const getMappedDataset = (
                     denebMetaVersion: getStateManagementVersionToStamp(
                         SUPPORT_FIELD_LEGACY_MIGRATION_ID
                     ),
-                    consolidateFieldParameters: false
+                    // Must match the value this pass processes with (see
+                    // `consolidate` below): a fresh-legacy pass (no existing
+                    // config) forces false, but a partial-persist recovery
+                    // pass (existing config present) is non-legacy and must
+                    // preserve the user's chosen setting rather than
+                    // silently discarding it on the next update.
+                    consolidateFieldParameters: hasExistingConfig
+                        ? (state.project.consolidateFieldParameters ?? true)
+                        : false
                 };
             }
 

--- a/src/lib/persistence/__test__/project.test.ts
+++ b/src/lib/persistence/__test__/project.test.ts
@@ -46,19 +46,19 @@ describe('resolveContextMenuProperties', () => {
         ]);
     });
 
-    it('should default to contextMenu: false and contextMenuSelector: true when interactivity is undefined', () => {
+    it('should migrate to show menu without selector when interactivity is undefined (no interactivity block at all)', () => {
         const result = resolveContextMenuProperties(undefined);
         expect(result).toEqual([
-            { name: 'enableContextMenu', value: false },
-            { name: 'enableContextMenuSelector', value: true }
+            { name: 'enableContextMenu', value: true },
+            { name: 'enableContextMenuSelector', value: false }
         ]);
     });
 
-    it('should default to contextMenu: false and contextMenuSelector: true for empty object', () => {
+    it('should migrate to show menu without selector for empty object (contextMenu unspecified)', () => {
         const result = resolveContextMenuProperties({});
         expect(result).toEqual([
-            { name: 'enableContextMenu', value: false },
-            { name: 'enableContextMenuSelector', value: true }
+            { name: 'enableContextMenu', value: true },
+            { name: 'enableContextMenuSelector', value: false }
         ]);
     });
 });

--- a/src/lib/persistence/context-menu-migration.ts
+++ b/src/lib/persistence/context-menu-migration.ts
@@ -12,7 +12,12 @@ export const resolveContextMenuProperties = (
     interactivity?: Partial<UsermetaInteractivity>
 ) => {
     const isLegacy = interactivity?.contextMenuSelector === undefined;
-    const legacyMenuOff = !(interactivity?.contextMenu ?? true);
+    // Absent contextMenu must resolve identically to the fallthrough default
+    // below (`?? false`) so the legacy-off detector and the value it gates
+    // never diverge. This mirrors the persisted-visual remap's legacy-default
+    // handling in migration.ts (isLegacyContextMenuRemapApplicable) — keep
+    // both in sync if either changes.
+    const legacyMenuOff = !(interactivity?.contextMenu ?? false);
     return [
         {
             name: 'enableContextMenu',


### PR DESCRIPTION
Fixes **Important #4 and #5** from the 2.0 pre-merge review (WP2).

- **#4 — legacy templates without explicit `contextMenu` no longer suppress the context menu.** The template-import path's legacy-off detector treated an absent `contextMenu` as `true` while its fallthrough treated absent as `false`, so a legacy template with no `interactivity` block resolved `(enableContextMenu: false, enableContextMenuSelector: true)` — silently suppressing the menu under 2.0 split semantics, permanently (the persisted-visual remap never re-runs for visuals created at 2.0). Absent now resolves `(true, false)`, identical to the persisted-visual remap in `migration.ts`; a cross-reference comment keeps the two sites in sync. Full truth table verified across both migration paths; the test that pinned the wrong behavior now asserts the corrected mapping.
- **#5 — migration stamp preserves user `consolidateFieldParameters` on partial-persist recovery.** On the M10 recovery path (config half persisted, version stamp missing), processing honored the user's setting but the stamp wrote `false` over it — flipping behavior on the next update. The stamp now carries exactly the value the pass processed with (`hasExistingConfig ? user value ?? true : false`); fresh-legacy stamping is unchanged.

`npm run ci:local`: ALL CHECKS PASSED. Persistence suite 69/69, dataset suite 101/101, full workspace test + lint green.

Part of the 2.0 pre-merge review remediation (WP2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)