### PR TITLE
fix: alpha changelog range spans from last main release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,14 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Fetch all tags
               run: git fetch --tags --force
-            - name: Get last versioned tag
+            - name: Get last release tag
               id: last_tag
+              # Only pure 4-part numeric tags (e.g. 1.9.1.0) are releases cut
+              # from main. Prerelease tags like 2.0.0.alpha-1 sort higher but
+              # point at (or near) the commit being released, which would
+              # produce an empty changelog range.
               run: |
-                  LAST_TAG=$(git tag -l '[0-9]*' --sort=-v:refname | head -n 1)
+                  LAST_TAG=$(git tag -l --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
                   echo "tag=$LAST_TAG" >> $GITHUB_OUTPUT
                   echo "Last versioned tag: $LAST_TAG"
             - name: Generate changelog

--- a/benchmarks/compare.mjs
+++ b/benchmarks/compare.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Benchmark comparison and baseline management script.
  *


### PR DESCRIPTION
## Summary

Alpha release run [29873385904](https://github.com/deneb-viz/deneb/actions/runs/29873385904) failed at the **Generate changelog** step with `Couldn't find any commits between latest and previous tags`. The "last versioned tag" lookup used the glob `[0-9]*`, which also matches version-numbered prerelease tags — so `2.0.0.alpha-1` (version-sorted above `1.9.1.0`, and pointing at the same commit as the floating `alpha` tag) was chosen as the "previous" tag, producing an empty commit range.

The lookup now filters to pure 4-part numeric tags (`^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$`), which are exactly the releases cut from `main`. Alpha changelogs therefore span everything since the last AppSource release, and beta-suffixed tags are excluded by the same rule.

Verified against the current tag inventory: the filter selects `1.9.1.0` (previous behavior selected `2.0.0.alpha-1`).

## Also in this PR

- **Removed the unused shebang from `benchmarks/compare.mjs`.** On Windows checkouts (CRLF working-tree endings), the shebang line makes vitest's transform fail with `SyntaxError: Invalid or unexpected token`, breaking `npm run ci:local`. The script is only ever invoked as `node benchmarks/compare.mjs` (package.json scripts, ci.yml, bench-update-baseline.yml), so the shebang was dead weight. Verified: benchmark suite goes from failing to 69/69 passing on Windows; no behavior change on Linux CI.

## Notes for reviewer

- Tag-triggered runs execute the workflow file at the tagged commit, so the next `alpha` tag must point at a commit containing this change before the fix takes effect. Re-running the failed run will not pick it up.
- CI/tooling-only changes; no visual/runtime code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
