### PR TITLE
docs: compound learnings from the data-table replacement round

### DIFF
--- a/docs/solutions/test-failures/vitest-windows-externalizes-powerbi-utils-esm-2026-07-20.md
+++ b/docs/solutions/test-failures/vitest-windows-externalizes-powerbi-utils-esm-2026-07-20.md
@@ -1,0 +1,102 @@
+---
+title: 'vitest on Windows externalizes powerbi-visuals-utils packages, breaking extensionless ESM imports (masked by turbo cache)'
+date: 2026-07-20
+category: test-failures
+module: app-core
+problem_type: test_failure
+component: testing_framework
+severity: high
+symptoms:
+    - 'Error: Cannot find module ...\powerbi-visuals-utils-typeutils\lib\extensions\arrayExtensions imported from ...\lib\index.js'
+    - 'Suite fails at collection ("no tests") on Windows while Linux CI is green on the identical commit'
+    - 'Local ci:local passes on some runs and fails on others with no code change (turbo test-task cache hits vs misses)'
+root_cause: config_error
+resolution_type: config_change
+related_components:
+    - vega-runtime
+    - powerbi-compat
+tags:
+    - vitest
+    - vite-node
+    - esm
+    - externalization
+    - powerbi-visuals-utils
+    - turbo-cache
+    - windows
+---
+
+# vitest externalizes powerbi-visuals-utils on Windows, breaking extensionless ESM
+
+## Problem
+
+`schema-service.test.ts` (app-core) failed at collection on Windows with an ESM resolution
+error inside `powerbi-visuals-utils-typeutils`, while Linux CI passed the identical commit.
+The failure predated the branch under test and had been invisible for months.
+
+## Symptoms
+
+`Cannot find module '...\powerbi-visuals-utils-typeutils\lib\extensions\arrayExtensions'
+imported from '...\lib\index.js'` — the package's own internal, extensionless relative
+import failing under native Node ESM resolution rules.
+
+## What Didn't Work
+
+- **Blaming the branch under test**: a clean-room clone of `next` + fresh `npm ci` + package
+  build reproduced the failure — it was pre-existing. (Caution from the same investigation:
+  a clean-room probe is only valid after `npm run build` — without built workspace `dist/`
+  folders the test fails earlier with a *different* module-resolution error that is easy to
+  misread as the same one.)
+- **Blaming Node 24 vs CI's Node 22**: failed identically under both (verified via
+  `npx -p node@22 -c "node .../vitest.mjs run ..."`).
+- **`server.deps.inline`** (including `inline: true`): no effect. The import escapes vite's
+  module graph before the inline list is consulted.
+- **Dependency-tree theories** (styled-components removal changing hoisting): reinstalling
+  the removed package changed nothing.
+
+## Solution
+
+`deps.optimizer.ssr` in the package's vitest config — esbuild pre-bundles the packages,
+resolving the extensionless imports at bundle time:
+
+```ts
+// packages/app-core/vitest.config.ts
+test: {
+    deps: {
+        optimizer: {
+            ssr: {
+                enabled: true,
+                include: [
+                    'powerbi-visuals-utils-formattingutils',
+                    'powerbi-visuals-utils-typeutils',
+                    'powerbi-visuals-utils-dataviewutils'
+                ]
+            }
+        }
+    }
+}
+```
+
+Shipped in PR #723 (`a12120ee`); verified 12/12 in the clean-room clone.
+
+## Why This Works
+
+The `powerbi-visuals-utils-*` packages ship `main`/`module` pointing at ESM-syntax
+`lib/index.js` with **extensionless** internal imports, no `exports` map, and no
+`type: module` — a shape that only works when a bundler transforms it. On Windows,
+vite-node externalizes these packages (Linux inlines them), handing them to Node's native
+ESM loader, where extensionless relative imports are illegal. esbuild pre-bundling
+(`deps.optimizer.ssr`) rewrites the whole package into one resolved bundle before vite-node
+ever externalizes anything — which is why it works when `server.deps.inline` cannot.
+
+## Prevention
+
+- **Turbo's cached `test` task masks environment-dependent failures**: `npm run test` is
+  `turbo run test` with caching, so a broken test can stay green locally for months until a
+  source change busts the cache. When a test failure "appears from nowhere", suspect a cache
+  miss exposing an old problem — bisect the environment, not just the diff.
+- Diagnose externalization failures empirically with a clean-room clone
+  (`git clone --local`, `npm ci`, `npm run build`, run the one failing test) before
+  theorizing; three plausible theories (branch, Node version, hoisting) all died on
+  clean-room evidence here.
+- If another package starts consuming `powerbi-visuals-utils-*` directly in its tests, it
+  needs the same optimizer block in its own vitest config.

--- a/docs/solutions/tooling-decisions/debug-table-fluent-datagrid-over-rdt-v8-2026-07-20.md
+++ b/docs/solutions/tooling-decisions/debug-table-fluent-datagrid-over-rdt-v8-2026-07-20.md
@@ -1,0 +1,92 @@
+---
+title: 'Debug-pane data table: Fluent DataGrid over react-data-table-component v8 (decision record)'
+date: 2026-07-20
+category: tooling-decisions
+module: app-core
+problem_type: tooling_decision
+component: tooling
+severity: medium
+applies_when:
+    - 'Choosing or replacing a table/grid library for editor-side (non-certified-render-path) UI'
+    - 'Evaluating any dependency upgrade whose payoff depends on bundle size near the ~2MB certified ceiling'
+    - 'A dependency reads browser storage (localStorage/sessionStorage) anywhere in its mount path'
+related_components:
+    - debug-area
+    - data-table
+tags:
+    - react-data-table-component
+    - fluent-ui
+    - datagrid
+    - bundle-size
+    - sandbox
+    - dependency-selection
+---
+
+# Debug-pane data table: Fluent DataGrid over rdt v8
+
+## Context
+
+The debug-pane table ran on `react-data-table-component` (rdt) v7.7.0 + styled-components.
+An upgrade to rdt v8 (PR #719) was attempted for its new `cellNavigation` ARIA grid, then
+abandoned; a rebuild on Fluent UI v9 `DataGrid` (PR #723) replaced it instead. This records
+why, and the criteria for ever revisiting rdt.
+
+## Guidance
+
+**Why rdt v8 was abandoned** (full record in the #719 close comment):
+
+1. **Bundle grew** 1,997 → 2,011 KB gz against the ~2MB certified ceiling — v8 ships
+   filtering/pinning/resize/inline-edit/context-menu/localization the debug pane never uses,
+   outweighing the styled-components removal it enabled.
+2. **Sandbox crash**: v8's `useColorMode` reads `localStorage.getItem('theme')` in a
+   `useState` initializer with only an SSR guard. Power BI visuals run in a sandboxed iframe
+   without `allow-same-origin`, where ANY `localStorage` access throws `SecurityError` — the
+   table crashed into the editor error boundary on mount. (Workaround existed: probe the
+   accessor and shadow it with an inert stub via `Object.defineProperty` — permitted even in
+   sandboxed documents — but it is a shim to carry forever.)
+3. **Layout regressions**: v8's DOM/CSS restructure broke the status-bar flex pinning and
+   introduced a persistent horizontal scrollbar.
+4. The headline `cellNavigation` benefit was blocked upstream anyway: no cell-activation
+   callback (Enter hardwired to inline-edit), no `aria-rowcount`, no PageUp/PageDown.
+
+**Why Fluent DataGrid won**: already installed (zero new dependencies — the "already-paid-for
+dependency" rung), natively themed (the entire token-translation `customStyles` block
+disappeared), proven inside the PBI sandbox by the rest of the app, and the old equal-width
+objection is obsolete — `columnSizingOptions` takes declarative per-column pixel widths.
+Pagination isn't built in, but Deneb always owned the pagination UI; only a ~10-line slice
+was needed. Measured outcome: bundle ~1,787 KB gz (−210 KB vs baseline), rdt AND
+styled-components removed.
+
+**Costs accepted**: column drag-reorder dropped (no DataGrid equivalent); signal-viewer
+`grow` weights became fixed pixel widths; no built-in "no records" empty-grid text;
+header Enter-to-sort deferred to the ARIA-grid follow-up.
+
+## Why This Matters
+
+Two generalizable lessons:
+
+- **Smoke-test dependency upgrades against the real host early.** Three of the four
+  abandonment reasons (sandbox crash, layout, bundle) were only visible in the Power BI
+  harness, not in unit tests — and the bundle prediction ("removing styled-components will
+  shrink it") was wrong until measured.
+- **A dependency you already ship beats a better-featured one you don't**, especially under
+  a hard bundle ceiling: the marginal cost of Fluent DataGrid was near zero because it
+  shares primitives already in the bundle.
+
+## When to Apply
+
+- Revisit rdt only if ALL hold: upstream guards the `useColorMode` storage read;
+  `cellNavigation` gains a cell-activation callback; the bundle delta re-measures
+  acceptably. (Branch `chore/data-table-v8` was retained as a head start.)
+- Treat any dependency that touches `localStorage`/`sessionStorage` during mount as
+  sandbox-hostile until proven otherwise — grep the dist for `localStorage` before adopting.
+
+## Examples
+
+The one-line sandbox repro heuristic used in #719 triage:
+
+```
+grep -c "localStorage" node_modules/<candidate>/dist/*.js
+```
+
+Any hit in a mount/initializer path is a crash in the PBI sandbox unless guarded.

--- a/docs/solutions/ui-bugs/fluent-datagrid-migration-landmines-2026-07-20.md
+++ b/docs/solutions/ui-bugs/fluent-datagrid-migration-landmines-2026-07-20.md
@@ -1,0 +1,98 @@
+---
+title: 'Fluent UI v9 DataGrid migration landmines: arity-sniffed sortability, size-variant border drop, auto-fit compression'
+date: 2026-07-20
+category: ui-bugs
+module: app-core
+problem_type: ui_bug
+component: tooling
+severity: high
+symptoms:
+    - 'Column header clicks silently do nothing despite grid-level `sortable` and controlled `sortState`'
+    - 'No divider line between the header row and the first body row'
+    - 'Rows render 44px tall despite `minHeight` overrides targeting 24px'
+    - 'Columns compress/wrap to fit the container instead of honouring configured widths and overflowing horizontally'
+root_cause: wrong_api
+resolution_type: code_fix
+related_components:
+    - debug-area
+    - data-table
+tags:
+    - fluent-ui
+    - datagrid
+    - sorting
+    - column-sizing
+    - griffel
+    - react
+---
+
+# Fluent UI v9 DataGrid migration landmines
+
+## Problem
+
+Rebuilding the debug-pane `DataTableViewer` on Fluent UI v9 `DataGrid` (PR #723) hit four
+non-obvious library behaviors that each produced a silent visual or functional regression.
+All were diagnosed by reading the installed library source under
+`node_modules/@fluentui/react-table/lib/` — none are documented prominently upstream.
+
+## Symptoms
+
+- Header clicks never fired `onSortChange`, with no error or warning.
+- The header/body divider vanished while body-row dividers (explicitly styled) survived.
+- Rows stayed at 44px despite Griffel `minHeight: 24px` overrides.
+- Columns squeezed below their configured widths, wrapping header/cell text, instead of
+  overflowing with a horizontal scrollbar.
+
+## What Didn't Work
+
+- **Sorting:** grid-level `sortable`, controlled `sortState`, and per-column definitions were
+  all correct; the header still rendered inert. Nothing in the props surface hinted why.
+- **Row height:** `minHeight` on row/cell classes can only raise, never lower, the size
+  variant's own height.
+- **Widths:** `columnSizingOptions` `idealWidth`/`minWidth` were set correctly but appeared
+  to be ignored under space pressure.
+
+## Solution
+
+1. **Sortability is decided by the declared arity of `compare`.**
+   `isColumnSortable(column)` is literally `column.compare.length > 0`. An inert
+   `compare: () => 0` (arity 0) marks the column unsortable and header clicks are dropped.
+   When sorting is handled externally (the grid only ever receives one page of rows, so its
+   internal compare must not be used), the no-op must still declare two parameters:
+
+   ```ts
+   compare: column.sortable
+       ? (_a: unknown, _b: unknown) => 0 // arity 2 → header sortable
+       : () => 0 // arity 0 → suppresses the sort affordance entirely
+   ```
+
+2. **The `extra-small` size variant drops the built-in row border.** `medium` and `small`
+   `TableRow` variants carry `borderBottom`; `extra-small` sets only `fontSize`. Any divider
+   styling must be restated on both body rows AND the header row.
+
+3. **Row height comes from the size variant, not your CSS.** `TableCell` styles pin
+   `medium: 44px / small: 34px / extra-small: 24px`. Pass `size='extra-small'` on the
+   DataGrid (it flows into Table context via `...props`) instead of fighting it with CSS.
+
+4. **`resizableColumns` auto-fits (compresses) columns by default.**
+   `resizableColumnsOptions.autoFitColumns` defaults to `true`, shrinking columns toward
+   `minWidth` to fit the container. To honour pre-measured pixel widths with horizontal
+   overflow (classic data-table behavior): `resizableColumnsOptions={{ autoFitColumns: false }}`.
+
+## Why This Works
+
+Fluent's DataGrid conflates "has a usable comparator" with "is sortable" via function arity
+— defensible for its internal-sorting design, hostile to external sorting. The size variants
+are applied at the cell level through Table context, so component-level CSS loses. Auto-fit
+is designed for app-chrome tables that should never scroll horizontally, which inverts the
+expectation of a data-inspection table.
+
+## Prevention
+
+- When a Fluent component ignores correct-looking props, read the installed source under
+  `node_modules/@fluentui/*/lib/` — the `.styles.raw.js` files are human-readable and show
+  exactly what each variant sets.
+- Keep the in-code comments on the arity-based `compare` pair in `data-table.tsx`; a future
+  reader will otherwise "simplify" the arity-2 no-op back to `() => 0` and silently kill
+  sorting.
+- External sorting with DataGrid must sort the FULL dataset before pagination; the grid's
+  internal compare would sort only the visible page.

--- a/docs/solutions/workflow-issues/stale-package-dist-after-watcher-death-2026-07-20.md
+++ b/docs/solutions/workflow-issues/stale-package-dist-after-watcher-death-2026-07-20.md
@@ -1,0 +1,70 @@
+---
+title: 'Stale workspace dist after a package watcher dies: committed fixes appear to have no effect'
+date: 2026-07-20
+category: workflow-issues
+module: monorepo
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+symptoms:
+    - 'Correct, committed, pushed changes produce "little to no improvement" when smoke-tested in the running visual'
+    - 'Webpack dev server rebuilds and reloads, but behavior matches an older commit'
+applies_when:
+    - 'Smoke-testing changes to any workspace package (app-core, vega-runtime, etc.) through the webpack dev server'
+    - 'After an IDE/terminal crash, or any event that may have killed the per-package tsup watchers started by npm run dev'
+tags:
+    - turbo
+    - tsup
+    - webpack
+    - dev-server
+    - stale-build
+    - monorepo
+---
+
+# Stale workspace dist after a watcher death
+
+## Context
+
+During PR #723 smoke testing, two committed fixes (row-height `size` variant and
+`autoFitColumns: false`) were reported as having "little to no improvement" in the running
+visual. The fixes were correct — traced through the Fluent library source — which made the
+report confusing. The actual cause: the app-core tsup watcher had died with an earlier VS
+Code crash, so webpack kept bundling a `packages/app-core/dist` built *before* the fix
+commits. The visual was faithfully running old code.
+
+## Guidance
+
+Before debugging why a change "doesn't work" in the running visual, verify the change is
+actually IN the built package output:
+
+```bash
+# 1. Is dist newer than your last commit?  (mtime check)
+node -e "const fs=require('fs');const glob=d=>fs.readdirSync(d,{withFileTypes:true}).flatMap(e=>e.isDirectory()?glob(d+'/'+e.name):[d+'/'+e.name]);let n=0;for(const f of glob('packages/app-core/dist'))n=Math.max(n,fs.statSync(f).mtimeMs);console.log(new Date(n).toISOString())"
+
+# 2. Does dist contain a distinctive marker from the new code?
+grep -rl "autoFitColumns" packages/app-core/dist/ || echo STALE
+```
+
+If stale: `npm run build` in the package (immediate fix), and restart `npm run dev` (per the
+repo's own troubleshooting guidance — it clears `.tmp/`, rebuilds all packages, and restarts
+every watcher) so the session doesn't hit the same trap again.
+
+## Why This Matters
+
+The failure mode is maximally misleading: the dev server IS rebuilding and reloading (the
+webpack watcher is alive), so everything looks healthy — only the upstream package watcher
+is dead. Time is then spent debugging correct code. The mtime + marker check takes seconds
+and cleanly discriminates "code is wrong" from "build is stale".
+
+## When to Apply
+
+- Any "my change has no effect" report during dev-server smoke testing of workspace-package
+  changes — run the check FIRST, before reading code.
+- Routinely after IDE or terminal crashes: assume the `npm run dev` watcher set is degraded
+  and restart it.
+
+## Examples
+
+From the incident: `packages/app-core/dist` was 20 minutes older than the fix commit and
+`grep autoFitColumns dist/` returned nothing — one `npm run build` later, the same visual
+session showed both fixes working.


### PR DESCRIPTION
## Summary

Captures the durable learnings from the rdt-v8 abandonment (#719) and the Fluent DataGrid rebuild (#723) as four focused, searchable solution docs:

| Doc | Category | What it saves next time |
|---|---|---|
| Fluent DataGrid migration landmines | ui-bugs | The four silent regressions: **compare-arity-sniffed sortability** (`compare.length > 0`), `extra-small` dropping the built-in row border, size-variant row heights beating CSS, and `autoFitColumns` default compression |
| vitest Windows externalization of powerbi-visuals-utils | test-failures | The `deps.optimizer.ssr` fix (and why `server.deps.inline` can't work), turbo-cache masking, and the clean-room diagnosis method — including the build-first trap |
| Fluent DataGrid over rdt v8 | tooling-decisions | The decision record: bundle math against the cert ceiling, the sandbox `localStorage` crash class (with the grep heuristic), accepted costs, and the explicit revisit criteria |
| Stale workspace dist after watcher death | workflow-issues | The mtime + marker check that separates "code is wrong" from "build is stale" before any debugging starts |

All frontmatter validated against the ce-compound schema. CLAUDE.md already surfaces `docs/solutions/` so no discoverability edit was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)