### PR TITLE
perf: fast-follow hygiene (overlay gating, provider memoization, getRowMatch dedup)

### DIFF
--- a/packages/app-core/src/features/settings-pane/components/general-settings.tsx
+++ b/packages/app-core/src/features/settings-pane/components/general-settings.tsx
@@ -18,6 +18,7 @@ import { useSettingsPaneStyles } from '../styles';
 import { AssistivePreview } from './assistive-preview';
 import { HighlightText } from './highlight-text';
 import { generalSchema } from '../search/general-schema';
+import { getRowMatch } from '../search/get-row-match';
 import type { RowMatch, SectionMatchView } from '../search/types';
 
 type RadioOption = {
@@ -41,21 +42,6 @@ type SettingsRadioGroupProps = {
  */
 type RowComponentProps = {
     sectionMatchView?: SectionMatchView | null;
-};
-
-/**
- * Look up the row match for a given row id. Returns `undefined` when
- * the view is absent (no active filter) and `null` when the row is
- * explicitly filtered out.
- */
-const getRowMatch = (
-    view: SectionMatchView | null | undefined,
-    rowId: string
-): RowMatch | undefined | null => {
-    if (!view) return undefined;
-    const match = view.rows.get(rowId);
-    if (!match) return null;
-    return match.visible ? match : null;
 };
 
 type SettingsRadioGroupWithRowProps = SettingsRadioGroupProps & {

--- a/packages/app-core/src/features/settings-pane/components/performance-settings.tsx
+++ b/packages/app-core/src/features/settings-pane/components/performance-settings.tsx
@@ -24,20 +24,11 @@ import { INCREMENTAL_UPDATE_CONFIGURATION } from '../../../lib/vega/incremental-
 import { AssistivePreview } from './assistive-preview';
 import { HighlightText } from './highlight-text';
 import { performanceSchema } from '../search/performance-schema';
-import type { RowMatch, SectionMatchView } from '../search/types';
+import { getRowMatch } from '../search/get-row-match';
+import type { SectionMatchView } from '../search/types';
 
 type PerformanceSettingsProps = {
     sectionMatchView?: SectionMatchView | null;
-};
-
-const getRowMatch = (
-    view: SectionMatchView | null | undefined,
-    rowId: string
-): RowMatch | undefined | null => {
-    if (!view) return undefined;
-    const match = view.rows.get(rowId);
-    if (!match) return null;
-    return match.visible ? match : null;
 };
 
 /**

--- a/packages/app-core/src/features/settings-pane/search/__tests__/get-row-match.test.ts
+++ b/packages/app-core/src/features/settings-pane/search/__tests__/get-row-match.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRowMatch } from '../get-row-match';
+import type { RowMatch, SectionMatchView } from '../types';
+
+/**
+ * Extracted from two byte-identical copies previously colocated in
+ * `general-settings.tsx` and `performance-settings.tsx` — both row
+ * components look up their own `RowMatch` from a section-level
+ * `sectionMatchView` prop.
+ */
+describe('getRowMatch', () => {
+    it('returns undefined when the view is absent (no active filter)', () => {
+        expect(getRowMatch(undefined, 'provider')).toBeUndefined();
+        expect(getRowMatch(null, 'provider')).toBeUndefined();
+    });
+
+    it('returns null when the row id has no entry in the view (filtered out)', () => {
+        const view: SectionMatchView = {
+            headingHighlights: null,
+            rows: new Map<string, RowMatch>()
+        };
+        expect(getRowMatch(view, 'provider')).toBeNull();
+    });
+
+    it('returns null when the row entry exists but is not visible', () => {
+        const rowMatch: RowMatch = { visible: false, highlights: {} };
+        const view: SectionMatchView = {
+            headingHighlights: null,
+            rows: new Map<string, RowMatch>([['provider', rowMatch]])
+        };
+        expect(getRowMatch(view, 'provider')).toBeNull();
+    });
+
+    it('returns the RowMatch when the row entry exists and is visible', () => {
+        const rowMatch: RowMatch = {
+            visible: true,
+            highlights: { label: [{ start: 0, end: 3 }] }
+        };
+        const view: SectionMatchView = {
+            headingHighlights: null,
+            rows: new Map<string, RowMatch>([['provider', rowMatch]])
+        };
+        expect(getRowMatch(view, 'provider')).toBe(rowMatch);
+    });
+});

--- a/packages/app-core/src/features/settings-pane/search/get-row-match.ts
+++ b/packages/app-core/src/features/settings-pane/search/get-row-match.ts
@@ -1,0 +1,21 @@
+import type { RowMatch, SectionMatchView } from './types';
+
+/**
+ * Look up the row match for a given row id. Returns `undefined` when
+ * the view is absent (no active filter) and `null` when the row is
+ * explicitly filtered out.
+ *
+ * Shared by `general-settings.tsx` and `performance-settings.tsx` — both
+ * row components look up their own `RowMatch` from the section-level
+ * `sectionMatchView` prop so the section-level prop drilling stays
+ * simple.
+ */
+export const getRowMatch = (
+    view: SectionMatchView | null | undefined,
+    rowId: string
+): RowMatch | undefined | null => {
+    if (!view) return undefined;
+    const match = view.rows.get(rowId);
+    if (!match) return null;
+    return match.visible ? match : null;
+};

--- a/src/app/__test__/app-platform-provider-memoization.test.ts
+++ b/src/app/__test__/app-platform-provider-memoization.test.ts
@@ -20,10 +20,7 @@ import { resolve } from 'node:path';
  * memoization and its dependency array rather than a render harness.
  */
 describe('App platformProvider memoization', () => {
-    const source = readFileSync(
-        resolve(__dirname, '..', 'app.tsx'),
-        'utf8'
-    );
+    const source = readFileSync(resolve(__dirname, '..', 'app.tsx'), 'utf8');
 
     it('wraps platformProvider in useMemo rather than an inline object literal', () => {
         expect(source).toMatch(
@@ -73,9 +70,10 @@ describe('App platformProvider memoization', () => {
 
 const extractPlatformProviderMemoBlock = (source: string): string => {
     const start = source.indexOf('const platformProvider = useMemo(');
-    expect(start, 'could not find the platformProvider useMemo in app.tsx').toBeGreaterThan(
-        -1
-    );
+    expect(
+        start,
+        'could not find the platformProvider useMemo in app.tsx'
+    ).toBeGreaterThan(-1);
     const end = source.indexOf('\n    return (', start);
     expect(
         end,
@@ -91,7 +89,10 @@ const extractDepsArray = (source: string): string[] => {
     // matching the `settingsPanePlatformComponent` array literal inside
     // the factory body.
     const match = block.match(/\}\),\s*\[\s*([\s\S]*?)\s*\]\s*\)\s*;/);
-    expect(match, 'could not locate the useMemo dependency array').not.toBeNull();
+    expect(
+        match,
+        'could not locate the useMemo dependency array'
+    ).not.toBeNull();
     return match![1]
         .split(',')
         .map((entry) => entry.trim())

--- a/src/app/__test__/app-platform-provider-memoization.test.ts
+++ b/src/app/__test__/app-platform-provider-memoization.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Regression canary for `App`'s `platformProvider` object passed to
+ * `<DenebProvider>`. It used to be an inline object literal rebuilt on
+ * every `App` render, breaking reference equality for any context
+ * consumer further down the tree that compares it (e.g. a `useMemo` /
+ * `useEffect` dependency, or `React.memo` props equality). The fix wraps
+ * it in `useMemo`.
+ *
+ * `App` is the root visual's top-level component — it closes over the
+ * live Power BI host, the global Zustand stores, and Vega's loader/embed
+ * machinery, none of which this workspace mocks for component-tree
+ * render tests (see `src/features/toaster/__test__/notification-apply-changes-imports.test.ts`
+ * and `packages/app-core/.../no-data-message.test.tsx` for the
+ * established "defer component-tree tests, assert on source structure"
+ * precedent). This is therefore a static-source check that locks in the
+ * memoization and its dependency array rather than a render harness.
+ */
+describe('App platformProvider memoization', () => {
+    const source = readFileSync(
+        resolve(__dirname, '..', 'app.tsx'),
+        'utf8'
+    );
+
+    it('wraps platformProvider in useMemo rather than an inline object literal', () => {
+        expect(source).toMatch(
+            /const platformProvider = useMemo\(\s*\(\)\s*=>\s*\(\{/
+        );
+    });
+
+    it('DenebProvider consumes the memoized platformProvider variable, not an inline object', () => {
+        expect(source).toMatch(
+            /<DenebProvider platformProvider=\{platformProvider\}>/
+        );
+    });
+
+    it('does not suppress react-hooks/exhaustive-deps on the memo (dep array must be complete, not silenced)', () => {
+        const memoBlock = extractPlatformProviderMemoBlock(source);
+        expect(memoBlock).not.toMatch(/eslint-disable/);
+    });
+
+    it('the dependency array includes every prop/state identifier the factory closes over', () => {
+        const depsArray = extractDepsArray(source);
+        const expectedDeps = [
+            'host',
+            'isDownloadPermitted',
+            'launchUrl',
+            'onRenderingError',
+            'onRenderingFinished',
+            'onRenderingStarted',
+            'pbiTooltipHandler',
+            'vegaLoader',
+            'viewEventBinders'
+        ];
+        for (const dep of expectedDeps) {
+            expect(
+                depsArray,
+                `expected "${dep}" in the platformProvider useMemo deps array`
+            ).toContain(dep);
+        }
+        // No extras beyond what's expected — module-level functions
+        // (persistOnCreateFromTemplate, handlePersistBooleanProperty) and
+        // static JSX/constants (PLATFORM_SECTION_KEYS,
+        // platformSearchContributions) must NOT appear here; they are
+        // stable outside of `App`'s render and adding them would be a
+        // sign the memo is over-scoped.
+        expect(depsArray.sort()).toEqual(expectedDeps.sort());
+    });
+});
+
+const extractPlatformProviderMemoBlock = (source: string): string => {
+    const start = source.indexOf('const platformProvider = useMemo(');
+    expect(start, 'could not find the platformProvider useMemo in app.tsx').toBeGreaterThan(
+        -1
+    );
+    const end = source.indexOf('\n    return (', start);
+    expect(
+        end,
+        'could not find the end of the platformProvider useMemo block'
+    ).toBeGreaterThan(start);
+    return source.slice(start, end);
+};
+
+const extractDepsArray = (source: string): string[] => {
+    const block = extractPlatformProviderMemoBlock(source);
+    // The deps array immediately follows the factory's closing `}),` —
+    // anchoring there (rather than searching for any `[...]`) avoids
+    // matching the `settingsPanePlatformComponent` array literal inside
+    // the factory body.
+    const match = block.match(/\}\),\s*\[\s*([\s\S]*?)\s*\]\s*\)\s*;/);
+    expect(match, 'could not locate the useMemo dependency array').not.toBeNull();
+    return match![1]
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+};

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -400,7 +400,9 @@ export const App = ({
             </GatedDenebViewer>
             {mainComponent}
             <NotificationToaster />
-            {IS_UPDATE_HISTORY_OVERLAY_ENABLED && <VisualUpdateHistoryOverlay />}
+            {IS_UPDATE_HISTORY_OVERLAY_ENABLED && (
+                <VisualUpdateHistoryOverlay />
+            )}
             {IS_VIEWPORT_GATE_OVERLAY_ENABLED && <ViewportGateDebugOverlay />}
         </DenebProvider>
     );

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -330,42 +330,63 @@ export const App = ({
         }
     }, [mode]);
     logRender('App', mode);
+    /**
+     * Memoized so `DenebProvider` consumers (context readers deep in the
+     * component tree) keep a stable `platformProvider` reference across
+     * `App` renders that don't touch any of the values this object
+     * closes over. Without this, the object literal was rebuilt on every
+     * render, breaking reference equality for anything comparing it
+     * (e.g. a `useMemo`/`useEffect` dependency, or `React.memo` props
+     * equality) further down the tree.
+     */
+    const platformProvider = useMemo(
+        () => ({
+            embedContainerSetByHost: true,
+            isDownloadPermitted,
+            onCreateProject: persistOnCreateFromTemplate,
+            onEnableCrossHighlight: () =>
+                handlePersistBooleanProperty('enableHighlight', true),
+            onDisableCrossHighlight: () =>
+                handlePersistBooleanProperty('enableHighlight', false),
+            onRenderingError,
+            onRenderingFinished,
+            onRenderingStarted,
+            settingsPaneFooter: <InteractivityFooter />,
+            settingsPanePlatformComponent: [
+                <SemanticModelSettings key={PLATFORM_SECTION_KEYS[0]} />,
+                <TooltipSettings key={PLATFORM_SECTION_KEYS[1]} />,
+                <ContextMenuSettings key={PLATFORM_SECTION_KEYS[2]} />,
+                <CrossFilterSettings key={PLATFORM_SECTION_KEYS[3]} />,
+                <CrossHighlightSettings key={PLATFORM_SECTION_KEYS[4]} />
+            ],
+            settingsPanePlatformSearchable: platformSearchContributions,
+            tooltipHandler: pbiTooltipHandler,
+            vegaLoader,
+            viewEventBinders,
+            launchUrl,
+            downloadJsonFile: (content, filename, description) => {
+                host.downloadService.exportVisualsContentExtended(
+                    content,
+                    filename,
+                    'json',
+                    description
+                );
+            }
+        }),
+        [
+            host,
+            isDownloadPermitted,
+            launchUrl,
+            onRenderingError,
+            onRenderingFinished,
+            onRenderingStarted,
+            pbiTooltipHandler,
+            vegaLoader,
+            viewEventBinders
+        ]
+    );
     return (
-        <DenebProvider
-            platformProvider={{
-                embedContainerSetByHost: true,
-                isDownloadPermitted,
-                onCreateProject: persistOnCreateFromTemplate,
-                onEnableCrossHighlight: () =>
-                    handlePersistBooleanProperty('enableHighlight', true),
-                onDisableCrossHighlight: () =>
-                    handlePersistBooleanProperty('enableHighlight', false),
-                onRenderingError,
-                onRenderingFinished,
-                onRenderingStarted,
-                settingsPaneFooter: <InteractivityFooter />,
-                settingsPanePlatformComponent: [
-                    <SemanticModelSettings key={PLATFORM_SECTION_KEYS[0]} />,
-                    <TooltipSettings key={PLATFORM_SECTION_KEYS[1]} />,
-                    <ContextMenuSettings key={PLATFORM_SECTION_KEYS[2]} />,
-                    <CrossFilterSettings key={PLATFORM_SECTION_KEYS[3]} />,
-                    <CrossHighlightSettings key={PLATFORM_SECTION_KEYS[4]} />
-                ],
-                settingsPanePlatformSearchable: platformSearchContributions,
-                tooltipHandler: pbiTooltipHandler,
-                vegaLoader,
-                viewEventBinders,
-                launchUrl,
-                downloadJsonFile: (content, filename, description) => {
-                    host.downloadService.exportVisualsContentExtended(
-                        content,
-                        filename,
-                        'json',
-                        description
-                    );
-                }
-            }}
-        >
+        <DenebProvider platformProvider={platformProvider}>
             <RetainedDenebEditor
                 isEditorMode={mode === 'editor'}
                 hostViewportWidth={visualUpdateOptions?.viewport?.width}

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -37,7 +37,10 @@ import {
     IS_OVERLAY_ENABLED as IS_VIEWPORT_GATE_OVERLAY_ENABLED,
     ViewportGateDebugOverlay
 } from '../features/viewport-gate-debug-overlay';
-import { VisualUpdateHistoryOverlay } from '../features/visual-update-history-overlay';
+import {
+    IS_OVERLAY_ENABLED as IS_UPDATE_HISTORY_OVERLAY_ENABLED,
+    VisualUpdateHistoryOverlay
+} from '../features/visual-update-history-overlay';
 import { getVegaLoader } from '../lib/vega-embed';
 import { useDenebVisualState } from '../state';
 import {
@@ -376,7 +379,7 @@ export const App = ({
             </GatedDenebViewer>
             {mainComponent}
             <NotificationToaster />
-            <VisualUpdateHistoryOverlay />
+            {IS_UPDATE_HISTORY_OVERLAY_ENABLED && <VisualUpdateHistoryOverlay />}
             {IS_VIEWPORT_GATE_OVERLAY_ENABLED && <ViewportGateDebugOverlay />}
         </DenebProvider>
     );

--- a/src/features/visual-update-history-overlay/components/__test__/visual-update-history-overlay-gate.test.ts
+++ b/src/features/visual-update-history-overlay/components/__test__/visual-update-history-overlay-gate.test.ts
@@ -53,15 +53,19 @@ describe('VisualUpdateHistoryOverlay call-site gating', () => {
         expect(indexSource).toMatch(/\bIS_OVERLAY_ENABLED\b/);
     });
 
+    // Prettier may wrap the gated JSX in parentheses, so the pattern
+    // tolerates `{FLAG && <Overlay />}` and `{FLAG && (\n<Overlay />\n)}`.
+    const gatedMountPattern =
+        /\{IS_UPDATE_HISTORY_OVERLAY_ENABLED\s*&&\s*\(?\s*<VisualUpdateHistoryOverlay\s*\/>\s*\)?\s*\}/g;
+
     it('app.tsx gates the mount with `{FLAG && <VisualUpdateHistoryOverlay />}` rather than mounting unconditionally', () => {
-        expect(appSource).toMatch(
-            /\{IS_UPDATE_HISTORY_OVERLAY_ENABLED\s*&&\s*<VisualUpdateHistoryOverlay\s*\/>\}/
-        );
+        expect(appSource).toMatch(gatedMountPattern);
     });
 
-    it('app.tsx does not mount VisualUpdateHistoryOverlay unconditionally', () => {
-        expect(appSource).not.toMatch(
-            /^\s*<VisualUpdateHistoryOverlay\s*\/>\s*$/m
+    it('app.tsx does not mount VisualUpdateHistoryOverlay outside the gate', () => {
+        // Remove every gated occurrence; any tag left over is ungated.
+        expect(appSource.replace(gatedMountPattern, '')).not.toContain(
+            '<VisualUpdateHistoryOverlay'
         );
     });
 });

--- a/src/features/visual-update-history-overlay/components/__test__/visual-update-history-overlay-gate.test.ts
+++ b/src/features/visual-update-history-overlay/components/__test__/visual-update-history-overlay-gate.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Regression canary for the call-site gating pattern documented in
+ * docs/solutions/best-practices/gate-feature-flagged-react-components-at-call-site-2026-05-06.md
+ * (see that doc's `ViewportGateDebugOverlay` case history — this is the
+ * same fix applied to `VisualUpdateHistoryOverlay`).
+ *
+ * `VisualUpdateHistoryOverlay` previously guarded its JSX with an internal
+ * `if (!IS_OVERLAY_ENABLED) return <></>;` placed AFTER two
+ * `useDenebVisualState` subscriptions and two `useMemo`s. React's hooks
+ * contract means that guard only suppressed the returned JSX — the
+ * subscriptions and memo hooks still ran on every render, in every build,
+ * even with `PBIVIZ_DEV_OVERLAY=false` (the default). The fix exports
+ * `IS_OVERLAY_ENABLED` and gates the mount at the JSX call site in
+ * `src/app/app.tsx` instead, so a disabled build never invokes the
+ * component at all.
+ *
+ * The workspace defers component-tree render tests — vitest runs in the
+ * `node` environment with no `@testing-library/react` wired up for this
+ * package (see `src/features/toaster/__test__/notification-apply-changes-imports.test.ts`
+ * and `packages/app-core/.../no-data-message.test.tsx` for the established
+ * precedent). This is therefore a static-source check that locks in the
+ * structural invariant rather than a render/subscription-count assertion.
+ */
+describe('VisualUpdateHistoryOverlay call-site gating', () => {
+    const componentSource = readFileSync(
+        resolve(__dirname, '..', 'visual-update-history-overlay.tsx'),
+        'utf8'
+    );
+    const appSource = readFileSync(
+        resolve(__dirname, '..', '..', '..', '..', 'app', 'app.tsx'),
+        'utf8'
+    );
+
+    it('exports IS_OVERLAY_ENABLED so callers can gate at the JSX call site', () => {
+        expect(componentSource).toMatch(/export const IS_OVERLAY_ENABLED\s*=/);
+    });
+
+    it('does NOT early-return on IS_OVERLAY_ENABLED inside the component (the hooks above it would still run every render)', () => {
+        expect(componentSource).not.toMatch(
+            /if\s*\(!IS_OVERLAY_ENABLED\)\s*return/
+        );
+    });
+
+    it('the feature barrel re-exports IS_OVERLAY_ENABLED for app.tsx to consume', () => {
+        const indexSource = readFileSync(
+            resolve(__dirname, '..', '..', 'index.ts'),
+            'utf8'
+        );
+        expect(indexSource).toMatch(/\bIS_OVERLAY_ENABLED\b/);
+    });
+
+    it('app.tsx gates the mount with `{FLAG && <VisualUpdateHistoryOverlay />}` rather than mounting unconditionally', () => {
+        expect(appSource).toMatch(
+            /\{IS_UPDATE_HISTORY_OVERLAY_ENABLED\s*&&\s*<VisualUpdateHistoryOverlay\s*\/>\}/
+        );
+    });
+
+    it('app.tsx does not mount VisualUpdateHistoryOverlay unconditionally', () => {
+        expect(appSource).not.toMatch(
+            /^\s*<VisualUpdateHistoryOverlay\s*\/>\s*$/m
+        );
+    });
+});

--- a/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
+++ b/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
@@ -6,7 +6,7 @@ import { CollapsibleSection, DevOverlayShell } from '../../dev-overlay-shell';
 import { type RenderingLifecycleEvent } from '../../../lib/rendering-lifecycle';
 import { computeLifecycleTally } from '../lib/compute-tally';
 
-const IS_OVERLAY_ENABLED = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
+export const IS_OVERLAY_ENABLED = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
 
 const SECTION_HEADING_STYLE: CSSProperties = {
     fontWeight: 600,
@@ -82,8 +82,6 @@ export const VisualUpdateHistoryOverlay = () => {
                 .slice(-6),
         [lifecycleEvents]
     );
-
-    if (!IS_OVERLAY_ENABLED) return <></>;
 
     const tallyText = [
         `opens:        ${tally.opens}`,

--- a/src/features/visual-update-history-overlay/index.ts
+++ b/src/features/visual-update-history-overlay/index.ts
@@ -1,1 +1,4 @@
-export { VisualUpdateHistoryOverlay } from './components/visual-update-history-overlay';
+export {
+    IS_OVERLAY_ENABLED,
+    VisualUpdateHistoryOverlay
+} from './components/visual-update-history-overlay';


### PR DESCRIPTION
## Summary

Three perf/hygiene fast-follows from the 2026-07-15 holistic review (Minor section):

- **`VisualUpdateHistoryOverlay` gated at the call site** (mirrors the documented `ViewportGateDebugOverlay` pattern) — the internal after-hooks early-return is gone, so disabled builds never mount it and pay zero store subscriptions.
- **`platformProvider` memoized** in the App shell — `DenebProvider` consumers keep a stable reference across re-renders. Deps array covers all nine closed-over render-scoped values, verified manually (note: the repo has no `eslint-plugin-react-hooks` on the root package, so there is no mechanical exhaustive-deps check — a source canary test pins the deps array exactly; enabling the plugin repo-wide is a candidate follow-up).
- **`getRowMatch` deduplicated** — two byte-identical copies in the settings sections extracted to a single helper in the settings-pane search module, with unit tests. Architecture-boundaries canary green.

The final commit is a Prettier reflow plus a formatting-tolerance fix to the overlay gate canary (the negative check now strips gated occurrences before asserting none remain, so it cannot false-positive on paren-wrapped JSX).

## Testing

- New: overlay-gate + platform-provider source canaries (9), getRowMatch unit tests (4)
- Suites green: root 435, app-core 595 (incl. boundaries canary); tsc clean
- ci:local green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
