### PR TITLE
fix: debug pane empty states + settings pane search responsiveness

### DIFF
--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-cell.tsx
@@ -13,9 +13,9 @@ import {
 import type { WorkerDatasetViewerValueType } from '../../workers/types';
 import { getDenebState } from '../../../../state';
 import {
-    isOpenForCellId,
     shouldRefreshInspector,
-    useDataTableInspector
+    useDataTableInspectorActions,
+    useIsInspectorOpenForCell
 } from './inspector-popover-context';
 import {
     buildCellId,
@@ -93,17 +93,17 @@ export const DataTableCell = ({
         inspectable
     );
 
-    const inspector = useDataTableInspector();
+    const inspectorActions = useDataTableInspectorActions();
     const keyboard = useDataTableKeyboardActions();
     const cellRef = useRef<HTMLDivElement>(null);
 
-    // `inspector` may be null if the cell is rendered outside a
+    // `inspectorActions` may be null if the cell is rendered outside a
     // `DataTableInspectorProvider` (isolated test harness, signal-viewer key
     // column, etc.). In that case click-to-inspect is unavailable and the
     // cell renders in the non-inspectable branch below.
     const canInspect =
         inspectable &&
-        inspector !== null &&
+        inspectorActions !== null &&
         valueType !== undefined &&
         rowIndex !== undefined;
 
@@ -113,6 +113,15 @@ export const DataTableCell = ({
     }, [canInspect, rowIndex, effectiveColumnId]);
 
     const isActiveCell = useIsDataTableCellActive(cellId);
+
+    // Selector-based subscription: this cell re-renders only when whether
+    // IT is the open cell flips, not on every popover state change (e.g. a
+    // ticking signal's rawValue update in a DIFFERENT cell, or this cell's
+    // own live-refresh dispatch while the popover targets someone else).
+    // See `inspector-popover-context.tsx` for why the predecessor
+    // full-state context caused every mounted cell to re-render on every
+    // popover state change (Important #12).
+    const isInspectorOpen = useIsInspectorOpenForCell(cellId);
 
     // Register this cell with the keyboard provider for roving tabindex
     // tracking. Non-inspectable cells skip registration so arrow-key
@@ -130,14 +139,19 @@ export const DataTableCell = ({
     // viewer's currentDate signal ticking every second) would show stale
     // content until the user re-clicks. Only the currently-targeted cell
     // dispatches a refresh, so ticks from unrelated cells don't stomp the
-    // inspector. The Object.is guard suppresses the redundant re-dispatch
-    // that would otherwise fire immediately after click (when state is
-    // already current). `refreshInspector` internally checks
-    // `stateRef.current.isOpen` so a close fired earlier in the same tick
-    // cannot be undone — the cell's React-context snapshot is one render
-    // stale relative to the ref, and the dispatch has to be authoritative.
+    // inspector. The Object.is guard (inside `shouldRefreshInspector`)
+    // suppresses the redundant re-dispatch that would otherwise fire
+    // immediately after click (when state is already current).
+    // `inspectorActions.getSnapshot()` reads the store directly rather than
+    // subscribing to it — `refreshInspector` internally re-checks the
+    // store's current `isOpen` before writing, so a close fired earlier in
+    // the same tick cannot be undone by a stale snapshot read here.
+    // `inspectorActions` is identity-stable for the provider's lifetime, so
+    // listing it as a dependency does not cause this effect to re-run on
+    // every popover state change — only when this cell's own `rawValue` /
+    // `valueType` / `cellId` change.
     useEffect(() => {
-        if (!cellId || !inspector) return;
+        if (!cellId || !inspectorActions) return;
         // `cellId` non-null implies `canInspect` was true at memo time,
         // which implies `valueType !== undefined` — but React can't follow
         // that inference across render boundaries, so if a parent flips
@@ -145,13 +159,14 @@ export const DataTableCell = ({
         // effect, cellId may still be non-null. Guard explicitly rather
         // than leaning on a non-null assertion.
         if (valueType === undefined) return;
-        if (!shouldRefreshInspector(inspector, cellId, rawValue, valueType)) {
+        const snapshot = inspectorActions.getSnapshot();
+        if (!shouldRefreshInspector(snapshot, cellId, rawValue, valueType)) {
             return;
         }
-        inspector.refreshInspector(rawValue, valueType);
-    }, [rawValue, valueType, cellId, inspector]);
+        inspectorActions.refreshInspector(rawValue, valueType);
+    }, [rawValue, valueType, cellId, inspectorActions]);
 
-    if (!canInspect || !cellId || !inspector) {
+    if (!canInspect || !cellId || !inspectorActions) {
         return (
             <DataTableTooltip content={tooltipContent}>
                 <div>{displayValue}</div>
@@ -163,7 +178,7 @@ export const DataTableCell = ({
     // `DataTableViewer`), fall back to always-tabbable so the cell is at
     // least reachable.
     const isActive = keyboard ? isActiveCell : true;
-    const isOpen = isOpenForCellId(inspector, cellId);
+    const isOpen = isInspectorOpen;
 
     const openForThisCell = () => {
         // Same pattern as the live-refresh effect's guard: `canInspect`
@@ -172,7 +187,7 @@ export const DataTableCell = ({
         // boundaries. Narrow via control flow rather than a non-null
         // assertion so the invariant is visible at the call site.
         if (valueType === undefined) return;
-        inspector.openInspector(cellRef, rawValue, valueType, cellId);
+        inspectorActions.openInspector(cellRef, rawValue, valueType, cellId);
     };
 
     const handleClick = () => {

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -79,7 +79,7 @@ export const DataTableViewer = ({
                                 data={data}
                                 fixedHeader
                                 sortIcon={<ArrowSortDown16Regular />}
-                                defaultSortFieldId={columns[0].id}
+                                defaultSortFieldId={columns[0]?.id}
                                 pagination
                                 paginationComponent={DataTableStatusBar}
                                 paginationPerPage={

--- a/packages/app-core/src/features/debug-area/components/data-table/inspector-popover-context.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/inspector-popover-context.tsx
@@ -4,7 +4,7 @@ import {
     useContext,
     useMemo,
     useRef,
-    useState,
+    useSyncExternalStore,
     type ReactNode,
     type RefObject
 } from 'react';
@@ -22,37 +22,6 @@ interface InspectorPopoverState {
     rawValue: unknown;
     valueType: WorkerDatasetViewerValueType | null;
     cellId: string | null;
-}
-
-interface InspectorPopoverContextValue extends InspectorPopoverState {
-    /**
-     * Open the inspector on the given cell. Replaces any previously open state
-     * so that at most one inspector is visible at a time.
-     */
-    openInspector: (
-        anchorRef: RefObject<HTMLElement | null>,
-        rawValue: unknown,
-        valueType: WorkerDatasetViewerValueType,
-        cellId: string
-    ) => void;
-    /**
-     * Close the inspector and restore focus to the previously opening cell if
-     * the anchor element is still connected to the DOM.
-     */
-    closeInspector: () => void;
-    /**
-     * Update the currently-open inspector's `rawValue` / `valueType` without
-     * touching `anchorRef` or `cellId`. Used when the cell behind an open
-     * inspector has its value change beneath it (e.g. a signal-viewer cell
-     * whose signal ticks while inspected). No-ops when the inspector is
-     * already closed, reading from a synchronous internal ref so a dismiss
-     * fired earlier in the same event-loop tick cannot be undone by a
-     * refresh dispatched against the pre-dismiss context snapshot.
-     */
-    refreshInspector: (
-        rawValue: unknown,
-        valueType: WorkerDatasetViewerValueType
-    ) => void;
 }
 
 export const INSPECTOR_POPOVER_CLOSED_STATE: InspectorPopoverState = {
@@ -101,107 +70,218 @@ export const shouldRefreshInspector = (
     return true;
 };
 
-const InspectorPopoverContext =
-    createContext<InspectorPopoverContextValue | null>(null);
+/**
+ * Minimal external store (subscribe/getState/setState) backing the
+ * inspector popover's state. The store OBJECT — not a plain state value —
+ * is what travels through `InspectorStoreContext`, and its identity never
+ * changes across renders. That's what lets `useIsInspectorOpenForCell`
+ * subscribe via `useSyncExternalStore`: each cell computes its own
+ * boolean slice of the state and React bails out of re-rendering that cell
+ * when the slice is unchanged (`Object.is` on the returned boolean),
+ * instead of every consumer re-rendering whenever ANY field of the shared
+ * state changes (which is what a plain `useContext(fullStateContext)`
+ * cannot avoid).
+ */
+interface InspectorStore {
+    getState: () => InspectorPopoverState;
+    setState: (next: InspectorPopoverState) => void;
+    subscribe: (listener: () => void) => () => void;
+}
+
+const createInspectorStore = (
+    initial: InspectorPopoverState
+): InspectorStore => {
+    let state = initial;
+    const listeners = new Set<() => void>();
+    return {
+        getState: () => state,
+        setState: (next) => {
+            state = next;
+            listeners.forEach((listener) => listener());
+        },
+        subscribe: (listener) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        }
+    };
+};
+
+/** No-op subscription used by the selector hooks outside a provider. */
+const emptySubscribe = () => () => {};
 
 /**
- * Hook for cells and the inspector itself to consume the shared popover state.
- * Returns `null` outside a provider so cells with `inspectable={false}` (the
- * signal-viewer key column, or cells rendered in isolated test harnesses) can
- * mount without a `DataTableInspectorProvider`. Consumers that genuinely
- * require the provider (e.g. `InspectorPopover`) should short-circuit when
- * this returns null rather than throwing deep inside a render tree.
+ * Stable action surface exposed to cells for dispatching to the shared
+ * inspector popover. Mirrors the keyboard context's action/state split
+ * (`data-table-keyboard-context.tsx`): the identity of this object and its
+ * methods never changes for the lifetime of the provider, so a cell's
+ * `useEffect` dependency arrays that list these actions don't churn (or
+ * force a re-render) on every popover state change.
+ *
+ * `getSnapshot` is a non-reactive escape hatch: cells use it inside the
+ * live-refresh effect to read the inspector's CURRENTLY stored value (the
+ * comparison target for `shouldRefreshInspector`) without subscribing to
+ * state changes at the component level. Subscribing there — as the
+ * predecessor single-context design did, by listing the whole context
+ * value as an effect dependency — is what caused every mounted cell to
+ * re-render on every popover state change, including a signal ticking
+ * under an open inspector re-rendering every row on every tick (Important
+ * #12).
  */
-export const useDataTableInspector = (): InspectorPopoverContextValue | null =>
-    useContext(InspectorPopoverContext);
+interface InspectorPopoverActions {
+    openInspector: (
+        anchorRef: RefObject<HTMLElement | null>,
+        rawValue: unknown,
+        valueType: WorkerDatasetViewerValueType,
+        cellId: string
+    ) => void;
+    closeInspector: () => void;
+    refreshInspector: (
+        rawValue: unknown,
+        valueType: WorkerDatasetViewerValueType
+    ) => void;
+    getSnapshot: () => InspectorPopoverState;
+}
+
+const InspectorActionsContext = createContext<InspectorPopoverActions | null>(
+    null
+);
+const InspectorStoreContext = createContext<InspectorStore | null>(null);
+
+/**
+ * Hook for cells (and the inspector itself) to obtain the stable action
+ * callbacks, plus a non-reactive snapshot getter. Returns `null` outside a
+ * provider so cells with `inspectable={false}` (the signal-viewer key
+ * column, or cells rendered in isolated test harnesses) can mount without a
+ * `DataTableInspectorProvider`. Consumers that genuinely require the
+ * provider (e.g. `InspectorPopover`) should short-circuit when this returns
+ * null rather than throwing deep inside a render tree.
+ */
+export const useDataTableInspectorActions =
+    (): InspectorPopoverActions | null => useContext(InspectorActionsContext);
+
+/**
+ * Selector-based subscription: re-renders the calling cell only when
+ * whether-THIS-cell-is-open flips — not on every popover state change (a
+ * ticking signal's `rawValue` update while a different cell is inspected,
+ * or even while the popover is closed entirely). `useSyncExternalStore`
+ * bails out of the re-render when the selected boolean is unchanged, which
+ * a plain context subscription to the full state object cannot do (a new
+ * state object is a new reference every time, so every subscriber would
+ * re-render regardless of whether ITS derived value changed).
+ */
+export const useIsInspectorOpenForCell = (cellId: string | null): boolean => {
+    const store = useContext(InspectorStoreContext);
+    return useSyncExternalStore(store?.subscribe ?? emptySubscribe, () =>
+        store && cellId ? isOpenForCellId(store.getState(), cellId) : false
+    );
+};
+
+/**
+ * Full reactive inspector state. Intended for `InspectorPopover` only — the
+ * single instance per `DataTableViewer` that actually renders the popover
+ * surface and legitimately needs every field. Per-cell consumers should use
+ * `useIsInspectorOpenForCell` instead; subscribing to the full state here
+ * from every cell is exactly the fan-out re-render this module's split
+ * exists to avoid.
+ */
+export const useDataTableInspectorState = (): InspectorPopoverState | null => {
+    const store = useContext(InspectorStoreContext);
+    return useSyncExternalStore(
+        store?.subscribe ?? emptySubscribe,
+        () => store?.getState() ?? null
+    );
+};
 
 /**
  * Provides shared state for a single inspector popover hosted at the
- * `DataTableViewer` level. Cells call `openInspector` to target the popover;
- * the popover reads `isOpen`, `anchorRef`, `rawValue`, and `valueType` from
- * this provider.
+ * `DataTableViewer` level. Cells call `openInspector` (via
+ * `useDataTableInspectorActions`) to target the popover; `InspectorPopover`
+ * reads the reactive state via `useDataTableInspectorState`.
  */
 export const DataTableInspectorProvider = ({
     children
 }: {
     children: ReactNode;
 }) => {
-    const [state, setState] = useState<InspectorPopoverState>(
-        INSPECTOR_POPOVER_CLOSED_STATE
+    // The store is created once and its identity never changes — it is
+    // deliberately NOT React state. `setState` mutates a closure variable
+    // and synchronously notifies listeners, so `getState()` immediately
+    // after a `setState` call always reflects the latest value, with no
+    // dependency on React's render/commit timing (the predecessor
+    // `stateRef` mirror existed only to work around that timing; a plain
+    // closure variable sidesteps the problem entirely).
+    const storeRef = useRef<InspectorStore | null>(null);
+    if (!storeRef.current) {
+        storeRef.current = createInspectorStore(INSPECTOR_POPOVER_CLOSED_STATE);
+    }
+    const store = storeRef.current;
+
+    const openInspector = useCallback<InspectorPopoverActions['openInspector']>(
+        (anchorRef, rawValue, valueType, cellId) => {
+            store.setState({
+                isOpen: true,
+                anchorRef,
+                rawValue,
+                valueType,
+                cellId
+            });
+        },
+        [store]
     );
-
-    // Mirror state into a ref so `closeInspector` can read the current anchor
-    // without performing the focus side effect inside a `setState` updater.
-    // React treats updater callbacks as pure; in StrictMode (and under
-    // concurrent rendering) they may run more than once per dispatch, which
-    // would double-fire `anchorEl.focus()` and produce duplicate screen-reader
-    // announcements or a momentary flicker back to the cell.
-    const stateRef = useRef<InspectorPopoverState>(state);
-    stateRef.current = state;
-
-    const openInspector = useCallback<
-        InspectorPopoverContextValue['openInspector']
-    >((anchorRef, rawValue, valueType, cellId) => {
-        setState({
-            isOpen: true,
-            anchorRef,
-            rawValue,
-            valueType,
-            cellId
-        });
-    }, []);
 
     const closeInspector = useCallback(() => {
         // Idempotent: the coordinate-rect mousedown handler and Fluent's
         // own `onOpenChange` can both fire `closeInspector` for the same
-        // outside-click gesture in the same event-loop tick. The `isOpen`
-        // closure in `handleOpenChange` reads a stale render's value, so
-        // its `if (!isOpen) return` guard won't suppress the second call.
-        // Update `stateRef` synchronously so any follow-up call sees the
-        // closed state before React commits the next render, and
-        // `anchorEl.focus()` fires only once per dismissal.
-        if (!stateRef.current.isOpen) return;
-        const anchorEl = stateRef.current.anchorRef?.current;
-        stateRef.current = INSPECTOR_POPOVER_CLOSED_STATE;
-        setState(INSPECTOR_POPOVER_CLOSED_STATE);
+        // outside-click gesture in the same event-loop tick. Reading
+        // `store.getState()` (rather than a closed-over `state` value)
+        // means the second call in the same tick observes the first
+        // call's synchronous update and no-ops.
+        const current = store.getState();
+        if (!current.isOpen) return;
+        const anchorEl = current.anchorRef?.current;
+        store.setState(INSPECTOR_POPOVER_CLOSED_STATE);
         if (anchorEl?.isConnected) {
             anchorEl.focus({ preventScroll: true });
         }
-    }, []);
+    }, [store]);
 
     const refreshInspector = useCallback<
-        InspectorPopoverContextValue['refreshInspector']
-    >((rawValue, valueType) => {
-        // Read from `stateRef` rather than closing over `state` so a
-        // `closeInspector` call earlier in the same event-loop tick
-        // (which synchronously flips `stateRef.current.isOpen` to false)
-        // prevents a refresh dispatched against a pre-close context
-        // snapshot from reopening the popover. Cells see the open state
-        // via React context — which is one render stale relative to the
-        // ref — so the dispatch has to be the authoritative check.
-        if (!stateRef.current.isOpen) return;
-        const next: InspectorPopoverState = {
-            ...stateRef.current,
-            rawValue,
-            valueType
-        };
-        stateRef.current = next;
-        setState(next);
-    }, []);
+        InspectorPopoverActions['refreshInspector']
+    >(
+        (rawValue, valueType) => {
+            // Read from `store.getState()` rather than a closed-over
+            // `state` so a `closeInspector` call earlier in the same
+            // event-loop tick (which updates the store synchronously)
+            // prevents a refresh dispatched against a pre-close snapshot
+            // from reopening the popover.
+            const current = store.getState();
+            if (!current.isOpen) return;
+            store.setState({
+                ...current,
+                rawValue,
+                valueType
+            });
+        },
+        [store]
+    );
 
-    const value = useMemo<InspectorPopoverContextValue>(
+    const getSnapshot = useCallback(() => store.getState(), [store]);
+
+    const actions = useMemo<InspectorPopoverActions>(
         () => ({
-            ...state,
             openInspector,
             closeInspector,
-            refreshInspector
+            refreshInspector,
+            getSnapshot
         }),
-        [state, openInspector, closeInspector, refreshInspector]
+        [openInspector, closeInspector, refreshInspector, getSnapshot]
     );
 
     return (
-        <InspectorPopoverContext.Provider value={value}>
-            {children}
-        </InspectorPopoverContext.Provider>
+        <InspectorStoreContext.Provider value={store}>
+            <InspectorActionsContext.Provider value={actions}>
+                {children}
+            </InspectorActionsContext.Provider>
+        </InspectorStoreContext.Provider>
     );
 };

--- a/packages/app-core/src/features/debug-area/components/data-table/inspector-popover.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/inspector-popover.tsx
@@ -13,7 +13,10 @@ import type { editor as monacoEditor } from 'monaco-editor';
 import { POPOVER_Z_INDEX } from '../../../../lib';
 import { useDenebState } from '../../../../state';
 import { buildEditorProps } from '../../../../lib/monaco';
-import { useDataTableInspector } from './inspector-popover-context';
+import {
+    useDataTableInspectorActions,
+    useDataTableInspectorState
+} from './inspector-popover-context';
 import {
     formatInspectorValue,
     getInspectorDimensions,
@@ -65,16 +68,17 @@ export const InspectorPopover = ({
         fontSize: state.editorPreferences.jsonEditorFontSize,
         theme: state.editorPreferences.theme
     }));
-    const inspector = useDataTableInspector();
-    if (!inspector) {
+    const inspectorState = useDataTableInspectorState();
+    const inspectorActions = useDataTableInspectorActions();
+    if (!inspectorState || !inspectorActions) {
         // InspectorPopover is only valid inside DataTableInspectorProvider.
         // Fail here rather than downstream with a less actionable error.
         throw new Error(
             'InspectorPopover must be mounted inside DataTableInspectorProvider'
         );
     }
-    const { isOpen, anchorRef, cellId, rawValue, valueType, closeInspector } =
-        inspector;
+    const { isOpen, anchorRef, cellId, rawValue, valueType } = inspectorState;
+    const { closeInspector } = inspectorActions;
     const editorContainerRef = useRef<HTMLDivElement>(null);
     const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null);
 

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/__tests__/data-tab-utils.test.ts
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/__tests__/data-tab-utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveDataTabReason } from '../data-tab-utils';
+import {
+    resolveDataTabReason,
+    resolveDataTabRenderState
+} from '../data-tab-utils';
 
 /**
  * The Data tab's reason mapping has four outcomes: view-unavailable,
@@ -28,9 +31,9 @@ describe('resolveDataTabReason', () => {
         });
 
         it('view not available, even when values are defined', () => {
-            expect(
-                resolveDataTabReason(false, 0, 'dataset', [{ a: 1 }])
-            ).toBe('view-unavailable');
+            expect(resolveDataTabReason(false, 0, 'dataset', [{ a: 1 }])).toBe(
+                'view-unavailable'
+            );
         });
 
         it("view not available wins over a non-zero dataset count (a stale or impossible mix shouldn't downgrade the reason)", () => {
@@ -80,7 +83,9 @@ describe('resolveDataTabReason', () => {
         });
 
         it('valid view + name + populated array', () => {
-            expect(resolveDataTabReason(true, 1, 'name', [{ a: 1 }])).toBeNull();
+            expect(
+                resolveDataTabReason(true, 1, 'name', [{ a: 1 }])
+            ).toBeNull();
         });
 
         it('valid view + name + multi-row array', () => {
@@ -92,5 +97,38 @@ describe('resolveDataTabReason', () => {
                 ])
             ).toBeNull();
         });
+    });
+});
+
+/**
+ * C3: `values === null` (worker hasn't produced a result yet) and
+ * `values === []` (worker produced zero rows — e.g. a spec whose filters
+ * remove every row) both collapsed into a truthy `!values?.length` check
+ * that kept the spinner on screen forever for the zero-row case. These
+ * cases must resolve to distinct render states.
+ */
+describe('resolveDataTabRenderState', () => {
+    it('values === null → loading (worker has not produced a result yet)', () => {
+        expect(resolveDataTabRenderState(false, null)).toBe('loading');
+    });
+
+    it('values === [] → empty (zero-row result is not "still loading")', () => {
+        expect(resolveDataTabRenderState(false, [])).toBe('empty');
+    });
+
+    it('values with rows → data', () => {
+        expect(resolveDataTabRenderState(false, [{ a: 1 }])).toBe('data');
+    });
+
+    it('processing === true wins over a populated values array', () => {
+        expect(resolveDataTabRenderState(true, [{ a: 1 }])).toBe('loading');
+    });
+
+    it('processing === true wins over an empty values array', () => {
+        expect(resolveDataTabRenderState(true, [])).toBe('loading');
+    });
+
+    it('processing === true wins over null values', () => {
+        expect(resolveDataTabRenderState(true, null)).toBe('loading');
     });
 });

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/data-tab-utils.ts
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/data-tab-utils.ts
@@ -47,3 +47,35 @@ export const resolveDataTabReason = (
     }
     return null;
 };
+
+/**
+ * The Data tab's post-`reason` render state: whether to show the processing
+ * spinner, or hand off to `DataTableViewer` (which renders its own
+ * zero-rows presentation when `values` is an empty array — see
+ * `DataTable`'s built-in no-records handling once `columns[0]` is
+ * optional-chained; c.f. the zero-column fix in `data-table.tsx`).
+ *
+ * `values === null` means the worker has not produced a result for the
+ * current job yet — distinct from `[]`, a worker result with zero rows
+ * (e.g. a spec whose filters remove every row). Collapsing those two into a
+ * single falsy check (`!values?.length`) was the C3 bug: a zero-row dataset
+ * spun the loading indicator forever, because `[].length` is falsy too.
+ *
+ * `processing` (the debounced worker-busy flag) always wins regardless of
+ * `values`, since a new job may be in flight even while a previous result
+ * is still cached in state.
+ */
+export type DataTabRenderState = 'loading' | 'empty' | 'data';
+
+export const resolveDataTabRenderState = (
+    processing: boolean,
+    values: unknown[] | null
+): DataTabRenderState => {
+    if (processing || values === null) {
+        return 'loading';
+    }
+    if (values.length === 0) {
+        return 'empty';
+    }
+    return 'data';
+};

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/data-tab.tsx
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/data-tab.tsx
@@ -34,7 +34,10 @@ import {
     getDatasetViewerCharWidth,
     getDatasetViewerWorkerTranslations
 } from './dataset-viewer-worker-helpers';
-import { resolveDataTabReason } from './data-tab-utils';
+import {
+    resolveDataTabReason,
+    resolveDataTabRenderState
+} from './data-tab-utils';
 import { getAvailableDatasetNames } from './dataset-discovery';
 import { LOADING_INDICATOR_DEBOUNCE_MS } from './loading-debounce-constants';
 import { getSharedDataTableViewerProps } from './data-table-viewer-props';
@@ -232,9 +235,7 @@ export const DataTab = ({ datasetName, renderId }: DataTabProps) => {
      * Attempt to remove specified data listener from the supplied Vega view.
      * See `addListener` for the rationale on the explicit `view` parameter.
      */
-    const removeListener = (
-        view: View | null = VegaViewServices.getView()
-    ) => {
+    const removeListener = (view: View | null = VegaViewServices.getView()) => {
         try {
             logDebug(
                 `DataTab: attempting to remove listener for dataset [${datasetName}]...`
@@ -252,9 +253,7 @@ export const DataTab = ({ datasetName, renderId }: DataTabProps) => {
      * Attempt to cycle (add/remove) listeners for the specified dataset on
      * the supplied view.
      */
-    const cycleListeners = (
-        view: View | null = VegaViewServices.getView()
-    ) => {
+    const cycleListeners = (view: View | null = VegaViewServices.getView()) => {
         logDebug(`DataTab: cycling listeners for dataset: [${datasetName}]...`);
         removeListener(view);
         addListener(view);
@@ -462,16 +461,17 @@ export const DataTab = ({ datasetName, renderId }: DataTabProps) => {
         return <NoDataMessage reason={reason} />;
     }
 
-    // Either the worker is still processing (debounced — fast round-trips
-    // don't flicker the spinner), or it hasn't produced any rows yet
-    // (view + name + defined values, but no rows in `datasetState.values`).
-    // The empty-rows term is NOT debounced so first-load shows the spinner
-    // immediately. Mirrors the consolidated check in `SourceTab`.
-    //
-    // Inline rather than via `shouldShowLoadingIndicator` so TypeScript can
-    // narrow `datasetState.values` from `… | null` to `…[]` past the guard.
-    // The helper exists for unit-test ergonomics; behaviour is identical.
-    if (debouncedProcessing || !datasetState.values?.length) {
+    // 'loading' covers both "the worker is still processing" (debounced —
+    // fast round-trips don't flicker the spinner) and "no result yet"
+    // (`datasetState.values === null`). A worker result of `[]` (zero rows
+    // — e.g. a spec whose filters remove every row) is a distinct 'empty'
+    // state and falls through to `DataTableViewer` below, which renders its
+    // own zero-rows presentation rather than spinning forever (C3).
+    const renderState = resolveDataTabRenderState(
+        debouncedProcessing,
+        datasetState.values
+    );
+    if (renderState === 'loading') {
         return <ProcessingDataMessage />;
     }
 
@@ -484,7 +484,7 @@ export const DataTab = ({ datasetName, renderId }: DataTabProps) => {
                             (datasetState.columns ??
                                 []) as TableColumn<IWorkerDatasetViewerDataTableRow>[]
                         }
-                        data={datasetState.values}
+                        data={datasetState.values ?? []}
                         {...getSharedDataTableViewerProps({
                             sortEntry,
                             onSort: handleSort,

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/__tests__/signal-value-listener-wrapper.test.ts
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/__tests__/signal-value-listener-wrapper.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Characterizes the `Object.is` bail-out semantics behind the signal
+ * listener's `setSignalValue` fix in `signal-value.tsx`.
+ *
+ * Bug (Important #12): the listener used to call `setSignalValue(() =>
+ * value)` with the raw value Vega handed back. `useState` skips the
+ * re-render when `Object.is(next, prev)` is true — correct for primitives,
+ * but wrong when a Vega signal is backed by an object/array that Vega
+ * mutates in place and re-emits under the SAME reference. `Object.is` then
+ * reports "unchanged" even though the content changed, the state update is
+ * dropped, and the inspected cell shows a stale value.
+ *
+ * Fix: wrap every emitted value in a fresh `{ value }` object before handing
+ * it to `setSignalValue`. The wrapper is a new reference on every call, so
+ * `Object.is` never bails, and the triggering re-render always fires
+ * regardless of what Vega does with the underlying value's identity.
+ *
+ * Vitest runs in the `node` environment with no `@testing-library/react`
+ * available in this workspace (see `signal-value-memo-deps.test.ts` for the
+ * established precedent of characterising React internals as a pure model
+ * rather than rendering).
+ */
+
+/** Pure model of `useState`'s bail-out: would a `setState(next)` following a
+ * `setState(prev)` actually schedule a re-render? */
+const wouldReRender = (prev: unknown, next: unknown): boolean =>
+    !Object.is(prev, next);
+
+describe('signal listener setSignalValue — Object.is bail-out characterization', () => {
+    it('BUG (pre-fix shape): a mutated object re-emitted under the same reference does not trigger a re-render', () => {
+        const shared: { a: number } = { a: 1 };
+        const prev = shared;
+        shared.a = 2; // Vega mutates the object in place...
+        const next = shared; // ...and re-emits the SAME reference.
+        expect(wouldReRender(prev, next)).toBe(false);
+    });
+
+    it('FIX: wrapping every emit in a fresh object triggers a re-render even for the same mutated reference', () => {
+        const shared: { a: number } = { a: 1 };
+        const prevWrapped = { value: shared };
+        shared.a = 2;
+        const nextWrapped = { value: shared }; // fresh wrapper per emit
+        expect(wouldReRender(prevWrapped, nextWrapped)).toBe(true);
+    });
+
+    it('FIX still triggers a re-render for genuinely-changed primitive values', () => {
+        const prevWrapped = { value: 1 };
+        const nextWrapped = { value: 2 };
+        expect(wouldReRender(prevWrapped, nextWrapped)).toBe(true);
+    });
+
+    it('FIX triggers a re-render even when the emitted primitive is unchanged (accepted trade-off — see @privateRemarks in signal-value.tsx)', () => {
+        const prevWrapped = { value: 1 };
+        const nextWrapped = { value: 1 };
+        expect(wouldReRender(prevWrapped, nextWrapped)).toBe(true);
+    });
+});

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/signal-value.tsx
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/signal-value.tsx
@@ -45,9 +45,13 @@ const getInitialSignalValue = (signalName: string) => {
  * @privateRemarks [DM-P]: there is some technical debt here, where we're using `signalValue` as a triggering mechanism
  * for renders, but not for displaying its actual value (opting to go directly to the view instead).
  *
- * There seem to be some edge cases where the correct value is not returned, despite events and hooks lining-up
- * correctly. This needs more time to investigate (and is likely programmer error on my part), but as the render
- * happens anyway and it only affects dynamic signal values, this is an acceptable risk for now.
+ * The listener used to call `setSignalValue(() => value)` directly with the raw value Vega handed back. `useState`
+ * bails out of the re-render via `Object.is(next, prev)` — fine for primitives, but Vega signals backed by an object
+ * or array can be mutated in place and re-emitted under the SAME reference (e.g. a signal whose value is a shared
+ * data-derived object). `Object.is` then reports "unchanged" even though the content did change, the state update is
+ * dropped, and the cell shows a stale value until some unrelated re-render happens to occur. The listener now wraps
+ * the incoming value in a fresh `{ value }` object on every emit (see below) so the reference is always new and the
+ * triggering re-render always fires, regardless of what Vega does with the underlying value's identity.
  */
 // eslint-disable-next-line max-lines-per-function
 export const SignalValue = ({
@@ -105,7 +109,15 @@ export const SignalValue = ({
         removeListener(view);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const listener = (name: string, value: any) => {
-            setSignalValue(() => value);
+            // Wrap in a fresh object on every emit rather than passing
+            // `value` straight through. Vega signals backed by an object or
+            // array can be mutated in place and re-emitted under the SAME
+            // reference; `useState`'s `Object.is` bail-out would then treat
+            // a real content change as a no-op and skip the re-render that
+            // drives this cell's display. The wrapper is always a new
+            // reference, so the triggering re-render always fires. See the
+            // `@privateRemarks` above for the full rationale.
+            setSignalValue(() => ({ value }));
             logDebug(
                 `[${renderIdRef.current}] Signal value for ${name} has changed`,
                 value

--- a/packages/app-core/src/features/settings-pane/components/__tests__/settings-pane-utils.test.ts
+++ b/packages/app-core/src/features/settings-pane/components/__tests__/settings-pane-utils.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import { isEditableEventTarget } from '../settings-pane-utils';
+
+/**
+ * Important #10: `settings-pane.tsx`'s context-menu interception used to
+ * call `preventDefault()` unconditionally on the pane root, suppressing the
+ * browser's native context menu inside the search box `<input>` too — no
+ * right-click-paste, no Shift+F10 editing menu. `isEditableEventTarget` is
+ * the predicate the handlers now check before calling `preventDefault()`.
+ */
+describe('isEditableEventTarget', () => {
+    it('returns true for an <input> element', () => {
+        const input = document.createElement('input');
+        expect(isEditableEventTarget(input)).toBe(true);
+    });
+
+    it('returns true for a <textarea> element', () => {
+        const textarea = document.createElement('textarea');
+        expect(isEditableEventTarget(textarea)).toBe(true);
+    });
+
+    it('returns true for an explicit contenteditable element', () => {
+        const div = document.createElement('div');
+        div.setAttribute('contenteditable', 'true');
+        expect(isEditableEventTarget(div)).toBe(true);
+    });
+
+    it('returns true for a descendant of an <input> (e.g. an internal wrapper span)', () => {
+        const input = document.createElement('input');
+        const span = document.createElement('span');
+        input.appendChild(span);
+        expect(isEditableEventTarget(span)).toBe(true);
+    });
+
+    it('returns false for a non-editable element, e.g. the pane root div', () => {
+        const div = document.createElement('div');
+        expect(isEditableEventTarget(div)).toBe(false);
+    });
+
+    it('returns false for a div with contenteditable="false"', () => {
+        const div = document.createElement('div');
+        div.setAttribute('contenteditable', 'false');
+        expect(isEditableEventTarget(div)).toBe(false);
+    });
+
+    it('returns false for null or undefined targets', () => {
+        expect(isEditableEventTarget(null)).toBe(false);
+        expect(isEditableEventTarget(undefined)).toBe(false);
+    });
+
+    it('returns false for a bare EventTarget that is not an Element', () => {
+        const bareTarget = new EventTarget();
+        expect(isEditableEventTarget(bareTarget)).toBe(false);
+    });
+});

--- a/packages/app-core/src/features/settings-pane/components/__tests__/settings-pane-utils.test.ts
+++ b/packages/app-core/src/features/settings-pane/components/__tests__/settings-pane-utils.test.ts
@@ -27,6 +27,14 @@ describe('isEditableEventTarget', () => {
         expect(isEditableEventTarget(div)).toBe(true);
     });
 
+    it('returns true for the empty-string contenteditable form (contenteditable="")', () => {
+        // The HTML spec recognizes contenteditable="" as enabled; some
+        // rich-text libraries emit exactly this form.
+        const div = document.createElement('div');
+        div.setAttribute('contenteditable', '');
+        expect(isEditableEventTarget(div)).toBe(true);
+    });
+
     it('returns true for a descendant of an <input> (e.g. an internal wrapper span)', () => {
         const input = document.createElement('input');
         const span = document.createElement('span');

--- a/packages/app-core/src/features/settings-pane/components/settings-pane-utils.ts
+++ b/packages/app-core/src/features/settings-pane/components/settings-pane-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure helpers for `settings-pane.tsx`. Extracted so the context-menu
+ * interception predicate can be unit-tested in a jsdom environment without
+ * rendering the pane.
+ */
+
+/** Selector matching the elements whose native browser context menu (cut /
+ * copy / paste, spellcheck suggestions, etc.) must be preserved rather than
+ * replaced by the pane's custom context menu. */
+const EDITABLE_TARGET_SELECTOR = 'input, textarea, [contenteditable="true"]';
+
+/**
+ * Whether a context-menu (right-click or Shift+F10 / ContextMenu key)
+ * event's target is inside an editable control — the search box `<input>`
+ * today, but written generically so any future editable control (e.g. a
+ * contenteditable field) is covered without a follow-up fix.
+ *
+ * `settings-pane.tsx`'s `handleContextMenu` / `handleKeyDown` used to call
+ * `preventDefault()` unconditionally on the pane root, which suppressed the
+ * browser's native context menu everywhere under the pane — including
+ * inside the search box `<input>`, where the native menu is the only way to
+ * right-click-paste or reach the OS spellcheck suggestions, and where
+ * Shift+F10 is expected to surface the input's own editing menu rather than
+ * the pane's section menu (Important #10). Callers should return early
+ * (skip `preventDefault()` and the custom menu) when this returns `true`.
+ */
+export const isEditableEventTarget = (
+    target: EventTarget | null | undefined
+): boolean =>
+    target instanceof Element &&
+    target.closest(EDITABLE_TARGET_SELECTOR) !== null;

--- a/packages/app-core/src/features/settings-pane/components/settings-pane-utils.ts
+++ b/packages/app-core/src/features/settings-pane/components/settings-pane-utils.ts
@@ -6,8 +6,11 @@
 
 /** Selector matching the elements whose native browser context menu (cut /
  * copy / paste, spellcheck suggestions, etc.) must be preserved rather than
- * replaced by the pane's custom context menu. */
-const EDITABLE_TARGET_SELECTOR = 'input, textarea, [contenteditable="true"]';
+ * replaced by the pane's custom context menu. Both `contenteditable="true"`
+ * and the spec-recognized empty-string form (`contenteditable=""`, emitted
+ * by some rich-text libraries) count as enabled. */
+const EDITABLE_TARGET_SELECTOR =
+    'input, textarea, [contenteditable="true"], [contenteditable=""]';
 
 /**
  * Whether a context-menu (right-click or Shift+F10 / ContextMenu key)

--- a/packages/app-core/src/features/settings-pane/components/settings-pane.tsx
+++ b/packages/app-core/src/features/settings-pane/components/settings-pane.tsx
@@ -1,4 +1,11 @@
-import { isValidElement, useCallback, useMemo, useRef, useState } from 'react';
+import {
+    isValidElement,
+    useCallback,
+    useDeferredValue,
+    useMemo,
+    useRef,
+    useState
+} from 'react';
 import {
     Accordion,
     type AccordionToggleData,
@@ -119,11 +126,19 @@ export const SettingsPane = () => {
     const [menuOpen, setMenuOpen] = useState(false);
     const [menuAnchor, setMenuAnchor] = useState<DOMRect | null>(null);
 
-    // Resolve schemas + platform contribution + dataset descriptor,
-    // then run the match engine. The dataset indexer mirrors the
-    // render-time logic in DatasetSettings so match results line up
-    // with what the tree actually shows.
-    const matchView = useMemo<MatchView>(() => {
+    // Resolve schemas + platform contribution + dataset descriptor.
+    // Deliberately excludes `query` from its dependency list:
+    // `resolveSectionSchema` / `resolvePlatformSearchables` (translate) and
+    // `buildResolvedDatasetDescriptor` (a `.toLowerCase()` per row/flag —
+    // see `resolve-descriptors.ts`'s docs) are exactly the per-render cost
+    // the search design pre-lowers surfaces to avoid paying on every
+    // keystroke. Before this split, `query` sat in the same `useMemo` deps
+    // as these translate-heavy inputs, so every keystroke rebuilt every
+    // descriptor from scratch (Important #9) even though none of them
+    // depend on the query text. The dataset indexer mirrors the
+    // render-time logic in DatasetSettings so match results line up with
+    // what the tree actually shows.
+    const descriptors = useMemo(() => {
         const resolvedSections = [
             resolveSectionSchema(generalSchema, translate),
             resolveSectionSchema(performanceSchema, translate)
@@ -158,13 +173,8 @@ export const SettingsPane = () => {
             translate,
             headingKey: 'Text_Settings_Dataset'
         });
-        return buildMatchView({
-            query: resolveQuery(query),
-            sections: resolvedSections,
-            dataset: datasetDescriptor
-        });
+        return { resolvedSections, datasetDescriptor };
     }, [
-        query,
         translate,
         settingsPanePlatformSearchable,
         datasetFields,
@@ -174,6 +184,31 @@ export const SettingsPane = () => {
         interactivity,
         consolidateFieldParameters
     ]);
+
+    // Deferred so a fast typist's keystrokes commit to the input
+    // immediately while the match-view recompute below (the actual
+    // per-keystroke filtering work) trails slightly behind at lower
+    // priority — React re-renders once the deferred value catches up.
+    // `startTransition` around the store write in `settings-search-box.tsx`
+    // did not achieve this: that write flows through a Zustand
+    // `useSyncExternalStore` subscription, which transitions don't defer
+    // (see that file's updated comment).
+    const deferredQuery = useDeferredValue(query);
+
+    // Only re-runs the match engine — the actual per-keystroke filtering
+    // work — when the resolved descriptors change (rare: locale, platform
+    // contribution, dataset fields, support-field config) or the deferred
+    // query changes (every keystroke, but now doing filtering only, not
+    // re-translating/re-lowering every descriptor).
+    const matchView = useMemo<MatchView>(
+        () =>
+            buildMatchView({
+                query: resolveQuery(deferredQuery),
+                sections: descriptors.resolvedSections,
+                dataset: descriptors.datasetDescriptor
+            }),
+        [descriptors, deferredQuery]
+    );
 
     // Platform elements are a heterogeneous list of sibling
     // AccordionItems. Each element's React `key` is taken as its section

--- a/packages/app-core/src/features/settings-pane/components/settings-pane.tsx
+++ b/packages/app-core/src/features/settings-pane/components/settings-pane.tsx
@@ -28,6 +28,7 @@ import {
 } from './settings-search-box';
 import { SettingsEmptyState } from './settings-empty-state';
 import { SettingsPaneContextMenu } from './settings-pane-context-menu';
+import { isEditableEventTarget } from './settings-pane-utils';
 import { HighlightText } from './highlight-text';
 import { useDenebPlatformProvider } from '../../../components/deneb-platform';
 import { useDenebState } from '../../../state';
@@ -278,9 +279,14 @@ export const SettingsPane = () => {
         setCollapseAllEpoch((n) => n + 1);
     }, [setOpenItems]);
 
-    // Right-click: open menu anchored at the pointer.
+    // Right-click: open menu anchored at the pointer. Skips (and lets the
+    // browser's native menu through) when the target is an editable
+    // control — the search box `<input>` needs its native cut/copy/paste
+    // menu, which the pane-wide `preventDefault()` used to suppress
+    // unconditionally (Important #10).
     const handleContextMenu = useCallback(
         (event: React.MouseEvent<HTMLDivElement>) => {
+            if (isEditableEventTarget(event.target)) return;
             event.preventDefault();
             const rect = new DOMRect(event.clientX, event.clientY, 1, 1);
             setMenuAnchor(rect);
@@ -290,11 +296,15 @@ export const SettingsPane = () => {
     );
     // Keyboard equivalent: Shift+F10 / ContextMenu key. Anchor at the
     // focused element's bounding rect, or the pane root as a fallback.
+    // Same editable-target guard as `handleContextMenu` — without it,
+    // Shift+F10 inside the search box would replace the input's own
+    // editing menu with the pane's section menu.
     const handleKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLDivElement>) => {
             const isShiftF10 = event.shiftKey && event.key === 'F10';
             const isContextMenuKey = event.key === 'ContextMenu';
             if (!isShiftF10 && !isContextMenuKey) return;
+            if (isEditableEventTarget(event.target)) return;
             event.preventDefault();
             const active =
                 (document.activeElement as HTMLElement | null) ??

--- a/packages/app-core/src/features/settings-pane/components/settings-search-box.tsx
+++ b/packages/app-core/src/features/settings-pane/components/settings-search-box.tsx
@@ -1,6 +1,5 @@
 import {
     forwardRef,
-    startTransition,
     useCallback,
     useEffect,
     useImperativeHandle,
@@ -42,14 +41,20 @@ const useStyles = makeStyles({
  * Search box rendered above the settings-pane accordion. Bound to the
  * session-scoped query slice (`state.settingsPane.query`).
  *
- * Typing updates a local controlled value synchronously so the caret
- * stays in sync with keystrokes even under load. The store write is
- * routed through React's `startTransition` so the expensive matchView
- * rebuild, HighlightText re-renders, and dataset-tree recomputations
- * happen as a non-urgent transition — React can discard intermediate
- * values and commit only the latest, keeping the input responsive on
- * large datasets. External query changes (`clearQuery`, debug-driven
- * writes) sync back into the local value via `useEffect`.
+ * Typing updates a local controlled value synchronously so the caret stays
+ * in sync with keystrokes even under load, and writes straight through to
+ * the store on every change. The write used to be wrapped in React's
+ * `startTransition`, on the theory that it would let React defer the
+ * expensive matchView rebuild as a non-urgent update — but the store is a
+ * Zustand slice consumed via `useSyncExternalStore`
+ * (`state.settingsPane.query` in `settings-pane.tsx`), and
+ * `useSyncExternalStore` subscriptions always apply synchronously
+ * regardless of the transition/priority the triggering update ran under;
+ * `startTransition` had no effect here and only obscured the actual fix
+ * (see `settings-pane.tsx`, which now defers the expensive match-view
+ * recompute itself via `useDeferredValue`). External query changes
+ * (`clearQuery`, debug-driven writes) sync back into the local value via
+ * `useEffect`.
  */
 export const SettingsSearchBox = forwardRef<SettingsSearchBoxHandle>(
     (_props, ref) => {
@@ -83,9 +88,7 @@ export const SettingsSearchBox = forwardRef<SettingsSearchBoxHandle>(
             ) => {
                 const next = data.value ?? '';
                 setLocalValue(next);
-                startTransition(() => {
-                    setQuery(next);
-                });
+                setQuery(next);
             },
             [setQuery]
         );

--- a/packages/app-core/src/features/settings-pane/search/__tests__/settings-pane-descriptor-split.test.ts
+++ b/packages/app-core/src/features/settings-pane/search/__tests__/settings-pane-descriptor-split.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildMatchView } from '../match-engine';
+import {
+    resolveQuery,
+    resolveSectionSchema,
+    type TranslateFn
+} from '../resolve-descriptors';
+import type { SectionSchema } from '../schema-types';
+
+/**
+ * Characterizes the `settings-pane.tsx` fix for Important #9: descriptors
+ * (`resolveSectionSchema` / `resolvePlatformSearchables` /
+ * `buildResolvedDatasetDescriptor` — all translate + `.toLowerCase()` work)
+ * used to sit in the same `useMemo` dependency array as `query`, so every
+ * keystroke rebuilt every descriptor from scratch even though none of them
+ * depend on the query text.
+ *
+ * Post-fix, descriptor resolution is a separate `useMemo` with no `query`
+ * dependency; only `buildMatchView` (the actual filtering step) re-runs per
+ * keystroke. This test can't render the component (no
+ * `@testing-library/react` / jsdom in this workspace — see
+ * `data-tab-listener-rebind.test.ts` for the established precedent), so it
+ * characterises the same shape directly: resolve descriptors once through a
+ * spied `translate`, then run the match engine against that single resolved
+ * result across N distinct queries, asserting `translate` is never called
+ * again and every query still produces the correct match result.
+ */
+describe('settings-pane descriptor/match-view split (Important #9)', () => {
+    const schema = {
+        id: 'general',
+        headingKey: 'HEAD_GENERAL',
+        rows: [
+            { id: 'provider', labelKey: 'L_PROVIDER' },
+            { id: 'render-mode', labelKey: 'L_RENDER_MODE' }
+        ]
+    } as const satisfies SectionSchema;
+
+    it('resolves descriptors exactly once regardless of how many distinct queries are subsequently matched', () => {
+        const translateSpy: TranslateFn = vi.fn(
+            (key: string) => `tr:${key}`
+        ) as unknown as TranslateFn;
+
+        // Simulates the `descriptors` useMemo in settings-pane.tsx — built
+        // once, independent of query.
+        const resolvedSections = [resolveSectionSchema(schema, translateSpy)];
+        const callCountAfterBuild = (translateSpy as ReturnType<typeof vi.fn>)
+            .mock.calls.length;
+        expect(callCountAfterBuild).toBeGreaterThan(0);
+
+        // Simulates N keystrokes: each re-runs only `buildMatchView` (the
+        // `matchView` useMemo, keyed on `[descriptors, deferredQuery]`) —
+        // `resolvedSections` is reused by reference, never rebuilt.
+        const queries = ['p', 'pr', 'provider', 'render', 'xyz-no-match', ''];
+        for (const raw of queries) {
+            buildMatchView({
+                query: resolveQuery(raw),
+                sections: resolvedSections,
+                dataset: null
+            });
+        }
+
+        expect(
+            (translateSpy as ReturnType<typeof vi.fn>).mock.calls.length
+        ).toBe(callCountAfterBuild);
+    });
+
+    it('still produces correct, distinct match results per query against the single resolved descriptor set', () => {
+        const resolvedSections = [
+            resolveSectionSchema(schema, (key) => `tr:${key}`)
+        ];
+
+        const providerOnly = buildMatchView({
+            query: resolveQuery('provider'),
+            sections: resolvedSections,
+            dataset: null
+        });
+        expect(providerOnly.matchedSections.has('general')).toBe(true);
+        expect(providerOnly.sections.get('general')?.rows.has('provider')).toBe(
+            true
+        );
+        expect(
+            providerOnly.sections.get('general')?.rows.has('render-mode')
+        ).toBe(false);
+
+        const renderModeOnly = buildMatchView({
+            query: resolveQuery('render'),
+            sections: resolvedSections,
+            dataset: null
+        });
+        expect(
+            renderModeOnly.sections.get('general')?.rows.has('render-mode')
+        ).toBe(true);
+        expect(
+            renderModeOnly.sections.get('general')?.rows.has('provider')
+        ).toBe(false);
+
+        const noMatch = buildMatchView({
+            query: resolveQuery('nonexistent-term'),
+            sections: resolvedSections,
+            dataset: null
+        });
+        expect(noMatch.matchedSections.size).toBe(0);
+
+        const emptyQuery = buildMatchView({
+            query: resolveQuery(''),
+            sections: resolvedSections,
+            dataset: null
+        });
+        expect(emptyQuery.matchedSections.has('general')).toBe(true);
+        expect(emptyQuery.sections.get('general')?.rows.has('provider')).toBe(
+            true
+        );
+        expect(
+            emptyQuery.sections.get('general')?.rows.has('render-mode')
+        ).toBe(true);
+    });
+});


### PR DESCRIPTION
Fixes **Critical C3** and **Important #9, #10, #11, #12** from the 2.0 pre-merge review (WP7).

- **C3 — zero-row dataset no longer spins forever.** The data tab conflated `values === null` (worker pending) with `values === []` (zero rows — common when filters remove everything). New pure `resolveDataTabRenderState` gates the spinner on pending only; empty datasets fall through to the table's zero-rows rendering.
- **#11 — zero-column dataset no longer crashes** (`columns[0]?.id` guard for specs like `data: { values: [{}] }`).
- **#12 — inspector context split.** The single full-state context re-rendered every inspectable cell on any popover change (a ticking signal under an open inspector re-rendered every row per tick). Replaced with a stable actions context + a per-provider external store consumed via `useSyncExternalStore` selectors — a cell re-renders only when its own open-state flips (mirrors the keyboard context's house pattern). Signal display also survives Vega re-emitting the same mutated reference (fresh wrapper object defeats the `Object.is` bail-out the code's own `@privateRemarks` had flagged as unexplained staleness).
- **#9 — settings search stops rebuilding descriptors per keystroke.** Descriptor resolution (translate + pre-lowering) now memoizes independently of the query; matching runs over `useDeferredValue(query)`. Removed the inert `startTransition` around the Zustand write (no effect on external-store updates). Spy test proves descriptors build once across N query changes.
- **#10 — right-click/Shift+F10 works in the search box again.** The pane-wide `preventDefault()` now spares editable targets (`isEditableEventTarget` predicate, jsdom-tested).

`npm run ci:local`: ALL CHECKS PASSED. App-core 563 tests green; full workspace test + lint + prettier green.

Part of the 2.0 pre-merge review remediation (WP7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)