### PR TITLE
fix: validate datum.__row__ before trusting it in cross-filter identity resolution

### DIFF
--- a/src/lib/interactivity/__test__/data-point.test.ts
+++ b/src/lib/interactivity/__test__/data-point.test.ts
@@ -45,6 +45,23 @@ describe('getResolvedRowIdentities', () => {
         // via `not.toContain` (NaN !== NaN), so pin the actual result instead.
         expect(result).toEqual([]);
     });
+    it('single datum with invalid __row__ resolves the right row via field matching', () => {
+        // Unlike the empty-fields fixture above (which matches all rows and
+        // exercises the clear path), a real field must match only its own row.
+        const fieldedDataset = {
+            fields: { category: {} },
+            values: [
+                { category: 'A', [ROW]: 0 },
+                { category: 'B', [ROW]: 1 },
+                { category: 'C', [ROW]: 2 }
+            ]
+        } as never;
+        const result = getResolvedRowIdentities(
+            [{ category: 'B', [ROW]: 99 }],
+            fieldedDataset
+        );
+        expect(result).toEqual([1]);
+    });
     it('multi-datum keeps only valid indices', () => {
         const result = getResolvedRowIdentities(
             [{ [ROW]: 0 }, { [ROW]: 99 }],

--- a/src/lib/interactivity/__test__/data-point.test.ts
+++ b/src/lib/interactivity/__test__/data-point.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getRowNumbersFromData } from '../data-point';
+import {
+    getResolvedRowIdentities,
+    getRowNumbersFromData
+} from '../data-point';
 
 const ROW = '__row__';
 
@@ -21,5 +24,31 @@ describe('getRowNumbersFromData', () => {
     });
     it('with datasetLength 0, returns empty', () => {
         expect(getRowNumbersFromData([{ [ROW]: 0 }], 0)).toEqual([]);
+    });
+});
+
+describe('getResolvedRowIdentities', () => {
+    const dataset = {
+        fields: {},
+        values: [{ [ROW]: 0 }, { [ROW]: 1 }, { [ROW]: 2 }]
+    } as never;
+    it('single datum with valid __row__ returns it', () => {
+        expect(getResolvedRowIdentities([{ [ROW]: 1 }], dataset)).toEqual([1]);
+    });
+    it.each([
+        ['out of range', 99],
+        ['negative', -1],
+        ['non-integer', 1.5],
+        ['non-number', '1']
+    ])('single datum with %s __row__ never surfaces it', (_label, bad) => {
+        const result = getResolvedRowIdentities([{ [ROW]: bad }], dataset);
+        expect(result).not.toContain(bad);
+    });
+    it('multi-datum keeps only valid indices', () => {
+        const result = getResolvedRowIdentities(
+            [{ [ROW]: 0 }, { [ROW]: 99 }],
+            dataset
+        );
+        expect(result).toEqual([0]);
     });
 });

--- a/src/lib/interactivity/__test__/data-point.test.ts
+++ b/src/lib/interactivity/__test__/data-point.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-    getResolvedRowIdentities,
-    getRowNumbersFromData
-} from '../data-point';
+import { getResolvedRowIdentities, getRowNumbersFromData } from '../data-point';
 
 const ROW = '__row__';
 

--- a/src/lib/interactivity/__test__/data-point.test.ts
+++ b/src/lib/interactivity/__test__/data-point.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getRowNumbersFromData } from '../data-point';
+
+const ROW = '__row__';
+
+describe('getRowNumbersFromData', () => {
+    const data = [
+        { [ROW]: 0 },
+        { [ROW]: 2 },
+        { [ROW]: 2 }, // duplicate — must still dedupe
+        { [ROW]: -1 }, // invalid: negative
+        { [ROW]: 1.5 }, // invalid: non-integer
+        { [ROW]: '3' }, // invalid: non-number
+        { [ROW]: 99 } // invalid: out of range for length 5
+    ];
+    it('without datasetLength, keeps legacy behavior (defined values pass)', () => {
+        expect(getRowNumbersFromData(data)).toEqual([0, 2, -1, 1.5, '3', 99]);
+    });
+    it('with datasetLength, skips invalid indices and dedupes', () => {
+        expect(getRowNumbersFromData(data, 5)).toEqual([0, 2]);
+    });
+    it('with datasetLength 0, returns empty', () => {
+        expect(getRowNumbersFromData([{ [ROW]: 0 }], 0)).toEqual([]);
+    });
+});

--- a/src/lib/interactivity/__test__/data-point.test.ts
+++ b/src/lib/interactivity/__test__/data-point.test.ts
@@ -39,10 +39,14 @@ describe('getResolvedRowIdentities', () => {
         ['out of range', 99],
         ['negative', -1],
         ['non-integer', 1.5],
-        ['non-number', '1']
+        ['non-number', '1'],
+        ['NaN', NaN]
     ])('single datum with %s __row__ never surfaces it', (_label, bad) => {
         const result = getResolvedRowIdentities([{ [ROW]: bad }], dataset);
-        expect(result).not.toContain(bad);
+        // With the fixture's empty `fields`, field-matching matches all rows,
+        // hitting the "all rows selected -> clear" path. NaN can't be checked
+        // via `not.toContain` (NaN !== NaN), so pin the actual result instead.
+        expect(result).toEqual([]);
     });
     it('multi-datum keeps only valid indices', () => {
         const result = getResolvedRowIdentities(

--- a/src/lib/interactivity/cross-filter.ts
+++ b/src/lib/interactivity/cross-filter.ts
@@ -228,7 +228,10 @@ const getCrossFilterSelectionAdvanced = (
             .hover()
             .run()
             .data(datasetName);
-        const rowNumbers = getRowNumbersFromData(filteredData);
+        const rowNumbers = getRowNumbersFromData(
+            filteredData,
+            dataset.values.length
+        );
         logDebug(`${LOG_PREFIX} headless validation complete`, {
             filteredData,
             rowNumbers

--- a/src/lib/interactivity/data-point.ts
+++ b/src/lib/interactivity/data-point.ts
@@ -66,8 +66,10 @@ export const getResolvedRowIdentities = (
             return [rowIndex];
         }
     }
-    // Multiple values; all with identifiable row indices. Invalid entries are
-    // skipped; if none survive, fall through to field matching.
+    // All datum carry an identity field — including a single datum whose
+    // __row__ failed validation above, since presence (not validity) is what
+    // gets us here. Invalid entries are skipped; if none survive, fall
+    // through to field matching.
     if (allValuesHaveIdentityField(data)) {
         // logDebug(`${LOG_PREFIX} all datum have identity field`, { data });
         const rowNumbers = getRowNumbersFromData(data, dataset.values.length);

--- a/src/lib/interactivity/data-point.ts
+++ b/src/lib/interactivity/data-point.ts
@@ -55,17 +55,25 @@ export const getResolvedRowIdentities = (
         //logDebug(`${LOG_PREFIX} no data supplied, returning empty array`);
         return [];
     }
-    // Single, identifiable datum
-    if (data.length === 1 && data[0]?.[ROW_INDEX_FIELD_NAME] !== undefined) {
-        // logDebug(`${LOG_PREFIX} single datum with identity field found`, {
-        //     datum: data[0]
-        // });
-        return [data[0][ROW_INDEX_FIELD_NAME]];
+    // Single, identifiable datum — only if the identity survives validation;
+    // a spoofed/mutated __row__ falls through to field matching instead.
+    if (data.length === 1) {
+        const rowIndex = data[0]?.[ROW_INDEX_FIELD_NAME];
+        if (isValidRowIndex(rowIndex, dataset.values.length)) {
+            // logDebug(`${LOG_PREFIX} single datum with identity field found`, {
+            //     datum: data[0]
+            // });
+            return [rowIndex];
+        }
     }
-    // Multiple values; all with identifiable row indices
+    // Multiple values; all with identifiable row indices. Invalid entries are
+    // skipped; if none survive, fall through to field matching.
     if (allValuesHaveIdentityField(data)) {
         // logDebug(`${LOG_PREFIX} all datum have identity field`, { data });
-        return getRowNumbersFromData(data);
+        const rowNumbers = getRowNumbersFromData(data, dataset.values.length);
+        if (rowNumbers.length > 0) {
+            return rowNumbers;
+        }
     }
     // Otherwise, panic mode: try to identify from the matched values
     // logDebug(`${LOG_PREFIX} attempting to resolve via field matching`, {

--- a/src/lib/interactivity/data-point.ts
+++ b/src/lib/interactivity/data-point.ts
@@ -20,6 +20,20 @@ const allValuesHaveIdentityField = (data: VegaDatum[]) =>
     )?.length === data?.length;
 
 /**
+ * A row identity supplied by a Vega datum is only trustworthy if it is an
+ * integer within the bounds of the visual's current dataset — specs can
+ * mutate `__row__`, so an unchecked value enables spoofed selection (#650).
+ */
+const isValidRowIndex = (
+    value: unknown,
+    datasetLength: number
+): value is number =>
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value < datasetLength;
+
+/**
  * Get a reduced set of fields based on an array of key names from the dataset fields.
  */
 export const getDatasetFieldsBySelectionKeys = (
@@ -98,16 +112,22 @@ const getMatchedValues = (
 };
 
 /**
- * From an array of Vega datum, extract unique row numbers, provided that they exist.
+ * From an array of Vega datum, extract unique row numbers, provided that they exist. When
+ * `datasetLength` is supplied, each candidate row index is additionally validated as an integer
+ * within the bounds of the dataset — spec-mutated/spoofed values are skipped rather than trusted.
  */
-export const getRowNumbersFromData = (data: VegaDatum[]) => {
+export const getRowNumbersFromData = (
+    data: VegaDatum[],
+    datasetLength?: number
+) => {
     const resolvedIndices: number[] = [];
     data.forEach((d) => {
         const rowIndex = d[ROW_INDEX_FIELD_NAME];
-        if (
-            rowIndex !== undefined &&
-            resolvedIndices.indexOf(rowIndex as number) === -1
-        ) {
+        const isUsable =
+            datasetLength === undefined
+                ? rowIndex !== undefined
+                : isValidRowIndex(rowIndex, datasetLength);
+        if (isUsable && resolvedIndices.indexOf(rowIndex as number) === -1) {
             resolvedIndices.push(rowIndex as number);
         }
     });

--- a/src/lib/interactivity/data-point.ts
+++ b/src/lib/interactivity/data-point.ts
@@ -99,6 +99,7 @@ export const getResolvedRowIdentities = (
         return [];
     }
     logDebug(`${LOG_PREFIX} fall-through case`, { foundValues });
+    // foundValues come from dataset.values itself (host-generated __row__), so no bounds check is needed here.
     return foundValues ? getRowNumbersFromData(foundValues) : [];
 };
 


### PR DESCRIPTION
## Summary

Fixes deneb-viz/deneb#650 — `datum.__row__` was trusted blindly, so a spec that mutates it (non-integer, negative, out-of-range, NaN, non-number) could drive spoofed cross-filter selection identities.

- Local `isValidRowIndex` guard in `src/lib/interactivity/data-point.ts` (integer + `0 <= n < dataset.values.length`)
- `getRowNumbersFromData` gains an optional `datasetLength`; validation applies only when supplied — legacy call sites byte-identical
- `getResolvedRowIdentities` validates both identity branches; invalid identities fall through to the field-matching path
- Advanced (headless-view) cross-filter call site passes bounds

Supersedes #656 — credit to @citosid for the report and the validation approach; this implements it against `next`'s current layout. #655 and #656 will be closed after the `next` → `main` release merge.

## Testing

- New `src/lib/interactivity/__test__/data-point.test.ts` (10 tests incl. NaN, dedupe, legacy-path pin)
- Interactivity + harness scenario sweep green (181 tests)
- TDD red→green verified per task

🤖 Generated with [Claude Code](https://claude.com/claude-code)
