### PR TITLE
docs: compound learnings from the 2.0 pre-merge review + remediation

### DIFF
--- a/docs/solutions/architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md
+++ b/docs/solutions/architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md
@@ -1,6 +1,7 @@
 ---
 title: 'Rendering Lifecycle Coordinator — single-owner host-event pattern for Power BI custom visuals'
 date: 2026-07-03
+last_updated: 2026-07-16
 category: architecture-patterns
 module: rendering-lifecycle
 problem_type: architecture_pattern
@@ -123,11 +124,17 @@ An earlier iteration **deferred** an in-flight (`renderStarted === true`) render
 
 The bound in `src/index.ts` is `SAFETY_NET_BOUND_MS = 10_000`. **This is the Power BI certification ceiling, not a tunable.** The H2 fix changed the tick's _decision_ (defer → terminal close), not the bound, and added no re-arm or longer wait. If a legitimate path is exceeding the bound, the fix is to wire that path through the coordinator, not to raise the constant.
 
-### 6. Dependency injection at the seams
+### 6. In-flight render epoch — stale async terminals are no-ops (added 2026-07-16, PR #712)
+
+The no-arg async terminals (`closePendingRender`/`failPendingRender`) act on whatever id sits in the single pending-render slot. A superseded update's late in-flight embed callback could therefore terminally close the **freshly-bound** render before it painted — `renderingFinished` firing early in exactly the window Power BI export/print-to-PDF captures (exactly-once balance preserved, so never a cert violation; just untruthful timing).
+
+The guard: `pendingEpoch` bumps on every pending-render (re)binding; `markPendingRenderStarted` captures it as `inFlightEpoch`; an async terminal whose `inFlightEpoch` predates the current binding is a silent no-op that emits a `stale-close` observer event. `inFlightEpoch` clears on every real terminal and — deliberately — **not** on the supersede path: the superseded render's late callback is precisely what the guard must catch, so its epoch must survive the supersede (the design-phase suggestion to clear there was proven incompatible by the mandated failing test). The settle-close variant applies the same guard on its not-started terminal branch; its primary protection remains caller-side (the `app.tsx` arming effect is keyed on `visualUpdateOptions`, so each update's cleanup clears the prior timer), with the sub-frame gap between an update's synchronous bind and React's asynchronous cleanup as the guarded window. Accepted residual (documented in-line): a stale finish arriving after the newer render's own start matches epochs and closes early — that ordering is complementary-guarded by vega-react's generation suppression on real re-embeds.
+
+### 7. Dependency injection at the seams
 
 The factory takes `{ emitter, scheduler, logger?, observer? }`. Production wires the real host event service and `setTimeout`; unit tests inject a synthetic scheduler that exposes the pending callback for deterministic ticks and a plain mock emitter — no need to instantiate a full `IVisualHost`.
 
-### 7. Observer as the cert-permitted diagnostic channel
+### 8. Observer as the cert-permitted diagnostic channel
 
 Every state transition emits a structured event into an optional observer:
 
@@ -146,6 +153,11 @@ type RenderingLifecycleEvent =
           reason;
           error?;
           via: 'sync-current' | 'async-pending-render' | 'superseded';
+      }
+    | {
+          kind: 'stale-close'; // suppressed stale terminal (see §6)
+          id; // the id it WOULD have wrongly closed
+          via: 'async-pending-render' | 'settle-pending-render';
       }
     | { kind: 'safety-net-armed'; id }
     | {
@@ -190,8 +202,7 @@ this.#onRenderingStartedAdapter = () =>
 this.#onRenderingFinishedAdapter = () => this.#coordinator.closePendingRender();
 // Settle-timer close (app.tsx) — DEFERS to the real close / safety-net
 // when a render is in flight (H2). MUST be a distinct reference.
-this.#onSettleCloseAdapter = () =>
-    this.#coordinator.closePendingRenderSettle();
+this.#onSettleCloseAdapter = () => this.#coordinator.closePendingRenderSettle();
 this.#onRenderingErrorAdapter = (error) =>
     this.#coordinator.failPendingRender(error);
 ```
@@ -209,17 +220,17 @@ A companion `useEffect` in `app.tsx` handles the two paths Vega's callbacks can'
 
 Each property protects against a specific failure mode observed in Deneb:
 
-| Property | Failure mode when absent |
-|---|---|
-| Single owner of `rendering*` | Modules drift; some paths emit `renderingStarted` without any matching terminal. PDF export breaks. |
-| Delete before host emission | Host throws on emission → visual believes id is still open → follow-up `failCurrent` also emits → host contract violated twice. |
-| Supersede as failed | Prior orphan never closes; a burst of resize updates leaves one dangling `renderingStarted` per burst. |
-| `*Current` no-arg surface | Handlers need the id threaded through every call site; refactor pressure to route the id via globals or captured locals; attribution drift. |
-| `*PendingRender` no-arg surface | React callback captures a `visualUpdateOptions` from N updates ago and emits `renderingFinished(stale)`. Host sees terminal for the wrong id. |
-| Split test-surface type | Production code hard-codes `via: 'sync-current'` observer events from an async context; dev-overlay tally becomes actively misleading. |
-| Dep injection | Unit tests can't drive supersede/race/safety-net orderings deterministically; test complexity forces the coordinator to grow test-only branches. |
-| Safety-net at cert ceiling | If bound > 10s, cert reviewers observe an orphan window; if the bound is tuned per-path, the "raise the number" fix hides genuine wiring bugs. |
-| Observer | No cert-permitted way to surface `renderingFailed` error context during a certified build (host `reason` is write-only; `console.error` forbidden). |
+| Property                        | Failure mode when absent                                                                                                                            |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Single owner of `rendering*`    | Modules drift; some paths emit `renderingStarted` without any matching terminal. PDF export breaks.                                                 |
+| Delete before host emission     | Host throws on emission → visual believes id is still open → follow-up `failCurrent` also emits → host contract violated twice.                     |
+| Supersede as failed             | Prior orphan never closes; a burst of resize updates leaves one dangling `renderingStarted` per burst.                                              |
+| `*Current` no-arg surface       | Handlers need the id threaded through every call site; refactor pressure to route the id via globals or captured locals; attribution drift.         |
+| `*PendingRender` no-arg surface | React callback captures a `visualUpdateOptions` from N updates ago and emits `renderingFinished(stale)`. Host sees terminal for the wrong id.       |
+| Split test-surface type         | Production code hard-codes `via: 'sync-current'` observer events from an async context; dev-overlay tally becomes actively misleading.              |
+| Dep injection                   | Unit tests can't drive supersede/race/safety-net orderings deterministically; test complexity forces the coordinator to grow test-only branches.    |
+| Safety-net at cert ceiling      | If bound > 10s, cert reviewers observe an orphan window; if the bound is tuned per-path, the "raise the number" fix hides genuine wiring bugs.      |
+| Observer                        | No cert-permitted way to surface `renderingFailed` error context during a certified build (host `reason` is write-only; `console.error` forbidden). |
 
 ## When to Apply
 
@@ -247,8 +258,7 @@ After — no options capture; the coordinator remembers the id:
 
 ```tsx
 // src/index.ts constructor
-this.#onRenderingFinishedAdapter = () =>
-    this.#coordinator.closePendingRender();
+this.#onRenderingFinishedAdapter = () => this.#coordinator.closePendingRender();
 // app.tsx: passed as prop, threaded through provider unchanged
 ```
 

--- a/docs/solutions/design-patterns/viewer-blank-on-spec-error-by-design-2026-07-12.md
+++ b/docs/solutions/design-patterns/viewer-blank-on-spec-error-by-design-2026-07-12.md
@@ -55,6 +55,19 @@ decision (2026-07-12) is to **keep the reader experience blank**.
   `compilation.result.status === 'error'`. The editor debug area is the intended
   error surface and stays as-is.
 
+## Enforcement in the wild (2026-07-16)
+
+The 2.0 pre-merge review found `VegaEmbedErrorBoundary` rendering a "Vega
+Rendering Error" panel with the raw `error.message` to readers on any
+render-phase throw in the embed subtree — a real violation of both this rule
+and the message-hygiene rule, fixed in PR #716 by rendering blank (logging and
+the `renderingFailed` lifecycle signal preserved). Maintainer refinement,
+2026-07-15: the static construction-failure text in `src/index.ts` is
+sanctioned for **constructor-catch failures only**; Vega **view-init** failures
+must stay blank (with `displayWarningIcon` approved for that specific case,
+pending an accurate localized string); spec-compile errors remain fully blank
+per this document.
+
 ## If a minimal signal is ever wanted
 
 The sanctioned minimal approach is the host-native

--- a/docs/solutions/integration-issues/two-live-vega-embeds-after-editor-retention-2026-07-16.md
+++ b/docs/solutions/integration-issues/two-live-vega-embeds-after-editor-retention-2026-07-16.md
@@ -1,0 +1,127 @@
+---
+title: 'Two live Vega embeds after editor retention fight the last-bind-wins view singleton'
+date: 2026-07-16
+category: integration-issues
+module: 'app-core visual-viewer (retained editor tree x gated viewer x incremental updates)'
+problem_type: integration_issue
+component: viewer
+symptoms:
+    - 'After opening the in-visual editor once, cross-filter/slicer updates stop reaching the visible viewer chart (or apply intermittently)'
+    - 'Durable warning spam: every data update trips the incremental-update in-progress guard and forces a full recompile'
+    - 'Two renderingStarted/renderingFinished host event pairs per compile'
+    - 'Canvas DPR/scale nondeterminism: crispness differs run to run in the same mode'
+root_cause: logic_error
+resolution_type: code_fix
+severity: critical
+tags:
+    [
+        vega-embed,
+        editor-retention,
+        singleton,
+        incremental-update,
+        cross-filter,
+        view-ownership,
+        cross-pr-interaction
+    ]
+---
+
+# Two live Vega embeds after editor retention fight the last-bind-wins view singleton
+
+## Problem
+
+Once the in-visual editor had been opened, returning to viewer mode left TWO
+live `VisualViewer`/`VegaEmbed` instances mounted simultaneously: the retained
+(hidden, `display:none`) editor tree keeps its `PreviewArea → VisualViewer`
+subtree alive to keep Monaco warm, while `GatedDenebViewer` mounts a second
+instance for readers. Both share the compilation Zustand slice and the
+last-bind-wins `VegaViewServices` module singleton.
+
+## Symptoms
+
+- Every host data update ran both instances' data-change effects; the second
+  `performIncrementalUpdate` call on the same view tripped the in-progress
+  WeakSet guard → durable warning + forced full recompile (incremental
+  updates effectively disabled).
+- Two views raced to `VegaViewServices.bind()`; when the hidden editor's view
+  bound last, cross-filter, scroll signals, and tooltips targeted the
+  **hidden** view — the visible chart went stale.
+- Doubled `onRenderingStarted`/`onRenderingFinished` host events per compile.
+- Both instances wrote module-level `effectiveDevicePixelRatio` with different
+  scale inputs — last-writer-wins canvas DPR.
+
+## What Didn't Work
+
+- Nothing was "tried and failed" at fix time, but the defect itself survived
+  three separate PR reviews: editor retention, the gated viewer, and the
+  incremental-update guard were each individually reviewed and merged. The
+  interaction only exists when all three are live — no per-PR review had the
+  surface area to see it (found by the 2026-07-15 holistic pre-merge review;
+  see Related).
+- During the fix, keying the embed-in-flight window (`setViewReady(false)`)
+  on the spec memo's **identity** was rejected in review: `useVegaEmbed`
+  re-embeds only on **deep** inequality, and the platform provider is rebuilt
+  every App render, so identity churn without deep change would have parked
+  `viewReady` false forever and deadlocked every data update in `'defer'`.
+
+## Solution
+
+Exactly one live embed at any time, selected by a pure decision from the
+single `interface.type` store value — mount graph untouched (Monaco retention
+and the viewport-match-gate machinery are preserved):
+
+```typescript
+// packages/app-core/src/features/visual-viewer/embed-active.ts
+export const computeEmbedActive = (
+    interfaceType: InterfaceType,
+    isEmbeddedInEditor: boolean
+): boolean =>
+    isEmbeddedInEditor
+        ? interfaceType === 'editor'
+        : interfaceType === 'viewer';
+```
+
+- The inactive instance's `spec` memo returns `null` — `useVegaEmbed` already
+  finalizes the view, clears the container, and bumps its generation token on
+  null.
+- The inactive instance runs **no side effects**: compile effect, data-change
+  effect, and the DPR `useLayoutEffect` all early-return on `!isActive`
+  (gates encoded as tested pure functions `resolveDataChangeGate` /
+  `shouldAdvancePrevValues` in `incremental-update.ts`).
+- Deactivation clears the singleton **only with an ownership guard**
+  (`vega-embed.tsx`): clear only when `VegaViewServices.getView()` is the view
+  THIS instance bound (`ownViewRef`), so an unmounting/inactive instance can
+  never wipe the other instance's freshly-bound view.
+- The embed-in-flight window opens via `shouldOpenEmbedWindow(prev, next)` —
+  a deep-compare mirror of `useVegaEmbed`'s re-embed semantics — so
+  `viewReady=false` is only ever set when a real re-embed (and its
+  `setViewReady(true)`) is guaranteed to follow.
+
+## Why This Works
+
+Mutual exclusion is enforced by construction: both instances derive activity
+from the same single store value with complementary predicates, so they can
+never both be active (pinned by a truth-table + mutual-exclusion test). The
+ownership guard makes deactivation safe under any effect ordering across the
+two component trees. The deep-compare embed window means the
+`viewReady` false→true transition spans exactly the real embed lifecycle.
+
+## Prevention
+
+- Any component that binds a shared module singleton must (a) record what it
+  bound and (b) only clear what it owns — never clear unconditionally.
+- When two mounted instances can exist by design (retention patterns), an
+  explicit exactly-one-active invariant with a pure, truth-table-tested
+  decision function beats implicit "only one should render" assumptions.
+- Effects that set a flag another effect waits on must fire under the SAME
+  change semantics as the effect that resets it (identity vs deep-compare
+  mismatches deadlock).
+- Schedule a holistic cross-PR review before promoting branches where
+  retention/gating/guard features ship in separate PRs — this class is
+  invisible per-PR (see the workflow doc in Related).
+
+## Related Issues
+
+- [cross-pr-holistic-review-and-remediation-pipeline-2026-07-16](../workflow-issues/cross-pr-holistic-review-and-remediation-pipeline-2026-07-16.md) — how this was found
+- [module-level-singleton-escape-hatch-for-context-refs-2026-05-27](../design-patterns/module-level-singleton-escape-hatch-for-context-refs-2026-05-27.md) — the singleton/retention pattern this sits on
+- [freeze-on-viewer-editor-transition-2026-05-01](../ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md), [viewer-bounce-on-editor-exit-2026-05-04](../ui-bugs/viewer-bounce-on-editor-exit-2026-05-04.md) — earlier bugs at the same boundary
+- Fixed in PR #710 (`fix: single live Vega embed + in-flight update integrity`); review feedback follow-ups in the same PR

--- a/docs/solutions/workflow-issues/cross-pr-holistic-review-and-remediation-pipeline-2026-07-16.md
+++ b/docs/solutions/workflow-issues/cross-pr-holistic-review-and-remediation-pipeline-2026-07-16.md
@@ -1,0 +1,205 @@
+---
+title: 'Holistic multi-agent review before release promotion catches cross-PR interaction bugs per-PR review cannot see'
+date: 2026-07-16
+category: workflow-issues
+module: 'release process (cross-cutting: app-core visual-viewer, rendering-lifecycle, dataset pipeline, slice sync, build/certification config)'
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+applies_when:
+    - 'Promoting a long-lived integration branch (many individually-reviewed PRs) to a release/main branch'
+    - 'The branch touches multiple subsystems whose interactions were never reviewed together (e.g. editor retention x gated viewer x incremental updates)'
+    - 'Assembling a remediation plan from review findings that spans multiple work-package branches'
+    - 'Delegating fixes to subagents where some fixes are mechanical and some are behavioral/design-bearing'
+symptoms:
+    - 'Individually-reviewed PRs merged cleanly, but combined behavior produced a last-bind-wins singleton conflict between two live Vega embeds'
+    - 'A certification-relevant webpack override landed in the branch HEAD commit without triggering config validation'
+    - 'Per-row formatter construction passed every individual PR review but was a hot-path regression only visible in aggregate'
+    - 'A safety-net bound assertion used a regex loose enough to false-pass on a violating value'
+root_cause: missing_workflow_step
+resolution_type: workflow_improvement
+related_components:
+    - rendering-lifecycle coordinator
+    - app-core visual-viewer
+    - data-core support field processing
+    - build/certification config validation
+tags:
+    [
+        holistic-review,
+        multi-agent-review,
+        cross-pr-interaction,
+        remediation-pipeline,
+        design-checkpoint,
+        subagent-driven-development,
+        pre-release-review,
+        ci-local-gating
+    ]
+---
+
+# Holistic multi-agent review before release promotion catches cross-PR interaction bugs per-PR review cannot see
+
+## Context
+
+Every one of the 103 commits merged into `next` for the 2.0 release had passed
+individual PR review, but nobody had reviewed the accumulated 684-file branch
+as a whole before promoting it to `main` (an irreversible event for a certified
+AppSource visual). Per-PR review is structurally local: it cannot see that
+three separately merged, separately reviewed features — the retained hidden
+editor tree, the gated viewer, and the incremental-update in-progress guard —
+interact destructively only when combined. The 2026-07-15 holistic pass found
+**3 Critical + 13 Important** issues in a branch where every constituent PR
+was "clean", including one certification hole introduced by the branch's own
+HEAD commit. All were remediated across PRs #709–#716 before promotion.
+
+## Guidance
+
+The workflow that produced and remediated the findings, in the shape that made
+it work:
+
+**1. Review the branch, not the diffs that built it.** Six scoped parallel
+reviewer subagents split by module boundary (app-core UI; app-core state/lib;
+root `src/`; vega-runtime + vega-react; data/json/util packages;
+release/build/certification + cross-cutting), plus targeted sub-reviews where
+risk density was highest (`src/` tests, persistence/migration, state-sync).
+Scope is a pathspec over the whole range — not a PR list.
+
+**2. Constraint-prime every reviewer.** Each prompt front-loads the project's
+_deliberate_ decisions so they are not reported as findings: the 10s rendering
+safety-net certification ceiling, the readers-stay-blank error policy, the
+`powerbi-compat` singleton peerDependency+external pattern, alpha/beta builds
+staying debug-capable, the vega-embed `actions: false` both-layers workaround.
+Priming reviewers with known-intentional tradeoffs prevents review noise from
+drowning real findings — and it is cheap, because these decisions are already
+written down (CLAUDE.md, docs/solutions/, memory).
+
+**3. Severity-gate the output.** Critical / Important / Minor with file:line
+and a verify-before-report rule (a reviewer must confirm a suspected defect
+against the actual code before reporting it). The result is a workable
+remediation backlog, not a dump.
+
+**4. Decompose remediation into work-package branches.** Each finding cluster
+becomes its own branch off the integration branch and its own PR (#709–#716):
+reviewable in isolation, revertable in isolation, and each gated on
+`npm run ci:local` (see the ci-local discipline in
+[local-green-is-not-ci-or-production-green](../best-practices/local-green-is-not-ci-or-production-green-2026-07-13.md)).
+
+**5. Assign models by task nature, and gate design-bearing work on a
+checkpoint.** Mechanical fixes with exact prescribed code go to a cheaper
+model. Behavioral fixes (the dual-embed invariant, the coordinator epoch
+guard) go to a stronger model with a **mandatory design checkpoint**: the
+agent proposes a ≤1-page design, the orchestrator reviews it, and only then
+does implementation start. Checkpoints caught real design errors before any
+code existed — and, symmetrically, gave the implementer standing to push back
+on the approved design _with a failing test as evidence_ (see Why This
+Matters, item 4).
+
+**6. TDD, with the pure-function escape hatch for untestable layers.**
+app-core has no jsdom, so component-tree behavior cannot be unit-tested. The
+house pattern is extracting the _decision_ as a pure function and testing that
+exhaustively: `computeEmbedActive` (truth table + mutual exclusion),
+`resolveDataChangeGate`/`shouldAdvancePrevValues` (12 gate cases),
+`shouldOpenEmbedWindow` (deep-equal no-open case).
+
+**7. Orchestrator reviews every work package's diff before it ships.** Not
+"tests pass" — whether the fix is actually correct. This loop caught four
+defects the automated gates could not (below).
+
+**8. Propagate hygiene rules forward as they are learned.** Two rules were
+discovered mid-run and written into every subsequent agent brief: _no literal
+control bytes in generated source_ (a NUL delimiter made a source file
+git-binary) and _run `npx prettier --check` before committing_ (a skipped
+check failed ci:local late). A remediation pipeline is also a feedback loop
+for its own instructions.
+
+## Why This Matters
+
+Each of these would have shipped without the orchestrator review loop; none
+were catchable by the automated suite:
+
+1. **Identity-vs-deep-compare deadlock (PR #710).** The implementing agent
+   keyed a `setViewReady(false)` effect on the spec memo's _identity_, but
+   `useVegaEmbed` re-embeds only on _deep_ inequality — and the platform
+   provider object is rebuilt every App render, so every update mints a
+   new-identity, deep-equal spec. `viewReady` would park `false` forever and
+   every data update would deadlock in `'defer'`. Fix: `shouldOpenEmbedWindow`,
+   a pure deep-compare mirror of `useVegaEmbed`'s own semantics. The node-only
+   suite structurally cannot see this class (component-tree behavior).
+
+2. **A NUL byte made a source file binary to git (PR #713).** A literal NUL
+   used as a cache-key delimiter turned diffs opaque. The reviewer's own first
+   repair reintroduced the byte via the edit payload — this trap catches even
+   people actively watching for it. Fix: a space delimiter (spaces cannot occur
+   in BCP-47 locale tags) and a standing no-control-bytes rule.
+
+3. **A skipped prettier check failed ci:local after implementation was
+   "done" (PR #714).** Cheap to catch early, expensive late; the fix was
+   procedural, not technical.
+
+4. **The implementer refuted part of an approved design, with evidence
+   (PR #712).** The design said to clear `inFlightEpoch` on the supersede
+   path. The mandated failing-test-first cycle proved that clearing there
+   defeats the guard's entire purpose — the superseded render's late callback
+   is exactly what the guard exists to catch, so its epoch must survive the
+   supersede. Design checkpoints plus TDD give pushback a standard of
+   evidence: a failing test, not an opinion.
+
+And the headline structural argument: the dual-embed Critical required three
+separately merged, separately reviewed PRs to be live simultaneously before it
+manifested. No per-PR review has the surface area to see that.
+
+## When to Apply
+
+- Before promoting any branch of accumulated, individually-reviewed PRs to a
+  release/`main`/other irreversible target.
+- When multiple PRs touch interacting subsystems: state sync, async
+  lifecycles, view/embed ownership, anything with a singleton or shared
+  mutable slot (`VegaViewServices`, `pendingRenderId`).
+- When the artifact is certification-gated — a gap is a compliance risk, not
+  just a bug (PR #709: an unvalidated `VEGA_LOCAL_PATH` webpack alias could
+  have shipped a hand-built Vega inside a certified `.pbiviz`).
+- Not warranted for a single feature branch reviewed once and merged in
+  isolation; the fleet/work-package overhead pays for itself only at
+  "many merged PRs, promoting as a unit" scale.
+
+## Examples
+
+Pure decision function enforcing a component-tree invariant jsdom cannot test
+(`packages/app-core/src/features/visual-viewer/embed-active.ts`):
+
+```typescript
+export const computeEmbedActive = (
+    interfaceType: InterfaceType,
+    isEmbeddedInEditor: boolean
+): boolean =>
+    isEmbeddedInEditor
+        ? interfaceType === 'editor'
+        : interfaceType === 'viewer';
+```
+
+Deep equality selected per mapping for deserialized sync values
+(`src/lib/state/create-slice-sync.ts`) — fixes an always-false `shallowEqual`
+on fresh-`JSON.parse`'d config that re-synced state on every visual update:
+
+```typescript
+const areMappingValuesEqual = <TSliceKey extends string>(
+    mapping: SliceSyncMapping<TSliceKey>,
+    a: unknown,
+    b: unknown
+): boolean =>
+    mapping.serializeForPersistence ? deepEqual(a, b) : shallowEqual(a, b);
+```
+
+Compiler-enforced precondition replacing a silent misclassification
+(`src/lib/dataset/support-field-provider.ts` + `fields.ts`): the parameter
+type requires pre-filtered source columns, and `isSourceField` is a type
+predicate so the filter narrows — passing unfiltered columns is a compile
+error, not a wrong-index lookup at runtime.
+
+## Related
+
+- [rendering-lifecycle-coordinator-single-owner-2026-07-03](../architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md) — the coordinator this effort's epoch guard (PR #712) extends
+- [module-level-singleton-escape-hatch-for-context-refs-2026-05-27](../design-patterns/module-level-singleton-escape-hatch-for-context-refs-2026-05-27.md) — the retention/singleton pattern under the dual-embed Critical
+- [viewer-blank-on-spec-error-by-design-2026-07-12](../design-patterns/viewer-blank-on-spec-error-by-design-2026-07-12.md) — policy this effort enforced against a real leak (PR #716's error-boundary fix)
+- [local-green-is-not-ci-or-production-green-2026-07-13](../best-practices/local-green-is-not-ci-or-production-green-2026-07-13.md) — ci:local gate discipline each work package followed
+- [freeze-on-viewer-editor-transition-2026-05-01](../ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md), [viewer-bounce-on-editor-exit-2026-05-04](../ui-bugs/viewer-bounce-on-editor-exit-2026-05-04.md) — prior bug family at the same editor↔viewer boundary
+- PRs #709–#716 (remediation), review method described in PR bodies as "the 2.0 pre-merge review"


### PR DESCRIPTION
Captures the durable learnings from the 2026-07-15/16 holistic pre-merge review and its 8-PR remediation (#709–#716), per /ce-compound (full mode).

## New docs
- **`docs/solutions/workflow-issues/cross-pr-holistic-review-and-remediation-pipeline-2026-07-16.md`** — the primary learning: per-PR review is structurally blind to cross-PR interaction bugs; the holistic review fleet (scoped agents, constraint-priming with deliberate decisions, severity gating, verify-before-report) plus the remediation pipeline (work-package branches, model-by-task-nature with mandatory design checkpoints, TDD with the pure-function escape hatch, orchestrator diff review, forward-propagated hygiene rules). The four orchestrator-caught defects are documented as evidence. First doc in the new `workflow-issues/` category.
- **`docs/solutions/integration-issues/two-live-vega-embeds-after-editor-retention-2026-07-16.md`** — the C1 Critical as a searchable bug class: exactly-one-live-embed invariant (`computeEmbedActive`), ownership-guarded singleton clearing, deep-compare embed window, and the per-PR-review-blindness lesson.

## Targeted refreshes
- **`architecture-patterns/rendering-lifecycle-coordinator-single-owner-2026-07-03.md`** — gains the in-flight render epoch guard (PR #712) as documented protection §6, the `stale-close` observer event in the union, `last_updated` stamped. (Sections renumbered 6→7, 7→8; no numbered cross-references existed.)
- **`design-patterns/viewer-blank-on-spec-error-by-design-2026-07-12.md`** — new "Enforcement in the wild" section citing PR #716's error-boundary raw-message leak fix and the 2026-07-15 maintainer refinement (construction-failure text sanctioned; view-init = blank + displayWarningIcon pending an accurate string; spec-compile fully blank).

Overlap analysis confirmed LOW overlap with the PR #707 audit learnings (different effort, different root causes) — these stand alone with cross-references. Frontmatter validated with the compound schema validator; `npm run ci:local`: ALL CHECKS PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)