### PR TITLE
feat: debug-pane data table on Fluent DataGrid (drops react-data-table-component + styled-components)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,9 +76,9 @@
                 "tsup": "^8.5.0",
                 "turbo": "^2.6.0",
                 "typescript": "^5.6.2",
-                "vega": "^6.2.0",
-                "vega-embed": "^7.1.0",
-                "vega-lite": "^6.4.3",
+                "vega": "6.2.0",
+                "vega-embed": "7.1.0",
+                "vega-lite": "6.4.3",
                 "vitest": "^3.2.4",
                 "webpack": "^5.102.1",
                 "webpack-bundle-analyzer": "^4.10.2",
@@ -2138,21 +2138,6 @@
             "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
             "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@emotion/is-prop-valid": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-            "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/memoize": "^0.9.0"
-            }
-        },
-        "node_modules/@emotion/memoize": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
             "license": "MIT"
         },
         "node_modules/@epic-web/invariant": {
@@ -8593,15 +8578,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/camelize": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-            "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001782",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
@@ -9131,15 +9107,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/css-color-keywords": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-            "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/css-loader": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.4.tgz",
@@ -9187,17 +9154,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/css-to-react-native": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-            "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-            "license": "MIT",
-            "dependencies": {
-                "camelize": "^1.0.0",
-                "css-color-keywords": "^1.0.0",
-                "postcss-value-parser": "^4.0.2"
             }
         },
         "node_modules/css.escape": {
@@ -9572,15 +9528,6 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/deepmerge": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/default-browser": {
             "version": "5.5.0",
@@ -13731,6 +13678,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/powerbi-visuals-api": {
@@ -14171,24 +14119,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/react-data-table-component": {
-            "version": "7.7.0",
-            "resolved": "https://registry.npmjs.org/react-data-table-component/-/react-data-table-component-7.7.0.tgz",
-            "integrity": "sha512-5knL6zMSKlbvzu9P04KM5Lx8/EyQujb4I9z3rWeoVX++IDJadQ7aR4X5J6EeS90wjK0Xoa6btaVeglnCAqD2ag==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "deepmerge": "^4.3.1"
-            },
-            "peerDependencies": {
-                "react": ">= 17.0.0",
-                "styled-components": ">= 5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "styled-components": {
-                    "optional": false
-                }
             }
         },
         "node_modules/react-dom": {
@@ -15398,46 +15328,11 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/styled-components": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
-            "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/is-prop-valid": "1.4.0",
-                "css-to-react-native": "3.2.0",
-                "csstype": "3.2.3",
-                "stylis": "4.3.6"
-            },
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/styled-components"
-            },
-            "peerDependencies": {
-                "css-to-react-native": ">= 3.2.0",
-                "react": ">= 16.8.0",
-                "react-dom": ">= 16.8.0",
-                "react-native": ">= 0.68.0"
-            },
-            "peerDependenciesMeta": {
-                "css-to-react-native": {
-                    "optional": true
-                },
-                "react-dom": {
-                    "optional": true
-                },
-                "react-native": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/stylis": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
             "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/sucrase": {
@@ -18584,11 +18479,9 @@
                 "monaco-editor": "0.46.0",
                 "overlayscrollbars": "^2.10.1",
                 "overlayscrollbars-react": "^0.5.6",
-                "react-data-table-component": "^7.7.0",
                 "react-dropzone": "^14.2.3",
                 "react-hotkeys-hook": "^5.2.0",
                 "react-vega": "7.6.0",
-                "styled-components": "^6.1.19",
                 "use-resize-observer": "^9.1.0",
                 "zustand": "^4.5.5"
             },

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -72,11 +72,9 @@
         "monaco-editor": "0.46.0",
         "overlayscrollbars": "^2.10.1",
         "overlayscrollbars-react": "^0.5.6",
-        "react-data-table-component": "^7.7.0",
         "react-dropzone": "^14.2.3",
         "react-hotkeys-hook": "^5.2.0",
         "react-vega": "7.6.0",
-        "styled-components": "^6.1.19",
         "use-resize-observer": "^9.1.0",
         "zustand": "^4.5.5"
     },

--- a/packages/app-core/src/features/debug-area/components/data-table/__tests__/data-table-pagination.test.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/__tests__/data-table-pagination.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+
+import { getPageSlice } from '../data-table-pagination';
+
+const seq = (n: number): number[] => Array.from({ length: n }, (_, i) => i);
+
+describe('getPageSlice', () => {
+    it('returns the first page', () => {
+        expect(getPageSlice(seq(10), 1, 4)).toEqual([0, 1, 2, 3]);
+    });
+
+    it('returns a middle page', () => {
+        expect(getPageSlice(seq(10), 2, 4)).toEqual([4, 5, 6, 7]);
+    });
+
+    it('returns a partial last page', () => {
+        expect(getPageSlice(seq(10), 3, 4)).toEqual([8, 9]);
+    });
+
+    it('clamps a page beyond the range to the last page', () => {
+        expect(getPageSlice(seq(10), 99, 4)).toEqual([8, 9]);
+    });
+
+    it('clamps a page below 1 to the first page', () => {
+        expect(getPageSlice(seq(10), 0, 4)).toEqual([0, 1, 2, 3]);
+        expect(getPageSlice(seq(10), -5, 4)).toEqual([0, 1, 2, 3]);
+    });
+
+    it('returns an empty array when perPage is zero or negative', () => {
+        expect(getPageSlice(seq(10), 1, 0)).toEqual([]);
+        expect(getPageSlice(seq(10), 1, -3)).toEqual([]);
+    });
+
+    it('returns an empty array for empty input', () => {
+        expect(getPageSlice([], 1, 10)).toEqual([]);
+    });
+
+    it('returns all rows when perPage exceeds the row count', () => {
+        expect(getPageSlice(seq(3), 1, 50)).toEqual([0, 1, 2]);
+    });
+
+    it('does not mutate the input array', () => {
+        const input = seq(6);
+        getPageSlice(input, 2, 2);
+        expect(input).toEqual(seq(6));
+    });
+});

--- a/packages/app-core/src/features/debug-area/components/data-table/__tests__/data-table-sort.test.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/__tests__/data-table-sort.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { sortRows } from '../data-table-sort';
+import { resolveNextSortState, sortRows } from '../data-table-sort';
 import type { DataTableViewerColumn } from '../data-table-viewer-types';
 
 type Row = { id: string; v: unknown };
@@ -29,7 +29,11 @@ describe('sortRows', () => {
     });
 
     it('sorts strings via localeCompare (case-insensitive-ish ordering)', () => {
-        const result = sortRows(rows('banana', 'apple', 'cherry'), bySelector, true);
+        const result = sortRows(
+            rows('banana', 'apple', 'cherry'),
+            bySelector,
+            true
+        );
         expect(result.map((r) => r.v)).toEqual(['apple', 'banana', 'cherry']);
     });
 
@@ -42,12 +46,20 @@ describe('sortRows', () => {
     });
 
     it('places null and undefined last on ascending sort', () => {
-        const result = sortRows(rows(3, null, 1, undefined, 2), bySelector, true);
+        const result = sortRows(
+            rows(3, null, 1, undefined, 2),
+            bySelector,
+            true
+        );
         expect(result.map((r) => r.v)).toEqual([1, 2, 3, null, undefined]);
     });
 
     it('places null and undefined last on descending sort too', () => {
-        const result = sortRows(rows(3, null, 1, undefined, 2), bySelector, false);
+        const result = sortRows(
+            rows(3, null, 1, undefined, 2),
+            bySelector,
+            false
+        );
         // nulls stay last regardless of direction
         expect(result.slice(0, 3).map((r) => r.v)).toEqual([3, 2, 1]);
         expect(result.slice(3).map((r) => r.v)).toEqual([null, undefined]);
@@ -85,5 +97,42 @@ describe('sortRows', () => {
         const result = sortRows(rows(2, NaN, 1), bySelector, true);
         expect(result.slice(0, 2).map((r) => r.v)).toEqual([1, 2]);
         expect(Number.isNaN(result[2].v)).toBe(true);
+    });
+});
+
+describe('resolveNextSortState', () => {
+    const asc = 'ascending' as const;
+    const desc = 'descending' as const;
+    it('unsorted -> first click sorts ascending', () => {
+        expect(
+            resolveNextSortState(
+                { sortColumn: undefined, sortDirection: asc },
+                { sortColumn: 'a', sortDirection: asc }
+            )
+        ).toEqual({ sortColumn: 'a', sortDirection: asc });
+    });
+    it('ascending -> second click sorts descending', () => {
+        expect(
+            resolveNextSortState(
+                { sortColumn: 'a', sortDirection: asc },
+                { sortColumn: 'a', sortDirection: desc }
+            )
+        ).toEqual({ sortColumn: 'a', sortDirection: desc });
+    });
+    it('descending -> third click clears the sort', () => {
+        expect(
+            resolveNextSortState(
+                { sortColumn: 'a', sortDirection: desc },
+                { sortColumn: 'a', sortDirection: asc }
+            )
+        ).toEqual({ sortColumn: undefined, sortDirection: asc });
+    });
+    it('descending -> clicking a DIFFERENT column starts its ascending sort', () => {
+        expect(
+            resolveNextSortState(
+                { sortColumn: 'a', sortDirection: desc },
+                { sortColumn: 'b', sortDirection: asc }
+            )
+        ).toEqual({ sortColumn: 'b', sortDirection: asc });
     });
 });

--- a/packages/app-core/src/features/debug-area/components/data-table/__tests__/data-table-sort.test.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/__tests__/data-table-sort.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+
+import { sortRows } from '../data-table-sort';
+import type { DataTableViewerColumn } from '../data-table-viewer-types';
+
+type Row = { id: string; v: unknown };
+
+const col = (selector: (r: Row) => unknown): DataTableViewerColumn<Row> => ({
+    id: 'v',
+    name: 'v',
+    selector,
+    cell: () => null
+});
+
+const bySelector = col((r) => r.v);
+
+const rows = (...vs: unknown[]): Row[] =>
+    vs.map((v, i) => ({ id: `r${i}`, v }));
+
+describe('sortRows', () => {
+    it('sorts numbers numerically, not lexicographically', () => {
+        const result = sortRows(rows(10, 2, 1, 100), bySelector, true);
+        expect(result.map((r) => r.v)).toEqual([1, 2, 10, 100]);
+    });
+
+    it('sorts numbers descending', () => {
+        const result = sortRows(rows(10, 2, 1, 100), bySelector, false);
+        expect(result.map((r) => r.v)).toEqual([100, 10, 2, 1]);
+    });
+
+    it('sorts strings via localeCompare (case-insensitive-ish ordering)', () => {
+        const result = sortRows(rows('banana', 'apple', 'cherry'), bySelector, true);
+        expect(result.map((r) => r.v)).toEqual(['apple', 'banana', 'cherry']);
+    });
+
+    it('sorts dates chronologically', () => {
+        const d1 = new Date('2020-01-01');
+        const d2 = new Date('2021-06-15');
+        const d3 = new Date('2019-12-31');
+        const result = sortRows(rows(d1, d2, d3), bySelector, true);
+        expect(result.map((r) => r.v)).toEqual([d3, d1, d2]);
+    });
+
+    it('places null and undefined last on ascending sort', () => {
+        const result = sortRows(rows(3, null, 1, undefined, 2), bySelector, true);
+        expect(result.map((r) => r.v)).toEqual([1, 2, 3, null, undefined]);
+    });
+
+    it('places null and undefined last on descending sort too', () => {
+        const result = sortRows(rows(3, null, 1, undefined, 2), bySelector, false);
+        // nulls stay last regardless of direction
+        expect(result.slice(0, 3).map((r) => r.v)).toEqual([3, 2, 1]);
+        expect(result.slice(3).map((r) => r.v)).toEqual([null, undefined]);
+    });
+
+    it('is stable for ties (equal keys retain original order)', () => {
+        const input: Row[] = [
+            { id: 'a', v: 1 },
+            { id: 'b', v: 1 },
+            { id: 'c', v: 1 },
+            { id: 'd', v: 0 }
+        ];
+        const result = sortRows(input, bySelector, true);
+        expect(result.map((r) => r.id)).toEqual(['d', 'a', 'b', 'c']);
+    });
+
+    it('returns an empty array unchanged', () => {
+        expect(sortRows([], bySelector, true)).toEqual([]);
+    });
+
+    it('returns rows unchanged (copy) when no column is supplied', () => {
+        const input = rows(3, 1, 2);
+        const result = sortRows(input, null, true);
+        expect(result.map((r) => r.v)).toEqual([3, 1, 2]);
+        expect(result).not.toBe(input);
+    });
+
+    it('does not mutate the input array', () => {
+        const input = rows(3, 1, 2);
+        sortRows(input, bySelector, true);
+        expect(input.map((r) => r.v)).toEqual([3, 1, 2]);
+    });
+
+    it('treats NaN like a nil value (sorted last)', () => {
+        const result = sortRows(rows(2, NaN, 1), bySelector, true);
+        expect(result.slice(0, 2).map((r) => r.v)).toEqual([1, 2]);
+        expect(Number.isNaN(result[2].v)).toBe(true);
+    });
+});

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-pagination.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-pagination.ts
@@ -1,0 +1,23 @@
+/**
+ * Return the rows for a single (1-based) page from an already-sorted set.
+ *
+ * Clamping rules:
+ * - `perPage <= 0` (or an empty input) yields an empty page;
+ * - a `page` beyond the last page is clamped to the last page;
+ * - a `page` below 1 is clamped to the first page.
+ *
+ * The input array is never mutated (`slice` returns a shallow copy).
+ */
+export const getPageSlice = <T>(
+    rows: T[],
+    page: number,
+    perPage: number
+): T[] => {
+    if (perPage <= 0 || rows.length === 0) {
+        return [];
+    }
+    const numPages = Math.max(1, Math.ceil(rows.length / perPage));
+    const clampedPage = Math.min(Math.max(1, page), numPages);
+    const start = (clampedPage - 1) * perPage;
+    return rows.slice(start, start + perPage);
+};

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-sort.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-sort.ts
@@ -1,9 +1,11 @@
+import type { DataGridProps } from '@fluentui/react-components';
 import type { DataTableViewerColumn } from './data-table-viewer-types';
 
-export interface ViewerSortState {
-    sortColumn: string | number | undefined;
-    sortDirection: 'ascending' | 'descending';
-}
+/**
+ * The DataGrid's controlled sort-state shape (type-only import; this module
+ * stays runtime-dependency-free).
+ */
+export type ViewerSortState = NonNullable<DataGridProps['sortState']>;
 
 /**
  * Resolve the next controlled sort state from a DataGrid header click,
@@ -54,21 +56,11 @@ export const sortRows = <T>(
     }
     const selector = column.selector;
     const direction = asc ? 1 : -1;
+    // Array.prototype.sort is spec-stable (ES2019+), so ties keep their
+    // original input order without a manual index tie-break.
     return rows
-        .map((row, index) => ({ row, index }))
-        .sort((a, b) => {
-            const compared = compareValues(
-                selector(a.row),
-                selector(b.row),
-                direction
-            );
-            if (compared !== 0) {
-                return compared;
-            }
-            // Stable tie-break on original position.
-            return a.index - b.index;
-        })
-        .map((entry) => entry.row);
+        .slice()
+        .sort((a, b) => compareValues(selector(a), selector(b), direction));
 };
 
 /**

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-sort.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-sort.ts
@@ -1,5 +1,31 @@
 import type { DataTableViewerColumn } from './data-table-viewer-types';
 
+export interface ViewerSortState {
+    sortColumn: string | number | undefined;
+    sortDirection: 'ascending' | 'descending';
+}
+
+/**
+ * Resolve the next controlled sort state from a DataGrid header click,
+ * upgrading Fluent's native two-state toggle to a tri-state cycle:
+ * unsorted → ascending → descending → unsorted.
+ *
+ * Fluent's `toggleColumnSort` emits `ascending` for a newly-clicked column
+ * and flips direction on repeat clicks — it never emits "unsorted". Because
+ * the viewer controls `sortState`, a desc→asc flip on the SAME column is
+ * interpreted as the third click and clears the sort instead.
+ */
+export const resolveNextSortState = (
+    current: ViewerSortState,
+    next: ViewerSortState
+): ViewerSortState =>
+    current.sortColumn !== undefined &&
+    current.sortColumn === next.sortColumn &&
+    current.sortDirection === 'descending' &&
+    next.sortDirection === 'ascending'
+        ? { sortColumn: undefined, sortDirection: 'ascending' }
+        : next;
+
 /**
  * Sort the FULL row set by a column's `selector`, external to the DataGrid.
  *

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-sort.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-sort.ts
@@ -1,0 +1,85 @@
+import type { DataTableViewerColumn } from './data-table-viewer-types';
+
+/**
+ * Sort the FULL row set by a column's `selector`, external to the DataGrid.
+ *
+ * Deliberately owns sorting rather than delegating to the DataGrid's internal
+ * `compare`: the grid only ever receives the current page's rows, so its
+ * internal sort would order a single page. Sorting the whole set here (before
+ * pagination slices it) reproduces react-data-table-component's behaviour.
+ *
+ * Ordering rules:
+ * - numbers compared numerically, dates chronologically, booleans false<true,
+ *   everything else via `localeCompare` on the string form;
+ * - `null`, `undefined`, and `NaN` are always ordered last, regardless of the
+ *   sort direction;
+ * - ties preserve the original input order (stable sort).
+ *
+ * Returns a new array; the input is never mutated. When no sortable column is
+ * supplied, a shallow copy of the input (original order) is returned.
+ */
+export const sortRows = <T>(
+    rows: T[],
+    column: DataTableViewerColumn<T> | null | undefined,
+    asc: boolean
+): T[] => {
+    if (!column || !column.selector) {
+        return rows.slice();
+    }
+    const selector = column.selector;
+    const direction = asc ? 1 : -1;
+    return rows
+        .map((row, index) => ({ row, index }))
+        .sort((a, b) => {
+            const compared = compareValues(
+                selector(a.row),
+                selector(b.row),
+                direction
+            );
+            if (compared !== 0) {
+                return compared;
+            }
+            // Stable tie-break on original position.
+            return a.index - b.index;
+        })
+        .map((entry) => entry.row);
+};
+
+/**
+ * Whether a value should be treated as "empty" for sorting and pushed to the
+ * end. `NaN` is included because a numeric comparison against it yields `NaN`,
+ * which would otherwise destabilise the sort.
+ */
+const isNil = (value: unknown): boolean =>
+    value === null ||
+    value === undefined ||
+    (typeof value === 'number' && Number.isNaN(value));
+
+/**
+ * Three-way compare that keeps nil values last independent of `direction`, and
+ * applies `direction` only to the comparison between two real values.
+ */
+const compareValues = (a: unknown, b: unknown, direction: number): number => {
+    const aNil = isNil(a);
+    const bNil = isNil(b);
+    if (aNil && bNil) return 0;
+    if (aNil) return 1; // a after b
+    if (bNil) return -1; // a before b
+    return baseCompare(a, b) * direction;
+};
+
+/**
+ * Type-aware comparison of two non-nil values.
+ */
+const baseCompare = (a: unknown, b: unknown): number => {
+    if (typeof a === 'number' && typeof b === 'number') {
+        return a - b;
+    }
+    if (a instanceof Date && b instanceof Date) {
+        return a.getTime() - b.getTime();
+    }
+    if (typeof a === 'boolean' && typeof b === 'boolean') {
+        return a === b ? 0 : a ? 1 : -1;
+    }
+    return String(a).localeCompare(String(b));
+};

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-status-bar.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-status-bar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import {
     Caption1,
     Label,
@@ -42,8 +42,6 @@ const useDataTableStatusBarStyles = makeStyles({
 export interface DataTableStatusBarProps {
     /** Total row count across all pages. */
     rowCount: number;
-    /** Rows shown per page. */
-    rowsPerPage: number;
     /** Current (1-based) page. */
     currentPage: number;
     /** Navigate to a page. The second arg (total rows) is unused by callers. */
@@ -60,7 +58,6 @@ export interface DataTableStatusBarProps {
  */
 export const DataTableStatusBar = ({
     rowCount,
-    rowsPerPage,
     onChangePage,
     onChangeRowsPerPage,
     currentPage
@@ -70,11 +67,6 @@ export const DataTableStatusBar = ({
         mode: state.editorPreviewAreaSelectedPivot,
         translate: state.i18n.translate
     }));
-    useEffect(() => {
-        if (rowsPerPage !== rowsPerPageSetting) {
-            onChangeRowsPerPage(rowsPerPageSetting as number, currentPage);
-        }
-    }, [rowsPerPage, rowsPerPageSetting]);
     const handleFirstPageButtonClick = () => {
         onChangePage(1, rowCount);
     };

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-status-bar.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-status-bar.tsx
@@ -119,47 +119,52 @@ export const DataTableStatusBar = ({
     return (
         <StatusBarContainer
             nearItems={<div>{optionComponent}</div>}
+            // The pagination cluster is meaningless at zero rows (rdt hid
+            // its whole bar; we keep the bar for the dataset selector and
+            // hide only this side).
             farItems={
-                <div className={classes.navigation}>
-                    <div>
-                        <Label htmlFor={rowsPerPageId} size='small'>
-                            {translate('Text_Data_Table_Navigation_Rows')}
-                        </Label>
+                rowCount === 0 ? null : (
+                    <div className={classes.navigation}>
+                        <div>
+                            <Label htmlFor={rowsPerPageId} size='small'>
+                                {translate('Text_Data_Table_Navigation_Rows')}
+                            </Label>
+                        </div>
+                        <div>
+                            <Select
+                                id={rowsPerPageId}
+                                value={rowsPerPageSetting}
+                                onChange={handleChangeRowsPerPage}
+                                size='small'
+                            >
+                                {rowsPerPageEntries}
+                            </Select>
+                        </div>
+                        <div>
+                            <Caption1>{range}</Caption1>
+                        </div>
+                        <DataTableNavigationButton
+                            type='first'
+                            onClick={handleFirstPageButtonClick}
+                            disabled={currentPage === 1}
+                        />
+                        <DataTableNavigationButton
+                            type='previous'
+                            onClick={handlePreviousButtonClick}
+                            disabled={currentPage === 1}
+                        />
+                        <DataTableNavigationButton
+                            type='next'
+                            onClick={handleNextButtonClick}
+                            disabled={currentPage === numPages}
+                        />
+                        <DataTableNavigationButton
+                            type='last'
+                            onClick={handleLastPageButtonClick}
+                            disabled={currentPage === numPages}
+                        />
                     </div>
-                    <div>
-                        <Select
-                            id={rowsPerPageId}
-                            value={rowsPerPageSetting}
-                            onChange={handleChangeRowsPerPage}
-                            size='small'
-                        >
-                            {rowsPerPageEntries}
-                        </Select>
-                    </div>
-                    <div>
-                        <Caption1>{range}</Caption1>
-                    </div>
-                    <DataTableNavigationButton
-                        type='first'
-                        onClick={handleFirstPageButtonClick}
-                        disabled={currentPage === 1}
-                    />
-                    <DataTableNavigationButton
-                        type='previous'
-                        onClick={handlePreviousButtonClick}
-                        disabled={currentPage === 1}
-                    />
-                    <DataTableNavigationButton
-                        type='next'
-                        onClick={handleNextButtonClick}
-                        disabled={currentPage === numPages}
-                    />
-                    <DataTableNavigationButton
-                        type='last'
-                        onClick={handleLastPageButtonClick}
-                        disabled={currentPage === numPages}
-                    />
-                </div>
+                )
             }
         />
     );

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-status-bar.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-status-bar.tsx
@@ -8,8 +8,6 @@ import {
     tokens,
     useId
 } from '@fluentui/react-components';
-import { type PaginationComponentProps } from 'react-data-table-component';
-
 import { DATA_VIEWER_CONFIGURATION } from '@deneb-viz/configuration';
 import { useDenebState } from '../../../../state';
 import { handleDataTableRowsPerPageChange } from '../../../../lib';
@@ -36,6 +34,28 @@ const useDataTableStatusBarStyles = makeStyles({
 });
 
 /**
+ * Pagination contract consumed by the status bar. Field names and call
+ * signatures match what react-data-table-component's `PaginationComponentProps`
+ * exposed previously, so the component internals are unchanged; the type is now
+ * owned locally rather than imported from the (removed) table library.
+ */
+export interface DataTableStatusBarProps {
+    /** Total row count across all pages. */
+    rowCount: number;
+    /** Rows shown per page. */
+    rowsPerPage: number;
+    /** Current (1-based) page. */
+    currentPage: number;
+    /** Navigate to a page. The second arg (total rows) is unused by callers. */
+    onChangePage: (page: number, totalRows: number) => void;
+    /** Change the rows-per-page, preserving the caller's current page arg. */
+    onChangeRowsPerPage: (
+        currentRowsPerPage: number,
+        currentPage: number
+    ) => void;
+}
+
+/**
  * Displays at the footer of the data table, and used to control pagination and other options.
  */
 // eslint-disable-next-line max-lines-per-function
@@ -45,7 +65,7 @@ export const DataTableStatusBar = ({
     onChangePage,
     onChangeRowsPerPage,
     currentPage
-}: PaginationComponentProps) => {
+}: DataTableStatusBarProps) => {
     const { rowsPerPageSetting, mode, translate } = useDenebState((state) => ({
         rowsPerPageSetting: state.editorPreferences.dataViewerRowsPerPage,
         mode: state.editorPreviewAreaSelectedPivot,

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-status-bar.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-status-bar.tsx
@@ -58,7 +58,6 @@ export interface DataTableStatusBarProps {
 /**
  * Displays at the footer of the data table, and used to control pagination and other options.
  */
-// eslint-disable-next-line max-lines-per-function
 export const DataTableStatusBar = ({
     rowCount,
     rowsPerPage,

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-viewer-types.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-viewer-types.ts
@@ -48,7 +48,11 @@ export interface DataTableViewerProps<T> {
     defaultSortFieldId?: string | null;
     /** Initial sort direction when `defaultSortFieldId` is set. */
     defaultSortAsc?: boolean;
-    /** Reports a sort change up so it can be persisted in debug state. */
+    /**
+     * Reports a sort change up so it can be persisted in debug state. An
+     * empty `colId` signals the tri-state cycle returned to "unsorted"
+     * (consumers clear their persisted sort entry).
+     */
     onSort?: (colId: string, asc: boolean) => void;
     /** Reports a page change up so it can be persisted in debug state. */
     onChangePage?: (page: number) => void;

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-viewer-types.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-viewer-types.ts
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Local column contract for `DataTableViewer`, decoupled from any table
+ * library. Only the fields the three debug-area viewers (Data tab, Source
+ * tab, Signal viewer) genuinely use are modelled here — this replaces the
+ * former dependency on react-data-table-component's `TableColumn` type.
+ */
+export interface DataTableViewerColumn<T> {
+    /** Stable id — keyboard-nav registration + sort identity. */
+    id: string;
+    /** Header content (JSX via `DataTableHeaderCell`). */
+    name: ReactNode;
+    /**
+     * Raw value accessor. Used for sorting (and, in principle, default cell
+     * text — though every viewer supplies an explicit `cell`, so the text
+     * role is unused today). Returns the underlying raw value so sorting
+     * matches the previous rawValue-based `sortFunction` behaviour.
+     */
+    selector: (row: T) => unknown;
+    /** When `false`/absent, the column header does not toggle sort. */
+    sortable?: boolean;
+    /**
+     * Pre-computed pixel width (worker-measured for the dataset viewers).
+     * Fed to the DataGrid's `columnSizingOptions` as the column's ideal
+     * width. Optional — columns without a measured width fall back to the
+     * grid's default sizing.
+     */
+    width?: number;
+    /**
+     * Cell renderer (JSX via `DataTableCell`). `rowIndex` is the
+     * page-relative row index (0-based within the currently visible page),
+     * matching what react-data-table-component passed previously.
+     */
+    cell: (row: T, rowIndex: number) => ReactNode;
+}
+
+/**
+ * Local prop contract for `DataTableViewer`. Mirrors the exact set of props
+ * the three viewers pass today, mapped off react-data-table-component's
+ * `TableProps`. Sorting is reported up as `(colId, asc)` rather than rdt's
+ * `(column, direction, rows)` triple.
+ */
+export interface DataTableViewerProps<T> {
+    columns: DataTableViewerColumn<T>[];
+    data: T[];
+    /** Column id to seed the initial sort from (null/undefined => unsorted). */
+    defaultSortFieldId?: string | null;
+    /** Initial sort direction when `defaultSortFieldId` is set. */
+    defaultSortAsc?: boolean;
+    /** Reports a sort change up so it can be persisted in debug state. */
+    onSort?: (colId: string, asc: boolean) => void;
+    /** Reports a page change up so it can be persisted in debug state. */
+    onChangePage?: (page: number) => void;
+    /** Initial (1-based) page to display. */
+    paginationDefaultPage?: number;
+    /**
+     * Retained for API parity with the previous contract. In practice the
+     * tabs gate the loading state at the tab level (rendering
+     * `ProcessingDataMessage`) so the viewer only mounts once processing is
+     * complete; this flag is therefore always false at render time.
+     */
+    progressPending?: boolean;
+}

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-viewer-types.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-viewer-types.ts
@@ -12,10 +12,8 @@ export interface DataTableViewerColumn<T> {
     /** Header content (JSX via `DataTableHeaderCell`). */
     name: ReactNode;
     /**
-     * Raw value accessor. Used for sorting (and, in principle, default cell
-     * text — though every viewer supplies an explicit `cell`, so the text
-     * role is unused today). Returns the underlying raw value so sorting
-     * matches the previous rawValue-based `sortFunction` behaviour.
+     * Raw value accessor used for sorting (matches the previous
+     * rawValue-based `sortFunction` behaviour).
      */
     selector: (row: T) => unknown;
     /** When `false`/absent, the column header does not toggle sort. */
@@ -58,11 +56,4 @@ export interface DataTableViewerProps<T> {
     onChangePage?: (page: number) => void;
     /** Initial (1-based) page to display. */
     paginationDefaultPage?: number;
-    /**
-     * Retained for API parity with the previous contract. In practice the
-     * tabs gate the loading state at the tab level (rendering
-     * `ProcessingDataMessage`) so the viewer only mounts once processing is
-     * complete; this flag is therefore always false at render time.
-     */
-    progressPending?: boolean;
 }

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -1,9 +1,17 @@
-import { useMemo, useRef } from 'react';
-import { makeStyles } from '@fluentui/react-components';
-import { ArrowSortDown16Regular } from '@fluentui/react-icons';
-import { tokens } from '@fluentui/react-theme';
-import DataTable, { type TableProps } from 'react-data-table-component';
-import { StyleSheetManager } from 'styled-components';
+import { useMemo, useRef, useState } from 'react';
+import {
+    createTableColumn,
+    DataGrid,
+    DataGridBody,
+    DataGridCell,
+    DataGridHeader,
+    DataGridHeaderCell,
+    DataGridRow,
+    makeStyles,
+    tokens,
+    type DataGridProps,
+    type TableColumnDefinition
+} from '@fluentui/react-components';
 
 import { logDebug, logRender } from '@deneb-viz/utils/logging';
 import { DataTableStatusBar } from './data-table-status-bar';
@@ -11,6 +19,12 @@ import { DataTableTooltipProvider } from './data-table-tooltip-context';
 import { DataTableInspectorProvider } from './inspector-popover-context';
 import { DataTableKeyboardProvider } from './data-table-keyboard-context';
 import { InspectorPopover } from './inspector-popover';
+import { sortRows } from './data-table-sort';
+import { getPageSlice } from './data-table-pagination';
+import type {
+    DataTableViewerColumn,
+    DataTableViewerProps
+} from './data-table-viewer-types';
 import {
     DATA_TABLE_FONT_FAMILY,
     DATA_TABLE_FONT_SIZE,
@@ -26,27 +40,90 @@ const useDataTableStyles = makeStyles({
         height: '100%',
         overflow: 'hidden',
         width: '100%'
+    },
+    // The single scrollable region. `flexGrow: 1` + `minHeight: 0` lets it
+    // consume the space above the status bar and scroll internally; the
+    // status bar (a non-growing sibling below) stays pinned to the bottom.
+    // This is the flex contract the abandoned v8 upgrade got wrong.
+    scroll: {
+        flexGrow: 1,
+        minHeight: 0,
+        overflowY: 'auto',
+        overflowX: 'auto',
+        position: 'relative'
+    },
+    grid: {
+        fontFamily: DATA_TABLE_FONT_FAMILY,
+        fontSize: `${DATA_TABLE_FONT_SIZE}px`,
+        width: '100%'
+    },
+    // Pin the header while the body scrolls (the previous `fixedHeader`).
+    header: {
+        position: 'sticky',
+        top: 0,
+        zIndex: 1,
+        backgroundColor: tokens.colorNeutralBackground1
+    },
+    headerRow: {
+        paddingLeft: `${DATA_TABLE_ROW_PADDING_LEFT}px`,
+        minHeight: `${DATA_TABLE_ROW_HEIGHT}px`
+    },
+    headerCell: {
+        color: tokens.colorNeutralForeground1,
+        fontWeight: tokens.fontWeightBold,
+        fontSize: `${DATA_TABLE_FONT_SIZE}px`,
+        backgroundColor: tokens.colorNeutralBackground1
+    },
+    row: {
+        paddingLeft: `${DATA_TABLE_ROW_PADDING_LEFT}px`,
+        minHeight: `${DATA_TABLE_ROW_HEIGHT}px`,
+        color: tokens.colorNeutralForeground2,
+        borderBottomWidth: '1px',
+        borderBottomStyle: 'solid',
+        borderBottomColor: tokens.colorNeutralStroke3
+    },
+    cell: {
+        fontSize: `${DATA_TABLE_FONT_SIZE}px`,
+        alignItems: 'center'
     }
 });
 
+type LocalSortState = NonNullable<DataGridProps['sortState']>;
+
 /**
  * Displays a table of data, either for a dataset or the signals in the Vega
- * view.
+ * view. Built on Fluent UI's `DataGrid`, with sorting and pagination owned
+ * locally (external to the grid) so the FULL dataset is sorted before being
+ * paged — matching the previous react-data-table-component behaviour.
  */
 // eslint-disable-next-line max-lines-per-function
 export const DataTableViewer = ({
     columns,
     data,
-    ...props
+    defaultSortFieldId,
+    defaultSortAsc = false,
+    onSort,
+    onChangePage,
+    paginationDefaultPage
+    // `progressPending` is intentionally not consumed: the tabs gate the
+    // loading state upstream (rendering `ProcessingDataMessage`), so the
+    // viewer only mounts with real rows. Kept in the prop contract for parity.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-}: TableProps<any>) => {
+}: DataTableViewerProps<any>) => {
     const { debugTableRowsPerPage } = useDenebState((state) => ({
         debugTableRowsPerPage: state.editorPreferences.dataViewerRowsPerPage
     }));
     const classes = useDataTableStyles();
     logRender('DataTableViewer');
-    // Filter compact prop that RDT passes to column cells but shouldn't reach DOM
-    const shouldForwardProp = (propName: string) => propName !== 'compact';
+
+    // Look up a column definition by its id — used by the sort helper and the
+    // per-cell render path.
+    const columnsById = useMemo(() => {
+        const map = new Map<string, DataTableViewerColumn<unknown>>();
+        columns.forEach((c) => map.set(c.id, c));
+        return map;
+    }, [columns]);
+
     const colOrder = useMemo(() => {
         const ids = columns.map((c) => String(c.id ?? ''));
         const filtered = ids.filter((id) => id !== '');
@@ -61,106 +138,168 @@ export const DataTableViewer = ({
         }
         return filtered;
     }, [columns]);
+
+    // `rowCount` reflects the FULL dataset length (not the visible page),
+    // preserving the exact value the keyboard provider received previously.
     const rowCount = data?.length ?? 0;
+
+    // Fluent column definitions. `renderCell`/`compare` are intentionally
+    // inert: cells are rendered directly in the DataGridRow body below (so we
+    // can pass the row index), and sorting is external (see `sortedRows`).
+    const gridColumns = useMemo<TableColumnDefinition<unknown>[]>(
+        () =>
+            columns.map((column) =>
+                createTableColumn<unknown>({
+                    columnId: column.id,
+                    compare: () => 0,
+                    renderHeaderCell: () => column.name,
+                    renderCell: () => null
+                })
+            ),
+        [columns]
+    );
+
+    // Per-column ideal/min widths from the worker-measured sizes.
+    const sizingOptions = useMemo<
+        NonNullable<DataGridProps['columnSizingOptions']>
+    >(() => {
+        const options: NonNullable<DataGridProps['columnSizingOptions']> = {};
+        columns.forEach((column) => {
+            if (typeof column.width === 'number') {
+                options[column.id] = {
+                    idealWidth: column.width,
+                    minWidth: Math.min(column.width, 48)
+                };
+            }
+        });
+        return options;
+    }, [columns]);
+
+    // Controlled sort state, seeded once from the persisted default. Header
+    // clicks update it (and report up via `onSort`); the actual row ordering
+    // is applied by `sortRows` over the full dataset.
+    const [sortState, setSortState] = useState<LocalSortState>(() =>
+        defaultSortFieldId
+            ? {
+                  sortColumn: defaultSortFieldId,
+                  sortDirection: defaultSortAsc ? 'ascending' : 'descending'
+              }
+            : { sortColumn: undefined, sortDirection: 'ascending' }
+    );
+
+    const handleSortChange: DataGridProps['onSortChange'] = (_e, nextSort) => {
+        if (nextSort.sortColumn === undefined) return;
+        const column = columnsById.get(String(nextSort.sortColumn));
+        // Only sortable columns participate — mirrors rdt, where the signal
+        // "value" column (no `sortable`) ignores header clicks.
+        if (!column?.sortable) return;
+        setSortState(nextSort);
+        onSort?.(
+            String(nextSort.sortColumn),
+            nextSort.sortDirection === 'ascending'
+        );
+    };
+
+    // External sort over the FULL dataset, before pagination. DataGrid's
+    // internal compare is a no-op, so it never re-orders the page.
+    const sortedRows = useMemo(() => {
+        const column =
+            sortState.sortColumn !== undefined
+                ? columnsById.get(String(sortState.sortColumn))
+                : null;
+        return sortRows(data, column, sortState.sortDirection === 'ascending');
+    }, [data, columnsById, sortState.sortColumn, sortState.sortDirection]);
+
+    const perPage = debugTableRowsPerPage as number;
+    const [page, setPage] = useState<number>(paginationDefaultPage ?? 1);
+
+    const pageRows = useMemo(
+        () => getPageSlice(sortedRows, page, perPage),
+        [sortedRows, page, perPage]
+    );
+
+    const handleChangePage = (nextPage: number) => {
+        setPage(nextPage);
+        onChangePage?.(nextPage);
+    };
+
+    // Match rdt's `recalculatePage`: clamp the current page to the new page
+    // count when rows-per-page changes (NOT first-visible-row preservation).
+    const handleChangeRowsPerPage = (
+        newPerPage: number,
+        currentPage: number
+    ) => {
+        const numPages = Math.max(1, Math.ceil(rowCount / newPerPage));
+        const nextPage = Math.min(currentPage, numPages);
+        setPage(nextPage);
+        onChangePage?.(nextPage);
+    };
+
     // Owns the viewer-level scrollable enclosure reference so the inspector
     // popover can scope its scroll-dismissal listener to this viewer only —
-    // scrolls in a sibling viewer no longer dismiss our popover.
+    // scrolls in a sibling viewer no longer dismiss our popover. The listener
+    // is capture-phase, so scrolls from the inner scroll region are caught.
     const enclosureRef = useRef<HTMLDivElement>(null);
+
     return (
         <DataTableInspectorProvider>
             <DataTableKeyboardProvider colOrder={colOrder} rowCount={rowCount}>
                 <DataTableTooltipProvider>
                     <div ref={enclosureRef} className={classes.enclosure}>
-                        <StyleSheetManager
-                            shouldForwardProp={shouldForwardProp}
-                        >
-                            <DataTable
-                                columns={columns}
-                                data={data}
-                                fixedHeader
-                                sortIcon={<ArrowSortDown16Regular />}
-                                defaultSortFieldId={columns[0]?.id}
-                                pagination
-                                paginationComponent={DataTableStatusBar}
-                                paginationPerPage={
-                                    debugTableRowsPerPage as number
-                                }
-                                customStyles={{
-                                    head: {
-                                        style: {
-                                            color: tokens.colorNeutralForeground1,
-                                            fontWeight: 900
-                                        }
-                                    },
-                                    headRow: {
-                                        style: {
-                                            backgroundColor:
-                                                tokens.colorNeutralBackground1,
-                                            borderBottomColor:
-                                                tokens.colorNeutralStroke3,
-                                            borderBottomStyle: 'solid',
-                                            borderBottomWidth: '1px',
-                                            paddingLeft: `${DATA_TABLE_ROW_PADDING_LEFT}px`,
-                                            minHeight: `${DATA_TABLE_ROW_HEIGHT}px`
-                                        },
-                                        denseStyle: {
-                                            minHeight: `${DATA_TABLE_ROW_HEIGHT}px`
-                                        }
-                                    },
-                                    rows: {
-                                        style: {
-                                            backgroundColor:
-                                                tokens.colorNeutralBackground1,
-                                            color: tokens.colorNeutralForeground2,
-                                            paddingLeft: `${DATA_TABLE_ROW_PADDING_LEFT}px`,
-                                            borderBottomColor:
-                                                tokens.colorNeutralStroke3,
-                                            borderBottomStyle: 'solid',
-                                            borderBottomWidth: '1px',
-                                            minHeight: `${DATA_TABLE_ROW_HEIGHT}px`,
-                                            '&:not(:last-of-type)': {
-                                                borderBottomColor:
-                                                    tokens.colorNeutralStroke3,
-                                                borderBottomStyle: 'solid',
-                                                borderBottomWidth: '1px'
-                                            }
-                                        },
-                                        denseStyle: {
-                                            minHeight: `${DATA_TABLE_ROW_HEIGHT}px`
-                                        }
-                                    },
-                                    cells: {
-                                        style: {
-                                            fontSize: `${DATA_TABLE_FONT_SIZE}px`
-                                        }
-                                    },
-                                    table: {
-                                        style: {
-                                            backgroundColor:
-                                                tokens.colorNeutralBackground1,
-                                            boxSizing: 'border-box',
-                                            fontFamily: DATA_TABLE_FONT_FAMILY,
-                                            fontSize: `${DATA_TABLE_FONT_SIZE}px`
-                                        }
-                                    },
-                                    tableWrapper: {
-                                        style: {
-                                            height: '100%',
-                                            backgroundColor:
-                                                tokens.colorNeutralBackground1
-                                        }
-                                    },
-                                    responsiveWrapper: {
-                                        style: {
-                                            flexGrow: 1,
-                                            overflow: 'overlay'
-                                        }
-                                    }
-                                }}
-                                dense
-                                {...props}
-                            />
-                        </StyleSheetManager>
+                        <div className={classes.scroll}>
+                            <DataGrid
+                                className={classes.grid}
+                                items={pageRows}
+                                columns={gridColumns}
+                                sortable
+                                sortState={sortState}
+                                onSortChange={handleSortChange}
+                                resizableColumns
+                                columnSizingOptions={sizingOptions}
+                                focusMode='none'
+                                getRowId={undefined}
+                            >
+                                <DataGridHeader className={classes.header}>
+                                    <DataGridRow className={classes.headerRow}>
+                                        {({ renderHeaderCell }) => (
+                                            <DataGridHeaderCell
+                                                className={classes.headerCell}
+                                            >
+                                                {renderHeaderCell()}
+                                            </DataGridHeaderCell>
+                                        )}
+                                    </DataGridRow>
+                                </DataGridHeader>
+                                <DataGridBody<unknown>>
+                                    {({ item, rowId }) => (
+                                        <DataGridRow<unknown>
+                                            key={rowId}
+                                            className={classes.row}
+                                        >
+                                            {({ columnId }) => (
+                                                <DataGridCell
+                                                    className={classes.cell}
+                                                >
+                                                    {columnsById
+                                                        .get(String(columnId))
+                                                        ?.cell(
+                                                            item,
+                                                            Number(rowId)
+                                                        )}
+                                                </DataGridCell>
+                                            )}
+                                        </DataGridRow>
+                                    )}
+                                </DataGridBody>
+                            </DataGrid>
+                        </div>
+                        <DataTableStatusBar
+                            rowCount={rowCount}
+                            rowsPerPage={perPage}
+                            currentPage={page}
+                            onChangePage={handleChangePage}
+                            onChangeRowsPerPage={handleChangeRowsPerPage}
+                        />
                     </div>
                 </DataTableTooltipProvider>
                 <InspectorPopover scrollContainerRef={enclosureRef} />

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -72,7 +72,8 @@ const useDataTableStyles = makeStyles({
         color: tokens.colorNeutralForeground1,
         fontWeight: tokens.fontWeightBold,
         fontSize: `${DATA_TABLE_FONT_SIZE}px`,
-        backgroundColor: tokens.colorNeutralBackground1
+        backgroundColor: tokens.colorNeutralBackground1,
+        whiteSpace: 'nowrap'
     },
     row: {
         paddingLeft: `${DATA_TABLE_ROW_PADDING_LEFT}px`,
@@ -82,9 +83,14 @@ const useDataTableStyles = makeStyles({
         borderBottomStyle: 'solid',
         borderBottomColor: tokens.colorNeutralStroke3
     },
+    // Single-line cells with clipping, matching rdt's built-in cell chrome
+    // (`overflow: hidden; white-space: nowrap`). Content never wraps — a
+    // column narrower than its content clips instead of growing the row.
     cell: {
         fontSize: `${DATA_TABLE_FONT_SIZE}px`,
-        alignItems: 'center'
+        alignItems: 'center',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden'
     }
 });
 
@@ -254,7 +260,19 @@ export const DataTableViewer = ({
                                 sortState={sortState}
                                 onSortChange={handleSortChange}
                                 resizableColumns
+                                // Honour the worker-measured widths instead of
+                                // compressing columns to fit the container —
+                                // cumulative overflow scrolls horizontally in
+                                // the enclosure, matching the previous rdt
+                                // behaviour.
+                                resizableColumnsOptions={{
+                                    autoFitColumns: false
+                                }}
                                 columnSizingOptions={sizingOptions}
+                                // 24px rows — matches DATA_TABLE_ROW_HEIGHT
+                                // and rdt's `dense` chrome; Fluent's default
+                                // `medium` renders 44px rows.
+                                size='extra-small'
                                 focusMode='none'
                                 // No getRowId: Fluent's default rowId is the
                                 // index within `items` (= pageRows), which is

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -292,13 +292,18 @@ export const DataTableViewer = ({
                                 </DataGridBody>
                             </DataGrid>
                         </div>
-                        <DataTableStatusBar
-                            rowCount={rowCount}
-                            rowsPerPage={perPage}
-                            currentPage={page}
-                            onChangePage={handleChangePage}
-                            onChangeRowsPerPage={handleChangeRowsPerPage}
-                        />
+                        {/* Match rdt: the pagination bar is hidden when there
+                            are zero rows (rdt's `enabledPagination` required
+                            `data.length > 0`). */}
+                        {rowCount > 0 && (
+                            <DataTableStatusBar
+                                rowCount={rowCount}
+                                rowsPerPage={perPage}
+                                currentPage={page}
+                                onChangePage={handleChangePage}
+                                onChangeRowsPerPage={handleChangeRowsPerPage}
+                            />
+                        )}
                     </div>
                 </DataTableTooltipProvider>
                 <InspectorPopover scrollContainerRef={enclosureRef} />

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -96,7 +96,6 @@ type LocalSortState = NonNullable<DataGridProps['sortState']>;
  * locally (external to the grid) so the FULL dataset is sorted before being
  * paged — matching the previous react-data-table-component behaviour.
  */
-// eslint-disable-next-line max-lines-per-function
 export const DataTableViewer = ({
     columns,
     data,

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -19,7 +19,7 @@ import { DataTableTooltipProvider } from './data-table-tooltip-context';
 import { DataTableInspectorProvider } from './inspector-popover-context';
 import { DataTableKeyboardProvider } from './data-table-keyboard-context';
 import { InspectorPopover } from './inspector-popover';
-import { sortRows } from './data-table-sort';
+import { resolveNextSortState, sortRows } from './data-table-sort';
 import { getPageSlice } from './data-table-pagination';
 import type {
     DataTableViewerColumn,
@@ -157,12 +157,19 @@ export const DataTableViewer = ({
     // Fluent column definitions. `renderCell`/`compare` are intentionally
     // inert: cells are rendered directly in the DataGridRow body below (so we
     // can pass the row index), and sorting is external (see `sortedRows`).
+    // CAUTION: Fluent decides header sortability by the DECLARED ARITY of
+    // `compare` (`isColumnSortable` is `column.compare.length > 0`), so the
+    // no-op must take two parameters for sortable columns — an arity-0 no-op
+    // silently disables header clicks. Non-sortable columns get the arity-0
+    // form deliberately, which also suppresses their sort affordance.
     const gridColumns = useMemo<TableColumnDefinition<unknown>[]>(
         () =>
             columns.map((column) =>
                 createTableColumn<unknown>({
                     columnId: column.id,
-                    compare: () => 0,
+                    compare: column.sortable
+                        ? (_a: unknown, _b: unknown) => 0
+                        : () => 0,
                     renderHeaderCell: () => column.name,
                     renderCell: () => null
                 })
@@ -204,10 +211,18 @@ export const DataTableViewer = ({
         // Only sortable columns participate — mirrors rdt, where the signal
         // "value" column (no `sortable`) ignores header clicks.
         if (!column?.sortable) return;
-        setSortState(nextSort);
+        // Tri-state cycle: unsorted → ascending → descending → unsorted.
+        const resolved = resolveNextSortState(sortState, nextSort);
+        setSortState(resolved);
+        if (resolved.sortColumn === undefined) {
+            // Cleared — the tabs' handlers treat a falsy colId as "remove
+            // the persisted sort entry" (rows return to dataset order).
+            onSort?.('', false);
+            return;
+        }
         onSort?.(
-            String(nextSort.sortColumn),
-            nextSort.sortDirection === 'ascending'
+            String(resolved.sortColumn),
+            resolved.sortDirection === 'ascending'
         );
     };
 

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -238,9 +238,17 @@ export const DataTableViewer = ({
     const perPage = debugTableRowsPerPage as number;
     const [page, setPage] = useState<number>(paginationDefaultPage ?? 1);
 
+    // A dataset shrink (or perPage growth) can leave the raw `page` beyond
+    // the last page. Deriving the effective page at render time keeps the
+    // row slice, the status bar's range display, and the nav-button
+    // disabled states mutually consistent — without a corrective effect.
+    // The raw intent self-heals on the next user navigation.
+    const numPages = Math.max(1, Math.ceil(rowCount / perPage));
+    const effectivePage = Math.min(page, numPages);
+
     const pageRows = useMemo(
-        () => getPageSlice(sortedRows, page, perPage),
-        [sortedRows, page, perPage]
+        () => getPageSlice(sortedRows, effectivePage, perPage),
+        [sortedRows, effectivePage, perPage]
     );
 
     const handleChangePage = (nextPage: number) => {
@@ -340,8 +348,7 @@ export const DataTableViewer = ({
                             its pagination cluster at zero rows. */}
                         <DataTableStatusBar
                             rowCount={rowCount}
-                            rowsPerPage={perPage}
-                            currentPage={page}
+                            currentPage={effectivePage}
                             onChangePage={handleChangePage}
                             onChangeRowsPerPage={handleChangeRowsPerPage}
                         />

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -19,7 +19,11 @@ import { DataTableTooltipProvider } from './data-table-tooltip-context';
 import { DataTableInspectorProvider } from './inspector-popover-context';
 import { DataTableKeyboardProvider } from './data-table-keyboard-context';
 import { InspectorPopover } from './inspector-popover';
-import { resolveNextSortState, sortRows } from './data-table-sort';
+import {
+    resolveNextSortState,
+    sortRows,
+    type ViewerSortState
+} from './data-table-sort';
 import { getPageSlice } from './data-table-pagination';
 import type {
     DataTableViewerColumn,
@@ -100,8 +104,6 @@ const useDataTableStyles = makeStyles({
     }
 });
 
-type LocalSortState = NonNullable<DataGridProps['sortState']>;
-
 /**
  * Displays a table of data, either for a dataset or the signals in the Vega
  * view. Built on Fluent UI's `DataGrid`, with sorting and pagination owned
@@ -116,9 +118,6 @@ export const DataTableViewer = ({
     onSort,
     onChangePage,
     paginationDefaultPage
-    // `progressPending` is intentionally not consumed: the tabs gate the
-    // loading state upstream (rendering `ProcessingDataMessage`), so the
-    // viewer only mounts with real rows. Kept in the prop contract for parity.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }: DataTableViewerProps<any>) => {
     const { debugTableRowsPerPage } = useDenebState((state) => ({
@@ -196,7 +195,7 @@ export const DataTableViewer = ({
     // Controlled sort state, seeded once from the persisted default. Header
     // clicks update it (and report up via `onSort`); the actual row ordering
     // is applied by `sortRows` over the full dataset.
-    const [sortState, setSortState] = useState<LocalSortState>(() =>
+    const [sortState, setSortState] = useState<ViewerSortState>(() =>
         defaultSortFieldId
             ? {
                   sortColumn: defaultSortFieldId,

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -256,7 +256,10 @@ export const DataTableViewer = ({
                                 resizableColumns
                                 columnSizingOptions={sizingOptions}
                                 focusMode='none'
-                                getRowId={undefined}
+                                // No getRowId: Fluent's default rowId is the
+                                // index within `items` (= pageRows), which is
+                                // exactly the page-relative index the cell
+                                // renderers expect (rdt parity).
                             >
                                 <DataGridHeader className={classes.header}>
                                     <DataGridRow className={classes.headerRow}>

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -334,18 +334,18 @@ export const DataTableViewer = ({
                                 </DataGridBody>
                             </DataGrid>
                         </div>
-                        {/* Match rdt: the pagination bar is hidden when there
-                            are zero rows (rdt's `enabledPagination` required
-                            `data.length > 0`). */}
-                        {rowCount > 0 && (
-                            <DataTableStatusBar
-                                rowCount={rowCount}
-                                rowsPerPage={perPage}
-                                currentPage={page}
-                                onChangePage={handleChangePage}
-                                onChangeRowsPerPage={handleChangeRowsPerPage}
-                            />
-                        )}
+                        {/* Always mounted: the status bar hosts the dataset
+                            selector, which must stay reachable even for an
+                            empty dataset (e.g. a param populated on hover)
+                            so the user can switch away. The bar itself hides
+                            its pagination cluster at zero rows. */}
+                        <DataTableStatusBar
+                            rowCount={rowCount}
+                            rowsPerPage={perPage}
+                            currentPage={page}
+                            onChangePage={handleChangePage}
+                            onChangeRowsPerPage={handleChangeRowsPerPage}
+                        />
                     </div>
                 </DataTableTooltipProvider>
                 <InspectorPopover scrollContainerRef={enclosureRef} />

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -64,9 +64,15 @@ const useDataTableStyles = makeStyles({
         zIndex: 1,
         backgroundColor: tokens.colorNeutralBackground1
     },
+    // Fluent's `extra-small` size variant drops the built-in row
+    // borderBottom that medium/small carry, so the header/body divider is
+    // restated here (mirrors the old rdt `headRow` customStyles).
     headerRow: {
         paddingLeft: `${DATA_TABLE_ROW_PADDING_LEFT}px`,
-        minHeight: `${DATA_TABLE_ROW_HEIGHT}px`
+        minHeight: `${DATA_TABLE_ROW_HEIGHT}px`,
+        borderBottomWidth: '1px',
+        borderBottomStyle: 'solid',
+        borderBottomColor: tokens.colorNeutralStroke3
     },
     headerCell: {
         color: tokens.colorNeutralForeground1,

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/data-tab.tsx
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/data-tab.tsx
@@ -522,8 +522,7 @@ export const DataTab = ({ datasetName, renderId }: DataTabProps) => {
                             sortEntry,
                             onSort: handleSort,
                             onChangePage: handleChangePage,
-                            page,
-                            progressPending: debouncedProcessing
+                            page
                         })}
                     />
                 </div>

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/data-tab.tsx
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/data-tab.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { TableColumn, TableProps } from 'react-data-table-component';
 import { useDebounce } from '@uidotdev/usehooks';
 import { type View } from 'vega';
 
@@ -17,7 +16,6 @@ import { type VegaDatum } from '@deneb-viz/data-core/value';
 import { type DatasetRaw, type DatasetState } from './types';
 import {
     datasetViewerWorker,
-    IWorkerDatasetViewerDataTableRow,
     type IWorkerDatasetViewerMessage
 } from '../../workers';
 import {
@@ -414,22 +412,13 @@ export const DataTab = ({ datasetName, renderId }: DataTabProps) => {
      * sort record (`state.debug.dataPivotSort.data`). The Source tab's
      * sort is untouched.
      */
-    const handleSort: TableProps<
-        IWorkerDatasetViewerDataTableRow[]
-    >['onSort'] = (column, sortDirection) => {
-        logDebug('DataTab: setting sort columns...', {
-            column,
-            sortDirection
-        });
-        const colId = column?.id ?? null;
+    const handleSort = (colId: string, asc: boolean) => {
+        logDebug('DataTab: setting sort columns...', { colId, asc });
         if (!colId) {
             setDataTabSort(null);
             return;
         }
-        setDataTabSort({
-            colId: String(colId),
-            asc: sortDirection === 'asc'
-        });
+        setDataTabSort({ colId, asc });
     };
 
     const handleChangePage = useCallback(
@@ -480,10 +469,7 @@ export const DataTab = ({ datasetName, renderId }: DataTabProps) => {
             <div className={classes.wrapper}>
                 <div className={classes.details}>
                     <DataTableViewer
-                        columns={
-                            (datasetState.columns ??
-                                []) as TableColumn<IWorkerDatasetViewerDataTableRow>[]
-                        }
+                        columns={datasetState.columns ?? []}
                         data={datasetState.values ?? []}
                         {...getSharedDataTableViewerProps({
                             sortEntry,

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/data-tab.tsx
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/data-tab.tsx
@@ -272,6 +272,20 @@ export const DataTab = ({ datasetName, renderId }: DataTabProps) => {
     const lastListenerHashRef = useRef<string | null>(null);
 
     /**
+     * Pending deferred verification of an empty listener payload (see
+     * `dataListener`). Held so a superseding non-empty event, a listener
+     * cycle, or unmount can cancel it.
+     */
+    const emptyVerifyTimerRef = useRef<number | null>(null);
+
+    const cancelPendingEmptyVerify = useCallback(() => {
+        if (emptyVerifyTimerRef.current !== null) {
+            window.clearTimeout(emptyVerifyTimerRef.current);
+            emptyVerifyTimerRef.current = null;
+        }
+    }, []);
+
+    /**
      * Handler for dataset listener events. Vega exposes the `value` parameter
      * as `object` in its public typings, so we follow suit rather than `any`.
      */
@@ -287,17 +301,47 @@ export const DataTab = ({ datasetName, renderId }: DataTabProps) => {
             return;
         }
 
-        // Skip processing if we have data but the listener returns an empty array - likely an incremental update in progress
+        // An empty payload while we hold data is ambiguous: it can be a
+        // transient artifact of an in-flight incremental update, OR a
+        // legitimate clear (e.g. a param-driven dataset emptying on
+        // hover-out). Defer one tick and re-read the view: still empty
+        // means a real clear and the table empties; repopulated means it
+        // was transient and the non-empty listener event supersedes this.
         if (
             Array.isArray(newDataset) &&
             newDataset.length === 0 &&
             lastListenerHashRef.current !== null
         ) {
             logDebug(
-                `DataTab: dataset ${name} listener received empty array while we have existing data, skipping (likely incremental update in progress)`
+                `DataTab: dataset ${name} listener received empty array while we have existing data; deferring verification (incremental update vs. genuine clear)`
             );
+            cancelPendingEmptyVerify();
+            emptyVerifyTimerRef.current = window.setTimeout(() => {
+                emptyVerifyTimerRef.current = null;
+                const latest = getPrunedObject(
+                    (VegaViewServices.getDataByName(name) as object) ?? []
+                );
+                if (Array.isArray(latest) && latest.length === 0) {
+                    const emptyHash = getDataHash(latest);
+                    logDebug(
+                        `DataTab: dataset ${name} verified empty — applying clear`
+                    );
+                    lastListenerHashRef.current = emptyHash;
+                    setDatasetRawPending(() => ({
+                        hashValue: emptyHash,
+                        values: latest
+                    }));
+                } else {
+                    logDebug(
+                        `DataTab: dataset ${name} repopulated — transient empty ignored`
+                    );
+                }
+            }, 0);
             return;
         }
+
+        // A non-empty event supersedes any pending empty verification.
+        cancelPendingEmptyVerify();
 
         logDebug(`DataTab: dataset ${name} has changed`, {
             previousHash: lastListenerHashRef.current,
@@ -404,6 +448,9 @@ export const DataTab = ({ datasetName, renderId }: DataTabProps) => {
         }
         return () => {
             removeListener(viewAtEntry);
+            // A pending empty-verify belongs to the outgoing view/dataset;
+            // never let it fire against the successor.
+            cancelPendingEmptyVerify();
         };
     }, [datasetName, renderId]);
 

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/data-table-viewer-props.ts
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/data-table-viewer-props.ts
@@ -1,4 +1,4 @@
-import { type TableProps } from 'react-data-table-component';
+import { type DataTableViewerProps } from '../data-table/data-table-viewer-types';
 
 /**
  * The `DataTableViewer` prop-wiring shared by the Data and Source tabs: the sort
@@ -11,12 +11,12 @@ import { type TableProps } from 'react-data-table-component';
  */
 export const getSharedDataTableViewerProps = <T>(args: {
     sortEntry: { colId: string; asc: boolean } | null;
-    onSort: TableProps<T>['onSort'];
-    onChangePage: TableProps<T>['onChangePage'];
-    page: TableProps<T>['paginationDefaultPage'];
+    onSort: DataTableViewerProps<T>['onSort'];
+    onChangePage: DataTableViewerProps<T>['onChangePage'];
+    page: DataTableViewerProps<T>['paginationDefaultPage'];
     progressPending: boolean;
 }): Pick<
-    TableProps<T>,
+    DataTableViewerProps<T>,
     | 'defaultSortFieldId'
     | 'defaultSortAsc'
     | 'onSort'

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/data-table-viewer-props.ts
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/data-table-viewer-props.ts
@@ -2,7 +2,7 @@ import { type DataTableViewerProps } from '../data-table/data-table-viewer-types
 
 /**
  * The `DataTableViewer` prop-wiring shared by the Data and Source tabs: the sort
- * defaults, the sort/page handlers, the current page, and processing state. Only
+ * defaults, the sort/page handlers, and the current page. Only
  * `columns` and `data` differ between the two tabs, so keeping the rest in one
  * builder stops the two prop blocks from drifting apart.
  *
@@ -14,7 +14,6 @@ export const getSharedDataTableViewerProps = <T>(args: {
     onSort: DataTableViewerProps<T>['onSort'];
     onChangePage: DataTableViewerProps<T>['onChangePage'];
     page: DataTableViewerProps<T>['paginationDefaultPage'];
-    progressPending: boolean;
 }): Pick<
     DataTableViewerProps<T>,
     | 'defaultSortFieldId'
@@ -22,12 +21,10 @@ export const getSharedDataTableViewerProps = <T>(args: {
     | 'onSort'
     | 'onChangePage'
     | 'paginationDefaultPage'
-    | 'progressPending'
 > => ({
     defaultSortFieldId: args.sortEntry?.colId ?? null,
     defaultSortAsc: args.sortEntry?.asc ?? false,
     onSort: args.onSort,
     onChangePage: args.onChangePage,
-    paginationDefaultPage: args.page,
-    progressPending: args.progressPending
+    paginationDefaultPage: args.page
 });

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/dataset-viewer-worker-helpers.tsx
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/dataset-viewer-worker-helpers.tsx
@@ -1,4 +1,3 @@
-import type { TableColumn } from 'react-data-table-component';
 import { textMeasurementService } from 'powerbi-visuals-utils-formattingutils';
 
 import { getDenebState } from '../../../../state';
@@ -11,6 +10,7 @@ import type {
 } from '../../workers';
 import { DataTableCell } from '../data-table/data-table-cell';
 import { DataTableHeaderCell } from '../data-table/data-table-header-cell';
+import type { DataTableViewerColumn } from '../data-table/data-table-viewer-types';
 
 /**
  * Shared worker + column helpers used by both the Source and Data tabs.
@@ -21,15 +21,17 @@ import { DataTableHeaderCell } from '../data-table/data-table-header-cell';
  */
 
 /**
- * Build the react-data-table column definitions for a processed set of
+ * Build the `DataTableViewer` column definitions for a processed set of
  * dataset rows. Widths are monospace-derived from the worker's per-column
  * `maxWidths`; header labels pull documentation tooltips from the field
- * registry so support fields render their descriptions.
+ * registry so support fields render their descriptions. The `selector`
+ * returns the raw value so sorting matches the previous rawValue-based
+ * comparator (the visible text is produced by the `cell` renderer).
  */
 export const buildDatasetViewerColumns = (
     rows: IWorkerDatasetViewerDataTableRow[],
     maxLengths: IWorkerDatasetViewerMaxDisplayWidths
-): TableColumn<IWorkerDatasetViewerDataTableRow>[] => {
+): DataTableViewerColumn<IWorkerDatasetViewerDataTableRow>[] => {
     return Object.keys(rows?.[0] ?? {}).map((c) => ({
         id: c,
         name: (
@@ -49,24 +51,15 @@ export const buildDatasetViewerColumns = (
             />
         ),
         sortable: true,
-        selector: (row) => row[c]?.displayValue,
-        reorder: true,
-        compact: true,
-        width: `${calculateDatasetViewerMaxWidth(c, maxLengths[c])}px`,
-        sortFunction: (rowA, rowB) => {
-            const a = rowA[c]?.rawValue as string | number | Date;
-            const b = rowB[c]?.rawValue as string | number | Date;
-            if (a < b) return -1;
-            if (a > b) return 1;
-            return 0;
-        }
+        selector: (row) => row[c]?.rawValue,
+        width: calculateDatasetViewerMaxWidth(c, maxLengths[c])
     }));
 };
 
 /**
- * react-data-table has no dynamic sizing, so we pre-compute the max width
- * for each column from the worker-measured value widths plus the header
- * label width.
+ * We pre-compute the max width for each column from the worker-measured
+ * value widths plus the header label width, and feed it to the DataGrid's
+ * `columnSizingOptions` as the column's ideal width.
  */
 export const calculateDatasetViewerMaxWidth = (
     fieldName: string,

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/source-tab.tsx
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/source-tab.tsx
@@ -68,7 +68,9 @@ export const SourceTab = () => {
     const hashValue = useMemo(() => getHashValue(prunedValues), [prunedValues]);
 
     const [tableState, setTableState] = useState<{
-        columns: DataTableViewerColumn<IWorkerDatasetViewerDataTableRow>[] | null;
+        columns:
+            | DataTableViewerColumn<IWorkerDatasetViewerDataTableRow>[]
+            | null;
         jobQueue: string[];
         processing: boolean;
         rows: IWorkerDatasetViewerDataTableRow[] | null;
@@ -199,8 +201,7 @@ export const SourceTab = () => {
                             sortEntry,
                             onSort: handleSort,
                             onChangePage: handleChangePage,
-                            page,
-                            progressPending: debouncedProcessing
+                            page
                         })}
                     />
                 </div>

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/source-tab.tsx
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/source-tab.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import type { SortOrder, TableColumn } from 'react-data-table-component';
 import { useDebounce } from '@uidotdev/usehooks';
 
 import { getHashValue, getNewUuid } from '@deneb-viz/utils/crypto';
@@ -18,6 +17,7 @@ import {
     type IWorkerDatasetViewerMessage
 } from '../../workers';
 import { DataTableViewer } from '../data-table/data-table';
+import { type DataTableViewerColumn } from '../data-table/data-table-viewer-types';
 import { ProcessingDataMessage } from '../data-table/processing-data-message';
 import { NoDataMessage } from '../no-data-message';
 import { useDebugWrapperStyles } from '../styles';
@@ -68,7 +68,7 @@ export const SourceTab = () => {
     const hashValue = useMemo(() => getHashValue(prunedValues), [prunedValues]);
 
     const [tableState, setTableState] = useState<{
-        columns: TableColumn<IWorkerDatasetViewerDataTableRow>[] | null;
+        columns: DataTableViewerColumn<IWorkerDatasetViewerDataTableRow>[] | null;
         jobQueue: string[];
         processing: boolean;
         rows: IWorkerDatasetViewerDataTableRow[] | null;
@@ -145,19 +145,12 @@ export const SourceTab = () => {
     }, [worker]);
 
     const handleSort = useCallback(
-        (
-            column: TableColumn<IWorkerDatasetViewerDataTableRow>,
-            sortDirection: SortOrder
-        ) => {
-            const colId = column?.id ?? null;
+        (colId: string, asc: boolean) => {
             if (!colId) {
                 setSourceTabSort(null);
                 return;
             }
-            setSourceTabSort({
-                colId: String(colId),
-                asc: sortDirection === 'asc'
-            });
+            setSourceTabSort({ colId, asc });
         },
         [setSourceTabSort]
     );

--- a/packages/app-core/src/features/debug-area/components/dataset-viewer/types.ts
+++ b/packages/app-core/src/features/debug-area/components/dataset-viewer/types.ts
@@ -1,6 +1,6 @@
-import { type TableColumn } from 'react-data-table-component';
 import { type IWorkerDatasetViewerDataTableRow } from '../../workers';
 import { type VegaDatum } from '@deneb-viz/data-core/value';
+import { type DataTableViewerColumn } from '../data-table/data-table-viewer-types';
 
 export type DatasetRaw = {
     hashValue: string | null;
@@ -8,7 +8,7 @@ export type DatasetRaw = {
 };
 
 export type DatasetState = {
-    columns: TableColumn<IWorkerDatasetViewerDataTableRow>[] | null;
+    columns: DataTableViewerColumn<IWorkerDatasetViewerDataTableRow>[] | null;
     jobQueue: string[];
     processing: boolean;
     values: IWorkerDatasetViewerDataTableRow[] | null;

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/signal-viewer.tsx
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/signal-viewer.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
-import { TableColumn } from 'react-data-table-component';
 
 import { logRender } from '@deneb-viz/utils/logging';
 import { VegaViewServices } from '@deneb-viz/vega-runtime/view';
 import { DataTableViewer } from '../data-table/data-table';
+import { type DataTableViewerColumn } from '../data-table/data-table-viewer-types';
 import { NoDataMessage } from '../no-data-message';
 import { DataTableCell } from '../data-table/data-table-cell';
 import { SignalValue } from './signal-value';
@@ -76,7 +76,7 @@ const getSignalTableValues = () => {
  */
 const getTableColumns = (
     renderId: string
-): TableColumn<SignalTableDataRow>[] => {
+): DataTableViewerColumn<SignalTableDataRow>[] => {
     const { translate } = getDenebState().i18n;
     return [
         {
@@ -84,7 +84,10 @@ const getTableColumns = (
             id: 'key',
             selector: (row) => row.key,
             sortable: true,
-            grow: 2,
+            // Ideal widths in a ~2:5 ratio preserve the previous `grow`
+            // proportions; the DataGrid auto-fits columns to the container,
+            // so these act as relative weights rather than fixed sizes.
+            width: SIGNAL_KEY_COLUMN_WIDTH,
             cell: (row) => (
                 <DataTableCell
                     displayValue={row.key}
@@ -97,7 +100,7 @@ const getTableColumns = (
         {
             name: translate('Pivot_Signals_ValueColumn'),
             id: 'value',
-            grow: 5,
+            width: SIGNAL_VALUE_COLUMN_WIDTH,
             selector: (row) => row.key, // Use key for sorting since value is fetched dynamically
             cell: (row, rowIndex) => (
                 <SignalValue
@@ -109,3 +112,7 @@ const getTableColumns = (
         }
     ];
 };
+
+/** Relative column weights approximating the former `grow: 2` / `grow: 5`. */
+const SIGNAL_KEY_COLUMN_WIDTH = 200;
+const SIGNAL_VALUE_COLUMN_WIDTH = 500;

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/signal-viewer.tsx
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/signal-viewer.tsx
@@ -84,9 +84,9 @@ const getTableColumns = (
             id: 'key',
             selector: (row) => row.key,
             sortable: true,
-            // Ideal widths in a ~2:5 ratio preserve the previous `grow`
-            // proportions; the DataGrid auto-fits columns to the container,
-            // so these act as relative weights rather than fixed sizes.
+            // Fixed ideal widths in a ~2:5 ratio replace the previous
+            // `grow` weights (auto-fit is disabled grid-wide, so these are
+            // actual pixel sizes, user-resizable).
             width: SIGNAL_KEY_COLUMN_WIDTH,
             cell: (row) => (
                 <DataTableCell
@@ -113,6 +113,6 @@ const getTableColumns = (
     ];
 };
 
-/** Relative column weights approximating the former `grow: 2` / `grow: 5`. */
+/** Fixed pixel widths replacing the former `grow: 2` / `grow: 5` weights. */
 const SIGNAL_KEY_COLUMN_WIDTH = 200;
 const SIGNAL_VALUE_COLUMN_WIDTH = 500;

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -3,6 +3,28 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
     test: {
         environment: 'node',
+        deps: {
+            optimizer: {
+                ssr: {
+                    enabled: true,
+                    // The powerbi-visuals-utils packages ship an ESM entry
+                    // (`main`/`module`: lib/index.js, no `exports` map, no
+                    // `type: module`) whose internal imports are
+                    // extensionless. When vite-node externalizes them
+                    // (observed on Windows; Linux CI inlines them), Node's
+                    // native ESM resolution fails with "Cannot find module
+                    // .../extensions/arrayExtensions". Pre-bundling them via
+                    // esbuild resolves the extensionless imports at bundle
+                    // time. `server.deps.inline` does NOT fix this — the
+                    // import escapes vite's module graph before matching.
+                    include: [
+                        'powerbi-visuals-utils-formattingutils',
+                        'powerbi-visuals-utils-typeutils',
+                        'powerbi-visuals-utils-dataviewutils'
+                    ]
+                }
+            }
+        },
         benchmark: {
             include: ['src/**/__bench__/**/*.bench.ts'],
             reporters: ['default'],


### PR DESCRIPTION
## Summary

Rebuilds the debug-pane `DataTableViewer` on Fluent UI v9 `DataGrid` (already installed — zero new dependencies) and **removes `react-data-table-component` and `styled-components` entirely**. Follows the closure of #719: this is the alternative that keeps the bundle moving in the right direction while staying inside the design system already proven in the Power BI sandbox.

Plan: `docs/plans/2026-07-17-003-fluent-datagrid-spike.md` (local). All parity decisions were verified against the actual rdt 7.7.0 source during review.

### Architecture

- **Local prop/column contract** (`data-table-viewer-types.ts`) — the viewers no longer depend on any table library's types; only the 8 props actually used are modelled.
- **External full-set sort** (`data-table-sort.ts`, unit-tested): the grid's internal compare is a deliberate no-op (it only ever sees the current page); sorting runs over the whole dataset before pagination, matching rdt. Relies on `Array.prototype.sort`'s spec-guaranteed stability.
- **Local pagination** (`data-table-pagination.ts`, unit-tested) feeding the existing `DataTableStatusBar` (now owning its own 5-field props contract). Rows-per-page change clamps the page number exactly as rdt's `recalculatePage` did.
- **Measured column widths honoured**: worker-computed pixel widths flow into `columnSizingOptions` with `autoFitColumns: false`, so cumulative overflow scrolls horizontally like rdt (columns are additionally user-resizable — new capability). `size='extra-small'` matches the previous 24px dense rows.
- **Custom keyboard layer, inspector popover, and tooltip contexts untouched** (`focusMode="none"`); ARIA-grid consolidation is a deliberate follow-up, not part of this change.

### Behavioral improvements over rdt (deliberate)

- **Tri-state sorting**: headers cycle unsorted → ascending → descending → unsorted; default is unsorted (dataset order). rdt could never leave the sorted state.
- **Dataset selector stays reachable on empty datasets** (e.g. a param populated on hover): the status bar always mounts and hides only its pagination cluster at zero rows. rdt hid the whole bar, selector included.
- **Dataset clears now empty the table** — fixes a pre-existing bug (#637-era): the data listener skipped every empty payload while holding data ("likely an incremental update"), so a genuine clear left stale rows on screen. Empties are now verified on the next tick against the view; transients are still ignored.
- Non-sortable columns (signal value) no longer render a sort affordance.

### Notable implementation landmines (documented in-code)

- Fluent decides header sortability by the **declared arity** of a column's `compare` function (`compare.length > 0`) — the inert no-op must take two parameters for sortable columns.
- Fluent's `extra-small` size variant drops the built-in row `borderBottom` that medium/small carry — dividers are restated in the Griffel classes.
- `resizableColumns` auto-fits (compresses) columns to the container by default — disabled to honour measured widths.

### Also included

- **Windows-local vitest fix** (cherry-picked; supersedes branch `fix/vitest-powerbi-utils-optimizer`, which can be deleted): vite-node externalizes the `powerbi-visuals-utils-*` packages on Windows (ESM entries with extensionless internal imports, no exports map), so Node's native ESM resolution failed in schema-service tests — Linux CI inlines them and never sees it, and turbo's cached test task masked it locally. `deps.optimizer.ssr` esbuild pre-bundling resolves the extensionless imports at bundle time. Verified in a clean-room clone of `next` (12/12).

### Known deltas (accepted during review)

- rdt's column drag-reorder (`reorder: true`) has no DataGrid equivalent and is dropped.
- Signal viewer's `grow: 2/5` flex weights became fixed 200/500px ideal widths (user-resizable).
- A truly empty grid shows no "no records" text (rdt's hardcoded English default is gone; tab-level empty states cover the standard paths).
- Header Enter-to-sort is not keyboard-reachable under `focusMode="none"` (mouse only) — to be addressed with the ARIA-grid follow-up.

## Measurements

- **Bundle (gzip): ~1,787 KB vs ~1,997 KB baseline** (−210 KB; re-measure via `npm run webpack:analyze` if desired). Lockfile delta is removals only: rdt + styled-components + 6 orphaned transitives; zero packages added.
- app-core: 600 tests green (60 files); debug-area 240; root visual suite green; tsc clean; ci:local green.

## Testing

- TDD'd pure helpers (sort: 15 incl. tri-state cycle, nulls/NaN/date/stability; pagination: 9 incl. clamps).
- Spec review verified parity claims against the rdt 7.7.0 tarball (page-clamp semantics, page-relative row indexes, zero-row status bar behaviour).
- Maintainer smoke-tested in Power BI: row chrome, widths/overflow, sorting incl. tri-state, pagination, dataset switching, empty-dataset + clear flows, light theme. (Dark-theme pass worth a final check before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
