### PR TITLE
fix: slice-sync deep equality + project/editor state consistency

### DIFF
--- a/packages/app-core/src/state/__tests__/editor.test.ts
+++ b/packages/app-core/src/state/__tests__/editor.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { createDenebState } from '../state';
+import type { monaco } from '../../lib/monaco/types';
+
+/**
+ * Editor slice — `updateChanges` view-state fallback.
+ *
+ * When a role is edited WITHOUT supplying a fresh Monaco view state, each
+ * editor role must fall back to ITS OWN stored view state. A prior bug used
+ * the active role's view state as the fallback for the OTHER role, so every
+ * Spec keystroke overwrote the Config editor's saved cursor/scroll state (and
+ * vice versa).
+ */
+const makeStore = () => createDenebState({ applicationVersion: 'test' });
+
+const asViewState = (id: string) =>
+    ({ __id: id }) as unknown as monaco.editor.ICodeEditorViewState;
+
+describe('editor slice — updateChanges view-state fallback', () => {
+    it('preserves the Config view state when updating the Spec editor (no cross-contamination)', () => {
+        const store = makeStore();
+        const configViewState = asViewState('config');
+        const specViewState = asViewState('spec');
+        store.setState((state) => ({
+            editor: {
+                ...state.editor,
+                viewStateConfig: configViewState,
+                viewStateSpec: specViewState
+            }
+        }));
+
+        // Update the Spec editor WITHOUT supplying a new view state.
+        store
+            .getState()
+            .editor.updateChanges({ role: 'Spec', text: 'new spec text' });
+
+        const { viewStateConfig, viewStateSpec } = store.getState().editor;
+        // The Config editor's saved state must be untouched by a Spec edit.
+        expect(viewStateConfig).toBe(configViewState);
+        // The Spec editor keeps its own stored state (none supplied).
+        expect(viewStateSpec).toBe(specViewState);
+    });
+
+    it('preserves the Spec view state when updating the Config editor', () => {
+        const store = makeStore();
+        const configViewState = asViewState('config');
+        const specViewState = asViewState('spec');
+        store.setState((state) => ({
+            editor: {
+                ...state.editor,
+                viewStateConfig: configViewState,
+                viewStateSpec: specViewState
+            }
+        }));
+
+        store
+            .getState()
+            .editor.updateChanges({ role: 'Config', text: 'new config text' });
+
+        const { viewStateConfig, viewStateSpec } = store.getState().editor;
+        expect(viewStateSpec).toBe(specViewState);
+        expect(viewStateConfig).toBe(configViewState);
+    });
+});

--- a/packages/app-core/src/state/__tests__/project.test.ts
+++ b/packages/app-core/src/state/__tests__/project.test.ts
@@ -84,6 +84,48 @@ describe('project slice — syncProjectData initialization (M12)', () => {
 
         expect(store.getState().project.__isInitialized__).toBe(false);
     });
+
+    it('strips stale embedded support-field config from export dataset entries when a field is no longer configured (parity with setter/migration-stamp)', () => {
+        const store = makeStore();
+        // Seed an export dataset entry that already carries embedded config,
+        // as if a prior sync had configured this field.
+        store.setState((state) => ({
+            export: {
+                ...state.export,
+                metadata: {
+                    ...state.export.metadata!,
+                    datasets: {
+                        dataset: [
+                            {
+                                key: '__0__',
+                                name: 'Category',
+                                namePlaceholder: 'Category',
+                                type: 'text',
+                                supportFieldConfiguration: {
+                                    highlight: true,
+                                    format: true,
+                                    formatted: true
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }));
+
+        // Sync a project whose supportFieldConfiguration no longer includes
+        // 'Category'. The host-sync embed variant used to leave the stale
+        // embedded config in place; it must now be stripped.
+        store.getState().project.syncProjectData(
+            partialSync({
+                spec: '{"mark":"bar"}',
+                supportFieldConfiguration: {}
+            })
+        );
+
+        const entry = store.getState().export.metadata?.datasets?.dataset?.[0];
+        expect(entry?.supportFieldConfiguration).toBeUndefined();
+    });
 });
 
 describe('project slice — applySupportFieldMigrationStamp (M10)', () => {

--- a/packages/app-core/src/state/editor.ts
+++ b/packages/app-core/src/state/editor.ts
@@ -294,23 +294,23 @@ const handleUpdateChanges = (
     payload: EditorSliceUpdateChangesPayload
 ): Partial<StoreState> => {
     const { role, text, viewState } = payload;
-    const existingViewState =
-        role === 'Spec'
-            ? state.editor.viewStateSpec
-            : state.editor.viewStateConfig;
     const isDirty =
         (role === 'Spec'
             ? state.project.spec !== text
             : state.project.config !== text) &&
         state.editor.applyMode !== 'Auto';
+    // Each role falls back to ITS OWN stored view state when no fresh one is
+    // supplied. Using the active role's view state as the fallback for the
+    // OTHER role cross-contaminates them — every Spec edit would overwrite the
+    // Config editor's saved cursor/scroll state, and vice versa.
     const viewStateConfig =
         role === 'Config'
             ? (viewState ?? state.editor.viewStateConfig)
-            : existingViewState;
+            : state.editor.viewStateConfig;
     const viewStateSpec =
         role === 'Spec'
             ? (viewState ?? state.editor.viewStateSpec)
-            : existingViewState;
+            : state.editor.viewStateSpec;
     const stagedConfig = role === 'Config' ? text : state.editor.stagedConfig;
     const stagedSpec = role === 'Spec' ? text : state.editor.stagedSpec;
     const exportMetadata = getUpdatedExportMetadata(

--- a/packages/app-core/src/state/project.ts
+++ b/packages/app-core/src/state/project.ts
@@ -16,6 +16,31 @@ import {
 import { logDebug } from '@deneb-viz/utils/logging';
 import { type SupportFieldConfiguration } from '@deneb-viz/data-core/support-fields';
 import { DATASET_DEFAULT_NAME } from '@deneb-viz/data-core/dataset';
+import { type UsermetaDatasetField } from '@deneb-viz/data-core/field';
+
+/**
+ * Project each export dataset entry's per-field support configuration into its
+ * `supportFieldConfiguration` slot, and STRIP the slot from any field that is
+ * no longer present in `config`. This is the single, canonical implementation
+ * shared by every site that embeds support-field config into export metadata
+ * (template init, setter, migration stamp, host sync). Previously duplicated
+ * four times with two divergent semantics: two variants stripped stale config,
+ * two left it embedded on removed fields — corrupting export/template
+ * integrity when a field was reconfigured to defaults or removed.
+ */
+const embedSupportFieldConfig = (
+    dataset: UsermetaDatasetField[],
+    config: SupportFieldConfiguration | undefined
+): UsermetaDatasetField[] =>
+    dataset.map((d) => {
+        const fieldConfig = config?.[d.namePlaceholder ?? d.name];
+        if (fieldConfig) {
+            return { ...d, supportFieldConfiguration: fieldConfig };
+        }
+        // Remove stale config from a field that is no longer configured.
+        const { supportFieldConfiguration: _, ...rest } = d;
+        return rest as UsermetaDatasetField;
+    });
 
 export type ProjectSliceProperties = SyncableSlice &
     DenebProject & {
@@ -147,22 +172,12 @@ export const createProjectSlice =
                             __isInitialized__: true
                         };
                         // Embed support field config into dataset entries for export metadata
-                        const datasetWithConfig = (
+                        const datasetWithConfig = embedSupportFieldConfig(
                             state.export.metadata?.datasets?.[
                                 DATASET_DEFAULT_NAME
-                            ] ?? []
-                        ).map((d) => {
-                            const fieldConfig =
-                                updatedProject.supportFieldConfiguration?.[
-                                    d.namePlaceholder ?? d.name
-                                ];
-                            return fieldConfig
-                                ? {
-                                      ...d,
-                                      supportFieldConfiguration: fieldConfig
-                                  }
-                                : d;
-                        });
+                            ] ?? [],
+                            updatedProject.supportFieldConfiguration
+                        );
                         // Update export metadata for template creation
                         const exportMetadata = getUpdatedExportMetadata(
                             state.export.metadata as UsermetaTemplate,
@@ -293,23 +308,12 @@ export const createProjectSlice =
             setSupportFieldConfiguration: (config: SupportFieldConfiguration) =>
                 set(
                     (state) => {
-                        const currentDataset =
+                        const updatedDataset = embedSupportFieldConfig(
                             state.export.metadata?.datasets?.[
                                 DATASET_DEFAULT_NAME
-                            ] ?? [];
-                        const updatedDataset = currentDataset.map((d) => {
-                            const fieldConfig =
-                                config[d.namePlaceholder ?? d.name];
-                            if (fieldConfig) {
-                                return {
-                                    ...d,
-                                    supportFieldConfiguration: fieldConfig
-                                };
-                            }
-                            // Remove stale config from field if it was previously set
-                            const { supportFieldConfiguration: _, ...rest } = d;
-                            return rest as typeof d;
-                        });
+                            ] ?? [],
+                            config
+                        );
                         const exportMetadata = getUpdatedExportMetadata(
                             state.export.metadata as UsermetaTemplate,
                             {
@@ -352,25 +356,12 @@ export const createProjectSlice =
                         // Embed support field config into dataset entries
                         // for export metadata (same semantics as
                         // setSupportFieldConfiguration).
-                        const currentDataset =
+                        const updatedDataset = embedSupportFieldConfig(
                             state.export.metadata?.datasets?.[
                                 DATASET_DEFAULT_NAME
-                            ] ?? [];
-                        const updatedDataset = currentDataset.map((d) => {
-                            const fieldConfig =
-                                payload.supportFieldConfiguration[
-                                    d.namePlaceholder ?? d.name
-                                ];
-                            if (fieldConfig) {
-                                return {
-                                    ...d,
-                                    supportFieldConfiguration: fieldConfig
-                                };
-                            }
-                            // Remove stale config from field if it was previously set
-                            const { supportFieldConfiguration: _, ...rest } = d;
-                            return rest as typeof d;
-                        });
+                            ] ?? [],
+                            payload.supportFieldConfiguration
+                        );
                         const exportMetadata = getUpdatedExportMetadata(
                             state.export.metadata as UsermetaTemplate,
                             {
@@ -466,17 +457,10 @@ const handleSyncProjectData = (
     );
 
     // Embed support field config into dataset entries for export metadata
-    const currentDataset =
-        state.export.metadata?.datasets?.[DATASET_DEFAULT_NAME] ?? [];
-    const datasetWithConfig = currentDataset.map((d) => {
-        const fieldConfig =
-            updatedProject.supportFieldConfiguration?.[
-                d.namePlaceholder ?? d.name
-            ];
-        return fieldConfig
-            ? { ...d, supportFieldConfiguration: fieldConfig }
-            : d;
-    });
+    const datasetWithConfig = embedSupportFieldConfig(
+        state.export.metadata?.datasets?.[DATASET_DEFAULT_NAME] ?? [],
+        updatedProject.supportFieldConfiguration
+    );
 
     // Update export metadata for template export functionality
     const exportMetadata = getUpdatedExportMetadata(

--- a/src/lib/state/__test__/create-slice-sync.test.ts
+++ b/src/lib/state/__test__/create-slice-sync.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSliceSync } from '../create-slice-sync';
 import { PENDING_PERSIST_TIMEOUT_MS } from '../sync-types';
 import type { SliceSyncConfig, SliceSyncMapping } from '../sync-types';
+import { useDenebState } from '@deneb-viz/app-core';
+import { useDenebVisualState } from '../../../state';
 
 // ─── Mock Setup ──────────────────────────────────────────────────────────────
 
@@ -69,10 +71,18 @@ type TestSlice = {
     config: string;
     fontSize: number;
     interactivity: { tooltip: boolean };
+    // Deserialized-object value (nested per-field config), mirroring
+    // supportFieldConfiguration. Optional so existing fixtures are unaffected.
+    supportConfig?: Record<string, unknown>;
     syncData: (payload: Partial<TestSlice>) => void;
 };
 
-type TestSliceKey = 'spec' | 'config' | 'fontSize' | 'interactivity';
+type TestSliceKey =
+    | 'spec'
+    | 'config'
+    | 'fontSize'
+    | 'interactivity'
+    | 'supportConfig';
 
 let mockAppCoreState: Record<string, unknown>;
 let mockVisualSettings: Record<string, unknown>;
@@ -125,6 +135,23 @@ const TEST_MAPPINGS: SliceSyncMapping<TestSliceKey>[] = [
             (s as typeof DEFAULT_VISUAL_SETTINGS).interactivity
     }
 ];
+
+// Deserialized-object mapping: getVisualValue returns a FRESH object on every
+// call (JSON.parse), exactly like supportFieldConfiguration. shallowEqual
+// always reports a change for such values (new nested references); only
+// deepEqual detects content-equality.
+const OBJECT_MAPPING: SliceSyncMapping<TestSliceKey> = {
+    sliceKey: 'supportConfig',
+    getVisualValue: (s: Record<string, unknown>) =>
+        JSON.parse(
+            (s as { vega: { supportConfigRaw: string } }).vega.supportConfigRaw
+        ),
+    persistence: {
+        objectName: 'stateManagement',
+        propertyName: 'supportFieldConfiguration'
+    },
+    serializeForPersistence: (value) => JSON.stringify(value)
+};
 
 const CROSS_PROPERTY_MAPPINGS: SliceSyncMapping<TestSliceKey>[] = [
     {
@@ -959,6 +986,82 @@ describe('createSliceSync', () => {
             });
             expect(mockSyncFn).toHaveBeenCalledWith(
                 expect.objectContaining({ spec: 'different' })
+            );
+        });
+    });
+
+    describe('per-mapping deep equality (deserialized-object mappings)', () => {
+        it('should NOT sync a deserialized-object mapping when content is identical (deepEqual — no inbound churn)', () => {
+            // Inbound: app-core already holds content-identical config.
+            // getVisualValue re-parses fresh each call, so shallowEqual would
+            // always report a change and re-sync (churn on every update).
+            // deepEqual detects equality → no sync.
+            const slice = createSliceState({
+                __hasHydrated__: true,
+                supportConfig: { f1: { highlight: true, format: false } }
+            });
+            mockAppCoreState = { test: slice };
+            createSliceSync(createTestConfig({ mappings: [OBJECT_MAPPING] }));
+
+            fireVisualSubscriber({
+                vega: {
+                    supportConfigRaw: JSON.stringify({
+                        f1: { highlight: true, format: false }
+                    })
+                }
+            });
+
+            expect(mockSyncFn).not.toHaveBeenCalled();
+        });
+
+        it('should NOT bundle an unchanged deserialized-object mapping (nor record pending) when an unrelated key persists', () => {
+            // Outbound: only `spec` genuinely changes. The unchanged
+            // supportConfig must not be bundled into the persist and must not
+            // register a pendingPersists entry (which would put it under
+            // stale-echo suppression on the next inbound sync).
+            const specMapping = TEST_MAPPINGS[0]; // spec
+            const initialSlice = createSliceState({
+                __hasHydrated__: true,
+                spec: 'oldSpec',
+                supportConfig: { f1: { highlight: true } }
+            });
+            mockAppCoreState = { test: initialSlice };
+            mockVisualSettings = {
+                vega: {
+                    spec: 'oldSpec',
+                    supportConfigRaw: JSON.stringify({ f1: { highlight: true } })
+                }
+            };
+            createSliceSync(
+                createTestConfig({ mappings: [specMapping, OBJECT_MAPPING] })
+            );
+
+            const changedSlice = createSliceState({
+                __hasHydrated__: true,
+                spec: 'newSpec',
+                supportConfig: { f1: { highlight: true } } // content-identical, fresh ref
+            });
+            fireAppCoreSubscriber(changedSlice);
+
+            // Exactly one change — spec only, supportConfig NOT bundled.
+            expect(mockPersistProjectProperties).toHaveBeenCalledTimes(1);
+            const changes = mockPersistProjectProperties.mock.calls[0][0];
+            expect(changes).toHaveLength(1);
+            expect(changes[0]).toMatchObject({ propertyName: 'jsonSpec' });
+
+            // No pending entry for supportConfig: a genuine host change to it
+            // must sync (not be suppressed as a stale echo).
+            mockSyncFn.mockClear();
+            fireVisualSubscriber({
+                vega: {
+                    spec: 'newSpec',
+                    supportConfigRaw: JSON.stringify({ f1: { highlight: false } })
+                }
+            });
+            expect(mockSyncFn).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    supportConfig: { f1: { highlight: false } }
+                })
             );
         });
     });

--- a/src/lib/state/__test__/create-slice-sync.test.ts
+++ b/src/lib/state/__test__/create-slice-sync.test.ts
@@ -1001,7 +1001,9 @@ describe('createSliceSync', () => {
             });
             expect(mockSyncFn).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    supportConfig: { field1: { highlight: false, format: false } }
+                    supportConfig: {
+                        field1: { highlight: false, format: false }
+                    }
                 })
             );
         });
@@ -1046,7 +1048,9 @@ describe('createSliceSync', () => {
             mockVisualSettings = {
                 vega: {
                     spec: 'oldSpec',
-                    supportConfigRaw: JSON.stringify({ f1: { highlight: true } })
+                    supportConfigRaw: JSON.stringify({
+                        f1: { highlight: true }
+                    })
                 }
             };
             createSliceSync(
@@ -1072,7 +1076,9 @@ describe('createSliceSync', () => {
             fireVisualSubscriber({
                 vega: {
                     spec: 'newSpec',
-                    supportConfigRaw: JSON.stringify({ f1: { highlight: false } })
+                    supportConfigRaw: JSON.stringify({
+                        f1: { highlight: false }
+                    })
                 }
             });
             expect(mockSyncFn).toHaveBeenCalledWith(

--- a/src/lib/state/__test__/create-slice-sync.test.ts
+++ b/src/lib/state/__test__/create-slice-sync.test.ts
@@ -908,7 +908,18 @@ describe('createSliceSync', () => {
                 spec: 'oldSpec'
             });
             mockAppCoreState = { test: initialSlice };
+            mockVisualSettings = {
+                ...DEFAULT_VISUAL_SETTINGS,
+                vega: { ...DEFAULT_VISUAL_SETTINGS.vega, spec: 'oldSpec' }
+            };
             const cleanup = createSliceSync(createTestConfig());
+
+            // Capture the unsubscribe fns each store's subscribe() returned for
+            // THIS instance (one subscribe call per store, cleared per test).
+            const appCoreUnsub = vi.mocked(useDenebState.subscribe).mock
+                .results[0].value;
+            const visualUnsub = vi.mocked(useDenebVisualState.subscribe).mock
+                .results[0].value;
 
             // Create a pending entry (different reference triggers persist)
             const changedSlice = createSliceState({
@@ -916,76 +927,82 @@ describe('createSliceSync', () => {
                 spec: 'newSpec'
             });
             fireAppCoreSubscriber(changedSlice);
-            expect(mockPersistProjectProperties).toHaveBeenCalled();
+            expect(mockPersistProjectProperties).toHaveBeenCalledTimes(1);
 
-            // Cleanup should not throw and should clear pending state
             cleanup();
 
-            // After cleanup, a stale echo should sync normally (pending was cleared)
-            // Re-create the sync to get a fresh subscriber
-            const cleanup2 = createSliceSync(createTestConfig());
-            const postCleanupSlice = createSliceState({
-                __hasHydrated__: true,
-                spec: 'newSpec'
-            });
-            mockAppCoreState = { test: postCleanupSlice };
+            // Both store subscriptions were torn down exactly once.
+            expect(appCoreUnsub).toHaveBeenCalledTimes(1);
+            expect(visualUnsub).toHaveBeenCalledTimes(1);
+
+            // Fire THIS SAME instance's captured inbound subscriber with a value
+            // that WOULD have been suppressed as a stale echo had the pending
+            // map survived cleanup. Because cleanup cleared it, the spec syncs —
+            // proving the pending map was cleared — and no persist is triggered
+            // by an inbound sync.
+            mockPersistProjectProperties.mockClear();
+            mockSyncFn.mockClear();
             fireVisualSubscriber({
                 vega: { spec: 'fromPBI', config: '{}', fontSize: 14 },
                 interactivity: { tooltip: true }
             });
-            // Should sync — no pending entries blocking
             expect(mockSyncFn).toHaveBeenCalledWith(
                 expect.objectContaining({ spec: 'fromPBI' })
             );
-            cleanup2();
+            expect(mockPersistProjectProperties).not.toHaveBeenCalled();
         });
 
-        it('should confirm pending via deepEqual for nested objects (JSON round-trip)', () => {
-            const nestedValue = { field1: { highlight: true, format: false } };
+        it('should confirm pending via deepEqual for nested objects (fresh reference, identical content)', () => {
+            // Nested-object value rebuilt per call (real supportFieldConfiguration
+            // shape). Because every getVisualValue re-parses into a NEW object
+            // graph, reference equality would treat the host echo as stale;
+            // only deepEqual confirms the pending persist.
+            const buildConfig = () => ({
+                field1: { highlight: true, format: false }
+            });
             const oldSlice = createSliceState({
                 __hasHydrated__: true,
-                spec: JSON.stringify({ old: true })
+                supportConfig: { field0: { highlight: false } }
             });
             mockAppCoreState = { test: oldSlice };
             mockVisualSettings = {
-                ...DEFAULT_VISUAL_SETTINGS,
                 vega: {
-                    ...DEFAULT_VISUAL_SETTINGS.vega,
-                    spec: JSON.stringify({ old: true })
+                    supportConfigRaw: JSON.stringify({
+                        field0: { highlight: false }
+                    })
                 }
             };
-            createSliceSync(createTestConfig());
+            createSliceSync(createTestConfig({ mappings: [OBJECT_MAPPING] }));
 
-            // Persist the nested spec (different reference triggers persist)
+            // Persist a new nested-object config (different reference triggers persist)
             const newSlice = createSliceState({
                 __hasHydrated__: true,
-                spec: JSON.stringify(nestedValue)
+                supportConfig: buildConfig()
             });
             fireAppCoreSubscriber(newSlice);
-            expect(mockPersistProjectProperties).toHaveBeenCalled();
+            expect(mockPersistProjectProperties).toHaveBeenCalledTimes(1);
 
-            // Visual returns the same value (simulating JSON round-trip — same content, new ref)
-            const confirmedSettings = {
-                vega: {
-                    spec: JSON.stringify(nestedValue),
-                    config: '{}',
-                    fontSize: 14
-                },
-                interactivity: { tooltip: true }
-            };
-            fireVisualSubscriber(confirmedSettings);
+            // Power BI echoes back a FRESH object graph with identical content.
+            fireVisualSubscriber({
+                vega: { supportConfigRaw: JSON.stringify(buildConfig()) }
+            });
 
-            // deepEqual should confirm (same string content)
-            // No sync call — confirmed and cleared
+            // deepEqual confirms (identical content, distinct references) —
+            // pending cleared, no sync (app-core already correct).
             expect(mockSyncFn).not.toHaveBeenCalled();
 
-            // Subsequent different value syncs normally
+            // A genuinely different nested value now syncs normally.
             fireVisualSubscriber({
-                vega: { spec: 'different', config: '{}', fontSize: 14 },
-                interactivity: { tooltip: true }
+                vega: {
+                    supportConfigRaw: JSON.stringify({
+                        field1: { highlight: false, format: false }
+                    })
+                }
             });
             expect(mockSyncFn).toHaveBeenCalledWith(
-                expect.objectContaining({ spec: 'different' })
+                expect.objectContaining({
+                    supportConfig: { field1: { highlight: false, format: false } }
+                })
             );
         });
     });

--- a/src/lib/state/create-slice-sync.ts
+++ b/src/lib/state/create-slice-sync.ts
@@ -129,7 +129,11 @@ export const createSliceSync = <TSlice, TSliceKey extends string, TSyncPayload>(
                     // After hydration, only sync if values have changed.
                     if (
                         isFirstHydration ||
-                        !areMappingValuesEqual(mapping, visualValue, appCoreValue)
+                        !areMappingValuesEqual(
+                            mapping,
+                            visualValue,
+                            appCoreValue
+                        )
                     ) {
                         payload[mapping.sliceKey] = visualValue;
                     }
@@ -204,7 +208,9 @@ export const createSliceSync = <TSlice, TSliceKey extends string, TSyncPayload>(
                 const appCoreValue = getSliceValue(slice, mapping.sliceKey);
                 const visualValue = mapping.getVisualValue(settings);
 
-                if (!areMappingValuesEqual(mapping, appCoreValue, visualValue)) {
+                if (
+                    !areMappingValuesEqual(mapping, appCoreValue, visualValue)
+                ) {
                     // Determine the value to persist: use serializeForPersistence
                     // if available, otherwise use the raw app-core value
                     const persistValue = mapping.serializeForPersistence

--- a/src/lib/state/create-slice-sync.ts
+++ b/src/lib/state/create-slice-sync.ts
@@ -10,8 +10,30 @@ import {
 import {
     PENDING_PERSIST_TIMEOUT_MS,
     type PendingPersistEntry,
-    type SliceSyncConfig
+    type SliceSyncConfig,
+    type SliceSyncMapping
 } from './sync-types';
+
+/**
+ * Select the equality function used for a mapping's change detection.
+ *
+ * Mappings that carry `serializeForPersistence` hold deserialized-object
+ * values — e.g. `supportFieldConfiguration` is `JSON.parse`d fresh on every
+ * `getVisualValue` call — so the app-core and visual values are distinct
+ * references with identical content. `shallowEqual` reports these as changed
+ * on every pass, causing inbound re-sync churn (a full project-slice rebuild
+ * per visual update, including resize storms) and spurious outbound persists
+ * (bundling an unchanged value and registering a stale-echo pending entry).
+ * `deepEqual` — the same comparison used for pending-persist confirmation
+ * below — detects content-equality. Primitive mappings keep the cheaper
+ * `shallowEqual`.
+ */
+const areMappingValuesEqual = <TSliceKey extends string>(
+    mapping: SliceSyncMapping<TSliceKey>,
+    a: unknown,
+    b: unknown
+): boolean =>
+    mapping.serializeForPersistence ? deepEqual(a, b) : shallowEqual(a, b);
 
 /**
  * Creates a bidirectional sync subscription for a slice.
@@ -107,7 +129,7 @@ export const createSliceSync = <TSlice, TSliceKey extends string, TSyncPayload>(
                     // After hydration, only sync if values have changed.
                     if (
                         isFirstHydration ||
-                        !shallowEqual(visualValue, appCoreValue)
+                        !areMappingValuesEqual(mapping, visualValue, appCoreValue)
                     ) {
                         payload[mapping.sliceKey] = visualValue;
                     }
@@ -182,7 +204,7 @@ export const createSliceSync = <TSlice, TSliceKey extends string, TSyncPayload>(
                 const appCoreValue = getSliceValue(slice, mapping.sliceKey);
                 const visualValue = mapping.getVisualValue(settings);
 
-                if (!shallowEqual(appCoreValue, visualValue)) {
+                if (!areMappingValuesEqual(mapping, appCoreValue, visualValue)) {
                     // Determine the value to persist: use serializeForPersistence
                     // if available, otherwise use the raw app-core value
                     const persistValue = mapping.serializeForPersistence


### PR DESCRIPTION
Fixes **Important #3, #13, #14, #18b** from the 2.0 pre-merge review (WP4).

- **#3 — deep equality for deserialized sync mappings.** `supportFieldConfiguration`'s `getVisualValue` fresh-parses JSON per call, so `shallowEqual` change detection was ALWAYS false for any non-empty config: every visual-store `set()` (including each resize-storm tick) re-synced into app-core and rebuilt the project slice + export metadata, and every genuine persist spuriously bundled the unchanged config and armed a ~5s stale-echo suppression window for it. Mappings with `serializeForPersistence` now compare with `deepEqual` (the same import the file already used for pending-persist confirmation); primitive mappings keep `shallowEqual`.
- **#18b — the cleanup test can now fail.** It previously asserted neither of its claims (unsubscribes unchecked; post-cleanup state asserted on a second, fresh instance). It now captures both stores' unsubscribe fns, asserts each fires once, and drives the same instance's captured subscriber post-cleanup. Also rewrote the mislabelled deepEqual test to use nested objects rebuilt per call (was JSON strings that pass under `===`).
- **#13 — one stripping `embedSupportFieldConfig` helper** replaces four divergent inline copies in the project slice; template-init and host-sync now strip stale embedded config from removed fields like the setter/stamp variants always did (export/template-integrity edge).
- **#14 — Monaco view-state cross-contamination fixed.** `handleUpdateChanges` used the active role's view state as the fallback for the other role, so every Spec keystroke overwrote the Config editor's saved cursor/scroll state (latent, masked by retention). Each role now falls back to its own stored value.

`npm run ci:local`: ALL CHECKS PASSED. Full workspace test + lint green (slice-sync 25, app-core 546 incl. new editor/project cases).

Part of the 2.0 pre-merge review remediation (WP4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)