### PR TITLE
fix: recover Vega view size after host-late iframe resizes (#480)

### DIFF
--- a/docs/solutions/ui-bugs/vega-view-stuck-after-host-late-iframe-resize-2026-07-23.md
+++ b/docs/solutions/ui-bugs/vega-view-stuck-after-host-late-iframe-resize-2026-07-23.md
@@ -1,0 +1,72 @@
+---
+title: Vega view stuck at stale size when the host resizes the iframe after reporting the viewport (OoF title restore)
+date: 2026-07-23
+category: ui-bugs
+module: app-core/visual-viewer
+problem_type: ui_bug
+component: viewer
+symptoms:
+    - 'With on-object formatting enabled in Desktop, clicking the visual (title reserve shrinks viewport 710→682) then clicking off leaves the Vega view rendered at 682 inside a restored 710 container — a band of exposed background at the bottom (#480 follow-up)'
+    - 'Resizing the visual or navigating away and back fixes it; the bad state otherwise persists indefinitely'
+    - 'Dev-overlay instrumentation showed every upstream layer healthy in the failure state: host-reported viewport, committed embedViewport, last-compiled containerDimensions, and the physical container all read 710 — only the rendered canvas element read 682 (cv.h 682, Δ +28)'
+root_cause: async_timing
+resolution_type: code_fix
+severity: medium
+related_components:
+    - app-core/visual-viewer/vega-embed
+    - app-core/visual-viewer/container-size-observer
+    - vega-runtime/signals
+tags:
+    - viewport
+    - on-object-formatting
+    - denebContainer
+    - resize-observer
+    - iframe
+    - dev-overlay
+---
+
+# Vega view stuck at stale size when the host resizes the iframe after reporting the viewport (OoF title restore)
+
+## Problem
+
+After interacting with on-object formatting (OoF) in Power BI Desktop — clicking the visual so the title reserve shrinks the viewport, then clicking off so it restores — the Vega view stayed rendered at the shrunken height inside the restored container, leaving a visible gap until a manual resize or page re-entry ([#480](https://github.com/deneb-viz/deneb/issues/480) follow-up comments).
+
+## Symptoms
+
+- Vega content occupies the pre-restore height; exposed background band below it (Desktop's mis-placed OoF title chrome shows through).
+- Persistent until a genuine ResizeEnd (manual resize) or fresh construction (page navigation).
+- All store state ends CORRECT — this is invisible to state-level inspection.
+
+## What Didn't Work
+
+- **Hypothesis 1 — the embed-viewport ResizeEnd gate drops the restore.** Refuted by a full dev-overlay update trace: the restore arrives as type 36 (Resize+ResizeEnd) and a replay test (`src/state/__test__/updates-oof-viewport-replay.test.ts`) drives the exact captured 11-update sequence through the real updates slice, proving `embedViewport` commits 682 → 710 correctly.
+- **Hypothesis 2 — the recompile never ran with the restored dimensions.** Refuted by overlay instrumentation showing the last-compiled `denebContainer` init at 710 (`cd.h`).
+- **Reading the lifecycle tally as proof of "no render".** Misleading: renders triggered after a `skip`-path close aren't recorded against the already-closed lifecycle id, so `render-start` counts can't distinguish "no render" from "render after close".
+
+## Solution
+
+Root cause: **Desktop resizes the visual's iframe AFTER reporting the new viewport in `update()`.** The `denebContainer` signal effect in `vega-embed.tsx` sampled the DOM at React commit time — while the iframe was still physically at the old size — wrote the stale box, and never fired again. Nothing in the system observed the iframe's later physical growth, so the signal-bound `width`/`height` kept the view at the stale size.
+
+Fix (PR branch `fix/480-oof-viewport-restore`), one authority per concern:
+
+1. **`container-size-observer.ts`** — `observeContainerResize(container, onResize, debounceMs = 150)`: a ResizeObserver with a trailing debounce, so resize storms coalesce into one write at settle. The observer owns ongoing physical-size truth: whatever the host's update/resize ordering, a physical box change eventually fires it.
+2. **Post-embed reconcile** — the old signal effect shrinks to deps `[viewReady]` only: a one-shot write after each embed covering the born-stale case the observer can't see (a view embedded from stale spec-init dims whose container never changes again).
+3. **Shared guarded write** — both paths route through one `refreshContainerSignal`: skip when no signal exists yet, never write a 0×0 box (hidden/tearing-down container), suppress value-equal writes (Vega compares signal values by reference — an equal-but-new object still re-runs the dataflow), and only the active embed instance observes (the hidden editor twin must not write the shared `VegaViewServices` singleton).
+
+## Why This Works
+
+The patched spec binds top-level `width`/`height` to `denebContainer.width/height`, so the view follows the signal. The failure was never in the store/compile chain — it was that all signal writes were _point-in-time DOM reads triggered by update-shaped events_, while the physical resize is an _asynchronous host action with no event_. A ResizeObserver converts the physical change itself into the trigger, closing the class of "host reported X, applied X later" races rather than the single OoF instance.
+
+## Prevention
+
+- When a value is derived from the DOM, its refresh trigger must be the DOM changing (ResizeObserver/MutationObserver), not a store update that merely _predicts_ a DOM change. Host-reported state and physical state are separate clocks in Power BI visuals.
+- Debounce observers with a trailing window (150ms here) and suppress value-equal signal writes — Vega re-runs dataflow on reference-new values.
+- For Desktop diagnosis (no DevTools): the viewport-gate dev overlay (`PBIVIZ_VIEWPORT_GATE_OVERLAY=true`) now reports per-layer sizing truth — `ov` (host-reported), `ev` (committed), `cd` (last compiled), `ct` (container client/scroll box), `cv` (rendered canvas/svg element), `rid` (changes per embed), `vr` (viewReady) — and both overlays have a clipboard copy button (legacy `execCommand`; async Clipboard API is sandbox-blocked). Divergence between adjacent layers localises the broken link in one capture.
+- The lifecycle tally cannot prove a render did not happen for `skip`-closed updates; use `rid`/`cv` from the overlay instead.
+
+## Related Issues
+
+- [#480](https://github.com/deneb-viz/deneb/issues/480) — original scrollbars/container-utilization issue; this was the OoF residual reported in follow-up comments.
+- [viewer-bounce-on-editor-exit-2026-05-04.md](viewer-bounce-on-editor-exit-2026-05-04.md) — same underlying host behaviour (host-paced iframe resize decoupled from update reporting) on the editor→viewer path.
+- [vega-canvas-renderer-vertical-overflow-2026-05-20.md](vega-canvas-renderer-vertical-overflow-2026-05-20.md) — earlier #480 family fix (line-box overflow).
+- Follow-up (separate branch/PR): viewport-only changes still trigger a full recompile + re-embed; with the observer + signal binding they could resize the live view without teardown.

--- a/packages/app-core/src/features/visual-viewer/__tests__/container-size-observer.test.ts
+++ b/packages/app-core/src/features/visual-viewer/__tests__/container-size-observer.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    CONTAINER_RESIZE_DEBOUNCE_MS,
+    isSameDenebContainerValue,
+    observeContainerResize
+} from '../container-size-observer';
+
+/**
+ * jsdom does not implement ResizeObserver; a minimal recording stub is
+ * installed per-test so the module's observe/disconnect wiring and the
+ * trailing-debounce behaviour can be driven deterministically with fake
+ * timers.
+ */
+class ResizeObserverStub {
+    static instances: ResizeObserverStub[] = [];
+    callback: ResizeObserverCallback;
+    observed: Element[] = [];
+    disconnected = false;
+    constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+        ResizeObserverStub.instances.push(this);
+    }
+    observe(target: Element) {
+        this.observed.push(target);
+    }
+    disconnect() {
+        this.disconnected = true;
+    }
+    unobserve() {}
+    /** Simulate the browser delivering a resize notification. */
+    fire() {
+        this.callback([], this as unknown as ResizeObserver);
+    }
+}
+
+describe('observeContainerResize', () => {
+    beforeEach(() => {
+        ResizeObserverStub.instances = [];
+        vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    const arrange = (debounceMs?: number) => {
+        const container = document.createElement('div');
+        const onResize = vi.fn();
+        const dispose = observeContainerResize(container, onResize, debounceMs);
+        const observer = ResizeObserverStub.instances[0];
+        return { container, onResize, dispose, observer };
+    };
+
+    it('observes the given container element', () => {
+        const { container, observer } = arrange();
+        expect(observer.observed).toEqual([container]);
+    });
+
+    it('invokes onResize once after the debounce window elapses', () => {
+        const { onResize, observer } = arrange();
+        observer.fire();
+        expect(onResize).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(CONTAINER_RESIZE_DEBOUNCE_MS);
+        expect(onResize).toHaveBeenCalledTimes(1);
+    });
+
+    it('coalesces a burst of notifications into a single trailing call', () => {
+        const { onResize, observer } = arrange();
+        observer.fire();
+        vi.advanceTimersByTime(CONTAINER_RESIZE_DEBOUNCE_MS - 1);
+        observer.fire();
+        vi.advanceTimersByTime(CONTAINER_RESIZE_DEBOUNCE_MS - 1);
+        observer.fire();
+        expect(onResize).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(CONTAINER_RESIZE_DEBOUNCE_MS);
+        expect(onResize).toHaveBeenCalledTimes(1);
+    });
+
+    it('honours a caller-supplied debounce duration', () => {
+        const { onResize, observer } = arrange(500);
+        observer.fire();
+        vi.advanceTimersByTime(499);
+        expect(onResize).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(onResize).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispose cancels a pending trailing call and disconnects the observer', () => {
+        const { onResize, dispose, observer } = arrange();
+        observer.fire();
+        dispose();
+        vi.advanceTimersByTime(CONTAINER_RESIZE_DEBOUNCE_MS * 2);
+        expect(onResize).not.toHaveBeenCalled();
+        expect(observer.disconnected).toBe(true);
+    });
+});
+
+describe('isSameDenebContainerValue', () => {
+    const base = {
+        width: 949,
+        height: 710,
+        scrollWidth: 949,
+        scrollHeight: 710,
+        scrollTop: 0,
+        scrollLeft: 0
+    };
+
+    it('returns true for value-identical container signals', () => {
+        expect(isSameDenebContainerValue(base, { ...base })).toBe(true);
+    });
+
+    it('returns false when any dimension differs', () => {
+        expect(isSameDenebContainerValue(base, { ...base, height: 682 })).toBe(
+            false
+        );
+    });
+
+    it('returns false when the current signal value is undefined', () => {
+        expect(isSameDenebContainerValue(undefined, base)).toBe(false);
+    });
+});

--- a/packages/app-core/src/features/visual-viewer/__tests__/container-size-observer.test.ts
+++ b/packages/app-core/src/features/visual-viewer/__tests__/container-size-observer.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
     CONTAINER_RESIZE_DEBOUNCE_MS,
+    getContainerSignalRefresh,
     isSameDenebContainerValue,
     observeContainerResize
 } from '../container-size-observer';
@@ -95,6 +96,78 @@ describe('observeContainerResize', () => {
         vi.advanceTimersByTime(CONTAINER_RESIZE_DEBOUNCE_MS * 2);
         expect(onResize).not.toHaveBeenCalled();
         expect(observer.disconnected).toBe(true);
+    });
+});
+
+describe('getContainerSignalRefresh', () => {
+    /**
+     * jsdom computes no layout, so the container's box metrics are
+     * stubbed per-test. Scroll offsets default to 0 — matching the
+     * real embed wrapper, which never scrolls itself (the
+     * OverlayScrollbars viewport does).
+     */
+    const buildContainer = (metrics: {
+        clientWidth: number;
+        clientHeight: number;
+        scrollWidth?: number;
+        scrollHeight?: number;
+    }): HTMLElement => {
+        const container = document.createElement('div');
+        Object.defineProperties(container, {
+            clientWidth: { value: metrics.clientWidth },
+            clientHeight: { value: metrics.clientHeight },
+            scrollWidth: { value: metrics.scrollWidth ?? metrics.clientWidth },
+            scrollHeight: {
+                value: metrics.scrollHeight ?? metrics.clientHeight
+            }
+        });
+        return container;
+    };
+
+    const currentSignal = {
+        width: 949,
+        height: 682,
+        scrollWidth: 949,
+        scrollHeight: 1200,
+        scrollTop: 250,
+        scrollLeft: 10
+    };
+
+    it('preserves the current scroll offsets when the container reports zero scroll', () => {
+        // The embed wrapper always reads scrollTop/scrollLeft 0; the
+        // real offsets are written by the scroll path from the
+        // OverlayScrollbars viewport. A size refresh must not clobber
+        // them back to 0.
+        const container = buildContainer({
+            clientWidth: 949,
+            clientHeight: 710
+        });
+        const refresh = getContainerSignalRefresh(container, currentSignal);
+        expect(refresh?.value.height).toBe(710);
+        expect(refresh?.value.scrollTop).toBe(250);
+        expect(refresh?.value.scrollLeft).toBe(10);
+    });
+
+    it('returns null when there is no current signal (no live view yet)', () => {
+        const container = buildContainer({
+            clientWidth: 949,
+            clientHeight: 710
+        });
+        expect(getContainerSignalRefresh(container, undefined)).toBeNull();
+    });
+
+    it('returns null for a 0×0 container (hidden or tearing down)', () => {
+        const container = buildContainer({ clientWidth: 0, clientHeight: 0 });
+        expect(getContainerSignalRefresh(container, currentSignal)).toBeNull();
+    });
+
+    it('returns null when the refreshed value equals the current signal', () => {
+        const container = buildContainer({
+            clientWidth: 949,
+            clientHeight: 682,
+            scrollHeight: 1200
+        });
+        expect(getContainerSignalRefresh(container, currentSignal)).toBeNull();
     });
 });
 

--- a/packages/app-core/src/features/visual-viewer/__tests__/vega-embed-container-observer.test.ts
+++ b/packages/app-core/src/features/visual-viewer/__tests__/vega-embed-container-observer.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Structural canary for the #480 OoF-residual fix: `VegaEmbed` must
+ * wire `observeContainerResize` onto its embed container so the
+ * `denebContainer` signal tracks the container's PHYSICAL box, not
+ * just update-driven effect timings. The workspace defers
+ * component-tree render tests (no @testing-library/react — see the
+ * precedent cited in visual-update-history-overlay-gate.test.ts), so
+ * the wiring contract is locked structurally: the debounced observer
+ * module itself is behaviour-tested in
+ * container-size-observer.test.ts.
+ */
+describe('VegaEmbed container resize observer wiring', () => {
+    const componentSource = readFileSync(
+        resolve(__dirname, '..', 'components', 'vega-embed.tsx'),
+        'utf8'
+    );
+
+    it('imports the debounced observer and its equality guard from the feature module', () => {
+        expect(componentSource).toMatch(
+            /import\s*\{[^}]*observeContainerResize[^}]*\}\s*from\s*'\.\.\/container-size-observer'/s
+        );
+        expect(componentSource).toMatch(/\bisSameDenebContainerValue\b/);
+    });
+
+    it('registers the observer against the embed container element', () => {
+        expect(componentSource).toMatch(/observeContainerResize\(/);
+    });
+
+    it('returns the observer dispose from the effect for cleanup', () => {
+        // The dispose returned by observeContainerResize must be the
+        // effect's cleanup so unmount/deactivation disconnects the
+        // ResizeObserver and cancels any pending trailing call.
+        expect(componentSource).toMatch(
+            /return\s+observeContainerResize\(|const\s+\w+\s*=\s*observeContainerResize\([\s\S]*?return\s+\w+;/
+        );
+    });
+
+    it('reconcile effect depends only on viewReady — live tracking belongs to the observer', () => {
+        // One authority per concern: the ResizeObserver owns ongoing
+        // physical-size truth, so the older signal-update effect must
+        // shrink to its unique residual value — the one-shot
+        // post-embed reconciliation keyed on `viewReady` (a view born
+        // from stale spec-init dims with no subsequent box change is
+        // invisible to the observer). Viewport deps here would
+        // reintroduce double-writes on every committed resize.
+        expect(componentSource).not.toMatch(
+            /\[viewportHeight,\s*viewportWidth,\s*viewReady\]/
+        );
+        // The stable refresh callback rides along per exhaustive-deps;
+        // the contract is "viewReady and nothing viewport-shaped".
+        expect(componentSource).toMatch(
+            /\},\s*\[viewReady,\s*refreshContainerSignal\]\);/
+        );
+    });
+
+    it('both signal write paths share the guarded refresh helper', () => {
+        // The reconcile effect and the observer callback must route
+        // through the same guarded write (signal-exists, non-zero box,
+        // value-equality suppression) — two hand-rolled variants is
+        // how the guards drift apart.
+        const occurrences =
+            componentSource.match(/refreshContainerSignal\(/g) ?? [];
+        expect(occurrences.length).toBeGreaterThanOrEqual(2);
+    });
+});

--- a/packages/app-core/src/features/visual-viewer/__tests__/vega-embed-container-observer.test.ts
+++ b/packages/app-core/src/features/visual-viewer/__tests__/vega-embed-container-observer.test.ts
@@ -19,11 +19,14 @@ describe('VegaEmbed container resize observer wiring', () => {
         'utf8'
     );
 
-    it('imports the debounced observer and its equality guard from the feature module', () => {
+    it('imports the debounced observer and the guarded refresh builder from the feature module', () => {
         expect(componentSource).toMatch(
             /import\s*\{[^}]*observeContainerResize[^}]*\}\s*from\s*'\.\.\/container-size-observer'/s
         );
-        expect(componentSource).toMatch(/\bisSameDenebContainerValue\b/);
+        // The guard logic (signal-exists, non-zero box, value-equality,
+        // scroll-offset preservation) lives in the tested module — the
+        // component must consume it rather than hand-rolling a variant.
+        expect(componentSource).toMatch(/\bgetContainerSignalRefresh\b/);
     });
 
     it('registers the observer against the embed container element', () => {
@@ -51,9 +54,13 @@ describe('VegaEmbed container resize observer wiring', () => {
             /\[viewportHeight,\s*viewportWidth,\s*viewReady\]/
         );
         // The stable refresh callback rides along per exhaustive-deps;
-        // the contract is "viewReady and nothing viewport-shaped".
+        // the contract is "isActive + viewReady and nothing
+        // viewport-shaped". `isActive` is load-bearing: `viewReady` is
+        // SHARED app-core state, so without the guard the inactive
+        // viewer/editor twin also reconciles and can write its own
+        // container's dimensions into the active view's singleton.
         expect(componentSource).toMatch(
-            /\},\s*\[viewReady,\s*refreshContainerSignal\]\);/
+            /\},\s*\[isActive,\s*viewReady,\s*refreshContainerSignal\]\);/
         );
     });
 

--- a/packages/app-core/src/features/visual-viewer/components/vega-embed.tsx
+++ b/packages/app-core/src/features/visual-viewer/components/vega-embed.tsx
@@ -8,13 +8,18 @@ import { VegaViewServices } from '@deneb-viz/vega-runtime/view';
 import { VegaPatternFillServices } from '@deneb-viz/vega-runtime/pattern-fill';
 import {
     getSignalDenebContainer,
-    SIGNAL_DENEB_CONTAINER
+    SIGNAL_DENEB_CONTAINER,
+    type DenebContainerSignal
 } from '@deneb-viz/vega-runtime/signals';
 import { patchSpecWithData } from '@deneb-viz/vega-runtime/spec-processing';
 import { logDebug, logRender } from '@deneb-viz/utils/logging';
 import { useDenebState } from '../../../state';
 import { type ViewEventBinder } from '../../../components/deneb-platform';
 import { VEGA_EMBED_ROOT_STYLE } from './vega-embed-styles';
+import {
+    isSameDenebContainerValue,
+    observeContainerResize
+} from '../container-size-observer';
 import { getRestrictiveVegaLoader } from './restrictive-loader';
 import { shouldOpenEmbedWindow } from '../embed-window';
 
@@ -394,30 +399,72 @@ export const VegaEmbed: React.FC<VegaEmbedProps> = ({
     }, [compilation, viewportHeight, viewportWidth]);
 
     /**
-     * Update `denebContainer` signal when viewport changes.
-     * This handles responsive sizing when the container is resized.
+     * Guarded `denebContainer` refresh shared by both signal write
+     * paths (the post-embed reconcile effect and the ResizeObserver
+     * callback). Guards: no view/signal yet → nothing to update; 0×0
+     * (hidden or tearing-down container) → never write that over a
+     * live view; value-equal → skip, since Vega compares signal
+     * values by reference and an equal-but-new object would still
+     * re-run the dataflow. Stable deps — `VegaViewServices` is a
+     * module singleton.
      */
-    useEffect(() => {
-        // Don't update signal until view is ready (runAsync completed)
-        if (!embedRef.current || !viewReady) return;
-
-        if (
-            VegaViewServices.getSignalByName(SIGNAL_DENEB_CONTAINER) ===
-            undefined
-        ) {
-            return;
-        }
-
+    const refreshContainerSignal = useCallback((container: HTMLElement) => {
+        const current = VegaViewServices.getSignalByName(
+            SIGNAL_DENEB_CONTAINER
+        ) as DenebContainerSignal | undefined;
+        if (current === undefined) return;
         const signal = getSignalDenebContainer({
-            container: embedRef.current,
+            container,
             scroll: {
-                scrollTop: embedRef.current.scrollTop,
-                scrollLeft: embedRef.current.scrollLeft
+                scrollTop: container.scrollTop,
+                scrollLeft: container.scrollLeft
             }
         });
-
+        if (signal.value.width === 0 && signal.value.height === 0) return;
+        if (isSameDenebContainerValue(current, signal.value)) return;
         VegaViewServices.setSignalByName(signal.name, signal.value);
-    }, [viewportHeight, viewportWidth, viewReady]);
+    }, []);
+
+    /**
+     * Post-embed reconcile: sync `denebContainer` to the container's
+     * actual box once a fresh view is ready. A view is born from the
+     * compiled spec's INIT dimensions; if the container's physical box
+     * differed at embed time and never changes again, the
+     * ResizeObserver below has nothing to observe — this one-shot
+     * write closes that born-stale case. Ongoing size tracking is
+     * deliberately NOT handled here (no viewport deps): the observer
+     * owns physical-size truth, and viewport deps would reintroduce a
+     * second, stale-read-prone write on every committed resize (#480
+     * OoF residual).
+     */
+    useEffect(() => {
+        if (!embedRef.current || !viewReady) return;
+        refreshContainerSignal(embedRef.current);
+    }, [viewReady, refreshContainerSignal]);
+
+    /**
+     * Track the embed container's PHYSICAL box (#480 OoF residual).
+     *
+     * The host can resize the iframe AFTER reporting the new viewport
+     * in `update()` — on-object formatting's title-reserve restore
+     * does exactly this — so any update-driven effect can sample the
+     * stale pre-resize box with nothing left to observe the later
+     * physical change, leaving the view stuck at the old size. A
+     * debounced ResizeObserver on the container closes the gap:
+     * whenever the physical box settles, the `denebContainer` signal
+     * is refreshed and the signal-bound width/height follow.
+     *
+     * Only the active instance observes — the inactive twin's
+     * container must never write the shared singleton's signal
+     * (defect C1).
+     */
+    useEffect(() => {
+        const container = embedRef.current;
+        if (!isActive || !container) return;
+        return observeContainerResize(container, () =>
+            refreshContainerSignal(container)
+        );
+    }, [isActive, refreshContainerSignal]);
 
     return <div ref={embedRef} className={classes.root} />;
 };

--- a/packages/app-core/src/features/visual-viewer/components/vega-embed.tsx
+++ b/packages/app-core/src/features/visual-viewer/components/vega-embed.tsx
@@ -7,7 +7,6 @@ import { Handler as VegaTooltipHandler } from 'vega-tooltip';
 import { VegaViewServices } from '@deneb-viz/vega-runtime/view';
 import { VegaPatternFillServices } from '@deneb-viz/vega-runtime/pattern-fill';
 import {
-    getSignalDenebContainer,
     SIGNAL_DENEB_CONTAINER,
     type DenebContainerSignal
 } from '@deneb-viz/vega-runtime/signals';
@@ -17,7 +16,7 @@ import { useDenebState } from '../../../state';
 import { type ViewEventBinder } from '../../../components/deneb-platform';
 import { VEGA_EMBED_ROOT_STYLE } from './vega-embed-styles';
 import {
-    isSameDenebContainerValue,
+    getContainerSignalRefresh,
     observeContainerResize
 } from '../container-size-observer';
 import { getRestrictiveVegaLoader } from './restrictive-loader';
@@ -401,28 +400,21 @@ export const VegaEmbed: React.FC<VegaEmbedProps> = ({
     /**
      * Guarded `denebContainer` refresh shared by both signal write
      * paths (the post-embed reconcile effect and the ResizeObserver
-     * callback). Guards: no view/signal yet → nothing to update; 0×0
-     * (hidden or tearing-down container) → never write that over a
-     * live view; value-equal → skip, since Vega compares signal
-     * values by reference and an equal-but-new object would still
-     * re-run the dataflow. Stable deps — `VegaViewServices` is a
-     * module singleton.
+     * callback). Guard logic and scroll-offset preservation live in
+     * `getContainerSignalRefresh` (behaviour-tested in
+     * container-size-observer.test.ts) — this callback only supplies
+     * the live signal value and performs the write. Stable deps —
+     * `VegaViewServices` is a module singleton.
      */
     const refreshContainerSignal = useCallback((container: HTMLElement) => {
-        const current = VegaViewServices.getSignalByName(
-            SIGNAL_DENEB_CONTAINER
-        ) as DenebContainerSignal | undefined;
-        if (current === undefined) return;
-        const signal = getSignalDenebContainer({
+        const refresh = getContainerSignalRefresh(
             container,
-            scroll: {
-                scrollTop: container.scrollTop,
-                scrollLeft: container.scrollLeft
-            }
-        });
-        if (signal.value.width === 0 && signal.value.height === 0) return;
-        if (isSameDenebContainerValue(current, signal.value)) return;
-        VegaViewServices.setSignalByName(signal.name, signal.value);
+            VegaViewServices.getSignalByName(SIGNAL_DENEB_CONTAINER) as
+                | DenebContainerSignal
+                | undefined
+        );
+        if (refresh === null) return;
+        VegaViewServices.setSignalByName(refresh.name, refresh.value);
     }, []);
 
     /**
@@ -436,11 +428,18 @@ export const VegaEmbed: React.FC<VegaEmbedProps> = ({
      * owns physical-size truth, and viewport deps would reintroduce a
      * second, stale-read-prone write on every committed resize (#480
      * OoF residual).
+     *
+     * `isActive` guard: `viewReady` is SHARED app-core state, so the
+     * inactive viewer/editor twin's effect fires on the active
+     * instance's embed too — without the guard it would write its own
+     * (hidden, possibly non-zero) container box into the active
+     * view's singleton (defect C1, same rationale as the observer
+     * effect below).
      */
     useEffect(() => {
-        if (!embedRef.current || !viewReady) return;
+        if (!isActive || !embedRef.current || !viewReady) return;
         refreshContainerSignal(embedRef.current);
-    }, [viewReady, refreshContainerSignal]);
+    }, [isActive, viewReady, refreshContainerSignal]);
 
     /**
      * Track the embed container's PHYSICAL box (#480 OoF residual).

--- a/packages/app-core/src/features/visual-viewer/container-size-observer.ts
+++ b/packages/app-core/src/features/visual-viewer/container-size-observer.ts
@@ -1,4 +1,7 @@
-import type { DenebContainerSignal } from '@deneb-viz/vega-runtime/signals';
+import {
+    getSignalDenebContainer,
+    type DenebContainerSignal
+} from '@deneb-viz/vega-runtime/signals';
 
 /**
  * Trailing debounce applied to container ResizeObserver notifications
@@ -39,6 +42,40 @@ export const observeContainerResize = (
         clearTimeout(timeoutId);
         observer.disconnect();
     };
+};
+
+/**
+ * Build the refreshed `denebContainer` signal for a size change, or
+ * `null` when no write should happen.
+ *
+ * Guards: no current signal (no live view yet) → null; 0×0 container
+ * (hidden or tearing-down) → null, never write that over a live view;
+ * value-equal → null, since Vega compares signal values by reference
+ * and an equal-but-new object would still re-run the dataflow.
+ *
+ * Scroll offsets are PRESERVED from the current signal value: the
+ * embed wrapper this is called with never scrolls itself (the
+ * OverlayScrollbars viewport does, and the scroll path owns those
+ * fields), so reading offsets from the wrapper would clobber real
+ * offsets back to 0 on every size refresh. `getSignalDenebContainer`
+ * prefers container-read values only when truthy, so the wrapper's 0
+ * falls through to the preserved offsets passed via `scroll`.
+ */
+export const getContainerSignalRefresh = (
+    container: HTMLElement,
+    current: DenebContainerSignal | undefined
+): { name: string; value: DenebContainerSignal } | null => {
+    if (current === undefined) return null;
+    const signal = getSignalDenebContainer({
+        container,
+        scroll: {
+            scrollTop: current.scrollTop,
+            scrollLeft: current.scrollLeft
+        }
+    });
+    if (signal.value.width === 0 && signal.value.height === 0) return null;
+    if (isSameDenebContainerValue(current, signal.value)) return null;
+    return signal;
 };
 
 /**

--- a/packages/app-core/src/features/visual-viewer/container-size-observer.ts
+++ b/packages/app-core/src/features/visual-viewer/container-size-observer.ts
@@ -1,0 +1,60 @@
+import type { DenebContainerSignal } from '@deneb-viz/vega-runtime/signals';
+
+/**
+ * Trailing debounce applied to container ResizeObserver notifications
+ * before the `denebContainer` signal is refreshed. Long enough to
+ * coalesce a resize storm (the host emits continuous notifications
+ * while a visual is dragged) into a single signal write at settle,
+ * short enough that the settle is imperceptible.
+ */
+export const CONTAINER_RESIZE_DEBOUNCE_MS = 150;
+
+/**
+ * Observe an element's physical box with a ResizeObserver, invoking
+ * `onResize` on a trailing debounce once the size settles.
+ *
+ * Why this exists (#480 OoF residual): the host can resize the visual's
+ * iframe AFTER it reports the new viewport in `update()` — on-object
+ * formatting's title-reserve restore does exactly this. Update-driven
+ * effects sample the DOM at commit time and can capture the stale
+ * pre-resize box, with nothing left to observe the later physical
+ * change. Watching the container element itself closes that gap
+ * deterministically, whatever the host's ordering.
+ *
+ * @returns dispose function — cancels any pending trailing call and
+ * disconnects the observer.
+ */
+export const observeContainerResize = (
+    container: Element,
+    onResize: () => void,
+    debounceMs: number = CONTAINER_RESIZE_DEBOUNCE_MS
+): (() => void) => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const observer = new ResizeObserver(() => {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(onResize, debounceMs);
+    });
+    observer.observe(container);
+    return () => {
+        clearTimeout(timeoutId);
+        observer.disconnect();
+    };
+};
+
+/**
+ * Value-equality for `denebContainer` signal payloads. Vega compares
+ * signal values by reference, so writing a new-but-equal object still
+ * re-runs the dataflow; callers use this to suppress those no-op
+ * writes.
+ */
+export const isSameDenebContainerValue = (
+    current: DenebContainerSignal | undefined,
+    next: DenebContainerSignal
+): boolean =>
+    current !== undefined &&
+    current.width === next.width &&
+    current.height === next.height &&
+    current.scrollWidth === next.scrollWidth &&
+    current.scrollHeight === next.scrollHeight &&
+    current.scrollTop === next.scrollTop &&
+    current.scrollLeft === next.scrollLeft;

--- a/packages/app-core/src/index.ts
+++ b/packages/app-core/src/index.ts
@@ -7,6 +7,7 @@ export {
     type PlatformSearchRow,
     type ViewEventBinder
 } from './components/deneb-platform';
+export { copyToClipboard } from './lib/clipboard';
 export {
     handleDiscardChanges,
     handlePersistSpecification

--- a/packages/app-core/src/lib/clipboard.ts
+++ b/packages/app-core/src/lib/clipboard.ts
@@ -2,8 +2,11 @@
  * Copy text to the clipboard using a textarea workaround.
  *
  * The standard Clipboard API is blocked by Power BI's iframe sandbox, so we use legacy means.
+ *
+ * Returns whether the copy command reported success, so callers can
+ * surface accurate feedback (e.g. the dev-overlay copy button).
  */
-export const copyToClipboard = (text: string): void => {
+export const copyToClipboard = (text: string): boolean => {
     const textarea = document.createElement('textarea');
     textarea.style.position = 'fixed';
     textarea.style.left = '-9999px';
@@ -14,7 +17,9 @@ export const copyToClipboard = (text: string): void => {
     textarea.value = text;
     try {
         textarea.select();
-        document.execCommand('copy');
+        return document.execCommand('copy');
+    } catch {
+        return false;
     } finally {
         document.body.removeChild(textarea);
     }

--- a/src/features/dev-overlay-shell/components/dev-overlay-shell.tsx
+++ b/src/features/dev-overlay-shell/components/dev-overlay-shell.tsx
@@ -1,5 +1,7 @@
 import { useState, type CSSProperties, type ReactNode } from 'react';
 
+import { copyToClipboard } from '@deneb-viz/app-core';
+
 /**
  * Where the overlay anchors against the visual surface. Both
  * supported positions are corner-anchored — the visual canvas only
@@ -20,6 +22,15 @@ export type DevOverlayShellProps = {
     maxWidth?: number;
     /** Optional initial collapsed state (default: false). */
     initiallyCollapsed?: boolean;
+    /**
+     * When provided, a copy button is rendered in the title bar that
+     * places the returned text on the clipboard. Lazy (a thunk, not a
+     * string) so large payloads are only serialized on click. Uses the
+     * legacy textarea + `execCommand('copy')` path via app-core's
+     * `copyToClipboard` — the async Clipboard API is unavailable in
+     * the Power BI sandboxed iframe.
+     */
+    clipboardText?: () => string;
     children: ReactNode;
 };
 
@@ -59,9 +70,19 @@ export const DevOverlayShell = ({
     position,
     maxWidth,
     initiallyCollapsed = false,
+    clipboardText,
     children
 }: DevOverlayShellProps) => {
     const [collapsed, setCollapsed] = useState(initiallyCollapsed);
+    const [copyFeedback, setCopyFeedback] = useState<
+        'idle' | 'copied' | 'failed'
+    >('idle');
+    const handleCopy = () => {
+        if (!clipboardText) return;
+        const succeeded = copyToClipboard(clipboardText());
+        setCopyFeedback(succeeded ? 'copied' : 'failed');
+        window.setTimeout(() => setCopyFeedback('idle'), 1500);
+    };
 
     const positionStyle: CSSProperties =
         position === 'top-left'
@@ -133,24 +154,44 @@ export const DevOverlayShell = ({
         padding: '6px 8px',
         overflowY: 'auto',
         overflowX: 'hidden',
-        whiteSpace: 'pre-wrap'
+        whiteSpace: 'pre-wrap',
+        // The shell root disables selection (drag-friendly HUD chrome)
+        // but the body content must remain selectable — Desktop has no
+        // DevTools, so manual select/copy of panel data is a legitimate
+        // capture path alongside the title-bar copy button.
+        userSelect: 'text'
     };
 
     return (
         <div style={shellStyle}>
             <div style={titleBarStyle}>
                 <span>{title}</span>
-                <button
-                    type='button'
-                    style={buttonStyle}
-                    onClick={() => setCollapsed((current) => !current)}
-                    title={collapsed ? 'Restore' : 'Minimize'}
-                    aria-label={
-                        collapsed ? 'Restore overlay' : 'Minimize overlay'
-                    }
-                >
-                    {collapsed ? '+' : '−'}
-                </button>
+                <span>
+                    {clipboardText && (
+                        <button
+                            type='button'
+                            style={buttonStyle}
+                            onClick={handleCopy}
+                            title='Copy panel data to clipboard'
+                            aria-label='Copy panel data to clipboard'
+                        >
+                            {copyFeedback === 'idle' && '⧉'}
+                            {copyFeedback === 'copied' && '✓'}
+                            {copyFeedback === 'failed' && '✕'}
+                        </button>
+                    )}
+                    <button
+                        type='button'
+                        style={buttonStyle}
+                        onClick={() => setCollapsed((current) => !current)}
+                        title={collapsed ? 'Restore' : 'Minimize'}
+                        aria-label={
+                            collapsed ? 'Restore overlay' : 'Minimize overlay'
+                        }
+                    >
+                        {collapsed ? '+' : '−'}
+                    </button>
+                </span>
             </div>
             {!collapsed && <div style={bodyStyle}>{children}</div>}
         </div>

--- a/src/features/viewport-gate-debug-overlay/components/viewport-gate-debug-overlay.tsx
+++ b/src/features/viewport-gate-debug-overlay/components/viewport-gate-debug-overlay.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 
+import { useDenebState } from '@deneb-viz/app-core';
 import { toBoolean } from '@deneb-viz/utils/type-conversion';
 import { useDenebVisualState } from '../../../state';
 import { DevOverlayShell } from '../../dev-overlay-shell';
@@ -15,7 +16,12 @@ import { DevOverlayShell } from '../../dev-overlay-shell';
  * the only way to see the actual values is to render them inside the
  * visual itself. This overlay shows mode, host-reported viewport,
  * stored embedViewport, and the iframe's `window.innerWidth` /
- * `Height`, plus the deltas the gate predicate cares about.
+ * `Height`, plus the deltas the gate predicate cares about. It also
+ * shows the dimensions the last compile baked into the patched spec
+ * (`cd.*`, from the `denebContainer` signal init) and the Vega
+ * container element's client vs scroll box (`ct.*`) — together these
+ * localise a stale-size render to either the viewport→compile chain,
+ * the re-embed, or the physical iframe (#480 OoF residual).
  */
 export const IS_OVERLAY_ENABLED = toBoolean(
     process.env.PBIVIZ_VIEWPORT_GATE_OVERLAY
@@ -39,6 +45,46 @@ const formatDelta = (iframe: number, target: number | undefined): string => {
     return `${delta >= 0 ? '+' : ''}${delta}`;
 };
 
+/**
+ * Id of the Vega output container element — the OverlayScrollbars
+ * viewport that `VisualViewer` labels via its `initialized` event.
+ * Mirrors `VEGA_CONTAINER_ID` in app-core's visual-viewer feature
+ * (not exported from the package barrel; a dev-only overlay does not
+ * justify widening the public surface for one string).
+ */
+const VEGA_CONTAINER_ELEMENT_ID = 'deneb-vega-container';
+
+type ContainerBox = { cw: number; ch: number; sw: number; sh: number };
+
+/**
+ * CSS-pixel size of the rendered Vega output element (canvas or svg
+ * renderer). Read via getBoundingClientRect so it reflects layout
+ * size, not the DPR-scaled canvas backing store. This closes the
+ * `ct.sh` blind spot: scrollHeight can never read SMALLER than
+ * clientHeight, so a stale undersized view inside a grown container
+ * is invisible to the container probe — but shows directly here.
+ */
+type ViewBox = { w: number; h: number };
+
+/**
+ * Structural view of the compilation result — just enough to pull the
+ * `denebContainer` signal's init value (the literal container
+ * dimensions the last compile baked into the patched spec). Local
+ * structural type rather than the vega-runtime types so this dev
+ * overlay adds no cross-package type dependency.
+ */
+type CompilationResultShape = {
+    status?: string;
+    parsed?: {
+        spec?: {
+            signals?: Array<{
+                name?: string;
+                value?: { width?: number; height?: number };
+            }>;
+        } | null;
+    };
+} | null;
+
 export const ViewportGateDebugOverlay = () => {
     const mode = useDenebVisualState((state) => state.interface.mode);
     const embedViewport = useDenebVisualState(
@@ -47,20 +93,80 @@ export const ViewportGateDebugOverlay = () => {
     const optionsViewport = useDenebVisualState(
         (state) => state.updates.options?.viewport
     );
+    // The dimensions the LAST compile baked into the patched spec's
+    // `denebContainer` signal init. Divergence between these and
+    // `embedViewport` proves the viewport→compile chain broke;
+    // agreement (while the visual still renders at the wrong size)
+    // pushes the fault further downstream (re-embed or the physical
+    // iframe). Added for the #480 OoF residual investigation.
+    const compilationResult = useDenebState(
+        (state) => state.compilation.result as CompilationResultShape
+    );
+    // `renderId` regenerates on every successful embed (see
+    // `handleEmbed` in app-core's vega-embed.tsx), so comparing it
+    // across a repro distinguishes "the re-embed never fired" from
+    // "it fired but the view was subsequently resized to a stale
+    // dimension". `viewReady` is the embed-in-flight window flag.
+    const renderId = useDenebState((state) => state.interface.renderId);
+    const viewReady = useDenebState((state) => state.compilation.viewReady);
+    const compiledDims = useMemo(() => {
+        if (compilationResult?.status !== 'ready') return undefined;
+        return compilationResult.parsed?.spec?.signals?.find(
+            (signal) => signal.name === 'denebContainer'
+        )?.value;
+    }, [compilationResult]);
 
     // window.innerWidth/Height are not reactive; poll them at the
-    // same cadence the gate's effect polls (100ms). Cheap.
+    // same cadence the gate's effect polls (100ms). Cheap. The Vega
+    // container element (OverlayScrollbars viewport) is polled on the
+    // same tick — clientHeight is the physical container box,
+    // scrollHeight the rendered content extent, so a stale Vega view
+    // shows up as ct.sh disagreeing with ct.ch.
     const [iw, setIw] = useState<number>(
         typeof window !== 'undefined' ? window.innerWidth : 0
     );
     const [ih, setIh] = useState<number>(
         typeof window !== 'undefined' ? window.innerHeight : 0
     );
+    const [containerBox, setContainerBox] = useState<ContainerBox>();
+    const [viewBox, setViewBox] = useState<ViewBox>();
     useEffect(() => {
         if (typeof window === 'undefined') return;
         const tick = () => {
             setIw(window.innerWidth);
             setIh(window.innerHeight);
+            const container = document.getElementById(
+                VEGA_CONTAINER_ELEMENT_ID
+            );
+            const next = container
+                ? {
+                      cw: container.clientWidth,
+                      ch: container.clientHeight,
+                      sw: container.scrollWidth,
+                      sh: container.scrollHeight
+                  }
+                : undefined;
+            setContainerBox((previous) =>
+                previous?.cw === next?.cw &&
+                previous?.ch === next?.ch &&
+                previous?.sw === next?.sw &&
+                previous?.sh === next?.sh
+                    ? previous
+                    : next
+            );
+            const viewElement = container?.querySelector('canvas, svg');
+            const viewRect = viewElement?.getBoundingClientRect();
+            const nextView = viewRect
+                ? {
+                      w: Math.round(viewRect.width),
+                      h: Math.round(viewRect.height)
+                  }
+                : undefined;
+            setViewBox((previous) =>
+                previous?.w === nextView?.w && previous?.h === nextView?.h
+                    ? previous
+                    : nextView
+            );
         };
         tick();
         const intervalId = window.setInterval(tick, POLL_INTERVAL_MS);
@@ -83,7 +189,15 @@ export const ViewportGateDebugOverlay = () => {
         `ov.w      ${formatNumber(ovw)}    Δ ${formatDelta(iw, ovw)}`,
         `ov.h      ${formatNumber(ovh)}    Δ ${formatDelta(ih, ovh)}`,
         `ev.w      ${formatNumber(evw)}    Δ ${formatDelta(iw, evw)}`,
-        `ev.h      ${formatNumber(evh)}    Δ ${formatDelta(ih, evh)}`
+        `ev.h      ${formatNumber(evh)}    Δ ${formatDelta(ih, evh)}`,
+        `cd.w      ${formatNumber(compiledDims?.width)}    Δ ${formatDelta(iw, compiledDims?.width)}`,
+        `cd.h      ${formatNumber(compiledDims?.height)}    Δ ${formatDelta(ih, compiledDims?.height)}`,
+        `ct.cw/sw  ${formatNumber(containerBox?.cw)} / ${formatNumber(containerBox?.sw)}`,
+        `ct.ch/sh  ${formatNumber(containerBox?.ch)} / ${formatNumber(containerBox?.sh)}`,
+        `cv.w      ${formatNumber(viewBox?.w)}    Δ ${formatDelta(iw, viewBox?.w)}`,
+        `cv.h      ${formatNumber(viewBox?.h)}    Δ ${formatDelta(ih, viewBox?.h)}`,
+        `rid       ${renderId ? String(renderId).slice(0, 8) : '—'}`,
+        `vr        ${viewReady ? 'true' : 'false'}`
     ];
 
     return (
@@ -91,6 +205,7 @@ export const ViewportGateDebugOverlay = () => {
             title='viewport gate'
             position='top-right'
             maxWidth={240}
+            clipboardText={() => lines.join('\n')}
         >
             <pre style={PRE_STYLE}>{lines.join('\n')}</pre>
         </DevOverlayShell>

--- a/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
+++ b/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
@@ -5,6 +5,7 @@ import { useDenebVisualState } from '../../../state';
 import { CollapsibleSection, DevOverlayShell } from '../../dev-overlay-shell';
 import { type RenderingLifecycleEvent } from '../../../lib/rendering-lifecycle';
 import { computeLifecycleTally } from '../lib/compute-tally';
+import { getOverlayClipboardPayload } from '../lib/clipboard-payload';
 
 export const IS_OVERLAY_ENABLED = toBoolean(process.env.PBIVIZ_DEV_OVERLAY);
 
@@ -106,41 +107,18 @@ export const VisualUpdateHistoryOverlay = () => {
     // Structured dump for the title-bar copy button — the update
     // history records (type + viewport per update) are the primary
     // evidence when diagnosing host update sequences in Desktop, where
-    // there are no DevTools to capture them any other way. `opened`
-    // events embed the full VisualUpdateOptions (dataViews + spec),
-    // which balloons the payload past what can be pasted into an
-    // issue or chat — compact them to the update-shape essentials,
-    // keeping the persisted `stateManagement` object (it evidences
-    // viewport-persistence pollution, e.g. #480's OoF residue).
-    const getClipboardText = () => {
-        const compactEvents = lifecycleEvents.map((event) =>
-            event.kind === 'opened'
-                ? {
-                      ...event,
-                      options: {
-                          type: event.options.type,
-                          viewport: event.options.viewport,
-                          editMode: event.options.editMode,
-                          viewMode: event.options.viewMode,
-                          isInFocus: event.options.isInFocus,
-                          formatMode: (
-                              event.options as { formatMode?: boolean | null }
-                          ).formatMode,
-                          updateId: (event.options as { updateId?: string })
-                              .updateId,
-                          stateManagement:
-                              event.options.dataViews?.[0]?.metadata?.objects
-                                  ?.stateManagement
-                      }
-                  }
-                : event
-        );
-        return JSON.stringify(
-            { tally, recentFailures, history, lifecycleEvents: compactEvents },
-            null,
-            2
-        );
-    };
+    // there are no DevTools to capture them any other way. Event
+    // compaction and error-value sanitization live in the tested
+    // builder (`lib/clipboard-payload.ts`) — it never throws, so the
+    // copy button cannot be broken by the failure payload it exists
+    // to capture.
+    const getClipboardText = () =>
+        getOverlayClipboardPayload({
+            tally,
+            recentFailures,
+            history,
+            lifecycleEvents
+        });
 
     return (
         <DevOverlayShell

--- a/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
+++ b/src/features/visual-update-history-overlay/components/visual-update-history-overlay.tsx
@@ -103,11 +103,51 @@ export const VisualUpdateHistoryOverlay = () => {
                 : '')
     ].join('\n');
 
+    // Structured dump for the title-bar copy button — the update
+    // history records (type + viewport per update) are the primary
+    // evidence when diagnosing host update sequences in Desktop, where
+    // there are no DevTools to capture them any other way. `opened`
+    // events embed the full VisualUpdateOptions (dataViews + spec),
+    // which balloons the payload past what can be pasted into an
+    // issue or chat — compact them to the update-shape essentials,
+    // keeping the persisted `stateManagement` object (it evidences
+    // viewport-persistence pollution, e.g. #480's OoF residue).
+    const getClipboardText = () => {
+        const compactEvents = lifecycleEvents.map((event) =>
+            event.kind === 'opened'
+                ? {
+                      ...event,
+                      options: {
+                          type: event.options.type,
+                          viewport: event.options.viewport,
+                          editMode: event.options.editMode,
+                          viewMode: event.options.viewMode,
+                          isInFocus: event.options.isInFocus,
+                          formatMode: (
+                              event.options as { formatMode?: boolean | null }
+                          ).formatMode,
+                          updateId: (event.options as { updateId?: string })
+                              .updateId,
+                          stateManagement:
+                              event.options.dataViews?.[0]?.metadata?.objects
+                                  ?.stateManagement
+                      }
+                  }
+                : event
+        );
+        return JSON.stringify(
+            { tally, recentFailures, history, lifecycleEvents: compactEvents },
+            null,
+            2
+        );
+    };
+
     return (
         <DevOverlayShell
             title='lifecycle + history'
             position='top-left'
             maxWidth={520}
+            clipboardText={getClipboardText}
         >
             <div style={SECTION_HEADING_STYLE}>lifecycle tally</div>
             <pre style={HISTORY_PRE_STYLE}>{tallyText}</pre>

--- a/src/features/visual-update-history-overlay/lib/__test__/clipboard-payload.test.ts
+++ b/src/features/visual-update-history-overlay/lib/__test__/clipboard-payload.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { getOverlayClipboardPayload } from '../clipboard-payload';
+import { type RenderingLifecycleEvent } from '../../../../lib/rendering-lifecycle';
+
+/**
+ * The clipboard payload is a diagnostic capture surface — it must
+ * NEVER throw, because a throw in the copy handler breaks the button
+ * for exactly the failure event it exists to capture. Lifecycle
+ * `failed` events carry an arbitrary `error` value (cycles, BigInt,
+ * anything a Vega embed rejection produced), so the builder sanitizes
+ * those to strings and falls back to a plain error note if
+ * serialization still fails.
+ */
+describe('getOverlayClipboardPayload', () => {
+    const openedEvent = {
+        kind: 'opened',
+        id: 1,
+        options: {
+            type: 36,
+            viewport: { width: 949, height: 710, scale: 1 },
+            editMode: 0,
+            viewMode: 1,
+            isInFocus: false,
+            dataViews: [
+                {
+                    metadata: {
+                        columns: [{ displayName: 'bulky column payload' }],
+                        objects: {
+                            stateManagement: { viewportHeight: 710 },
+                            vega: { jsonSpec: 'HUGE SPEC TEXT' }
+                        }
+                    }
+                }
+            ]
+        }
+    } as unknown as RenderingLifecycleEvent;
+
+    const buildFailedEvent = (error: unknown): RenderingLifecycleEvent =>
+        ({
+            kind: 'failed',
+            id: 2,
+            reason: 'boom',
+            via: 'async-pending-render',
+            error
+        }) as unknown as RenderingLifecycleEvent;
+
+    const basePayload = {
+        tally: { opens: 1 },
+        history: [{ type: 36, viewport: { width: 949, height: 710 } }]
+    };
+
+    it('compacts opened events to update-shape essentials, keeping stateManagement and dropping the spec', () => {
+        const payload = getOverlayClipboardPayload({
+            ...basePayload,
+            recentFailures: [],
+            lifecycleEvents: [openedEvent]
+        });
+        expect(payload).toContain('"viewportHeight": 710');
+        expect(payload).not.toContain('HUGE SPEC TEXT');
+        expect(payload).not.toContain('bulky column payload');
+    });
+
+    it('does not throw when a failed event carries a cyclic error value', () => {
+        const cyclic: { self?: unknown } = {};
+        cyclic.self = cyclic;
+        const failed = buildFailedEvent(cyclic);
+        const payload = getOverlayClipboardPayload({
+            ...basePayload,
+            recentFailures: [failed],
+            lifecycleEvents: [failed]
+        });
+        expect(typeof payload).toBe('string');
+        expect(payload).toContain('"reason": "boom"');
+    });
+
+    it('does not throw when a failed event carries a BigInt error value', () => {
+        const failed = buildFailedEvent(BigInt(42));
+        const payload = getOverlayClipboardPayload({
+            ...basePayload,
+            recentFailures: [failed],
+            lifecycleEvents: [failed]
+        });
+        expect(typeof payload).toBe('string');
+        expect(payload).toContain('42');
+    });
+
+    it('surfaces Error messages readably in the sanitized payload', () => {
+        const failed = buildFailedEvent(new Error('view exploded'));
+        const payload = getOverlayClipboardPayload({
+            ...basePayload,
+            recentFailures: [failed],
+            lifecycleEvents: [failed]
+        });
+        expect(payload).toContain('view exploded');
+    });
+
+    it('falls back to an error note instead of throwing when serialization fails outright', () => {
+        const cyclicTally: { self?: unknown } = {};
+        cyclicTally.self = cyclicTally;
+        const payload = getOverlayClipboardPayload({
+            tally: cyclicTally,
+            history: [],
+            recentFailures: [],
+            lifecycleEvents: []
+        });
+        expect(typeof payload).toBe('string');
+        expect(payload.length).toBeGreaterThan(0);
+    });
+});

--- a/src/features/visual-update-history-overlay/lib/clipboard-payload.ts
+++ b/src/features/visual-update-history-overlay/lib/clipboard-payload.ts
@@ -1,0 +1,92 @@
+import { type RenderingLifecycleEvent } from '../../../lib/rendering-lifecycle';
+
+export type OverlayClipboardPayloadInput = {
+    /** Computed lifecycle tally (plain data from computeLifecycleTally). */
+    tally: unknown;
+    /** Recent `failed` lifecycle events shown in the failures section. */
+    recentFailures: RenderingLifecycleEvent[];
+    /** Display-history records (type + viewport per update). */
+    history: unknown;
+    /** Full lifecycle event ring. */
+    lifecycleEvents: RenderingLifecycleEvent[];
+};
+
+/**
+ * Render an arbitrary lifecycle `error` value as a JSON-safe string.
+ * `failed` events carry whatever the embed rejection produced —
+ * cyclic objects, BigInt, anything — and `JSON.stringify` throws on
+ * those, which would break the copy button for exactly the event it
+ * exists to capture. `Error` instances keep their message; everything
+ * else goes through `String()`.
+ */
+const describeErrorValue = (error: unknown): string | undefined => {
+    if (error === undefined) return undefined;
+    if (error instanceof Error) return error.message;
+    return String(error);
+};
+
+/**
+ * Compact a lifecycle event for the clipboard dump:
+ *
+ *  - `opened` events embed the full VisualUpdateOptions (dataViews +
+ *    spec), which balloons the payload past what can be pasted into
+ *    an issue or chat — reduce to the update-shape essentials,
+ *    keeping the persisted `stateManagement` object (it evidences
+ *    viewport-persistence pollution, e.g. #480's OoF residue).
+ *  - `failed` events carry an arbitrary `error` value — sanitize to a
+ *    string so serialization cannot throw.
+ */
+const compactLifecycleEvent = (event: RenderingLifecycleEvent): unknown => {
+    if (event.kind === 'opened') {
+        return {
+            ...event,
+            options: {
+                type: event.options.type,
+                viewport: event.options.viewport,
+                editMode: event.options.editMode,
+                viewMode: event.options.viewMode,
+                isInFocus: event.options.isInFocus,
+                formatMode: (event.options as { formatMode?: boolean | null })
+                    .formatMode,
+                updateId: (event.options as { updateId?: string }).updateId,
+                stateManagement:
+                    event.options.dataViews?.[0]?.metadata?.objects
+                        ?.stateManagement
+            }
+        };
+    }
+    if (event.kind === 'failed') {
+        return {
+            ...event,
+            error: describeErrorValue(event.error)
+        };
+    }
+    return event;
+};
+
+/**
+ * Build the structured JSON dump for the overlay's copy button. Never
+ * throws: event error values are sanitized before serialization, and
+ * if `JSON.stringify` still fails on something unexpected the
+ * function returns a plain error note instead — a diagnostic surface
+ * must not break on the data it is diagnosing.
+ */
+export const getOverlayClipboardPayload = (
+    input: OverlayClipboardPayloadInput
+): string => {
+    const { tally, recentFailures, history, lifecycleEvents } = input;
+    try {
+        return JSON.stringify(
+            {
+                tally,
+                recentFailures: recentFailures.map(compactLifecycleEvent),
+                history,
+                lifecycleEvents: lifecycleEvents.map(compactLifecycleEvent)
+            },
+            null,
+            2
+        );
+    } catch (error) {
+        return `Overlay payload serialization failed: ${describeErrorValue(error)}`;
+    }
+};

--- a/src/state/__test__/updates-oof-viewport-replay.test.ts
+++ b/src/state/__test__/updates-oof-viewport-replay.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+import type powerbi from 'powerbi-visuals-api';
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+//
+// Replays the EXACT host update sequence captured from Power BI Desktop
+// during the #480 on-object-formatting (OoF) residual investigation
+// (2026-07-23 dev-overlay trace). Unlike `updates.test.ts` (which stubs
+// the display-mode helpers to isolate the M4 synchronous-throw
+// contract), this suite runs the REAL display-mode module so the
+// embed-viewport commit gate is exercised end-to-end: display-mode
+// resolution → `doesModeAllowEmbedViewportSet` → ResizeEnd bitmask →
+// `setEmbedViewport`.
+//
+// `powerbi-visuals-api` const enums are inlined by tsc in production
+// builds but resolve to `undefined` under vitest's transform, which
+// would silently break every bitmask helper in display-mode. The mock
+// pins the production numeric values (guarded by `satisfies` checks in
+// display-mode.ts against enum drift).
+vi.mock('powerbi-visuals-api', () => ({
+    default: {
+        VisualUpdateType: {
+            Data: 2,
+            Resize: 4,
+            ViewMode: 8,
+            Style: 16,
+            ResizeEnd: 32,
+            All: 62
+        },
+        ViewMode: { View: 0, Edit: 1, InFocusEdit: 2 },
+        EditMode: { Default: 0, Advanced: 1 }
+    }
+}));
+
+// Map the `../../lib/state` barrel to the real display-mode module
+// only. The barrel also re-exports `initializeStoreSynchronization`
+// (sync.ts), which imports `@deneb-viz/app-core` and the full visual
+// store — far heavier than this replay needs and irrelevant to the
+// commit gate under test.
+vi.mock('../../lib/state', async () => {
+    return await vi.importActual('../../lib/state/display-mode');
+});
+
+vi.mock('../../lib/persistence', () => ({
+    getVisualFormattingModel: vi.fn(() => ({
+        resolveDeveloperSettings: vi.fn(),
+        stateManagement: {
+            viewport: {
+                viewportHeight: { value: '710' },
+                viewportWidth: { value: '949' }
+            }
+        },
+        vega: {
+            output: {
+                jsonSpec: { value: 'NON_DEFAULT_SPEC' }
+            }
+        }
+    }))
+}));
+
+vi.mock('@deneb-viz/configuration', async () => {
+    const actual = await vi.importActual<
+        typeof import('@deneb-viz/configuration')
+    >('@deneb-viz/configuration');
+    return actual;
+});
+
+import { createUpdatesSlice } from '../updates';
+
+// ─── Trace fixture ────────────────────────────────────────────────────────────
+
+/**
+ * The captured host sequence, chronological. Heights: steady 710 →
+ * OoF title-add shrinks to 682 (arrives WITH ResizeEnd, type 36) →
+ * clicking off restores 710 (also type 36). Types are the production
+ * `VisualUpdateType` bitmask values (64 = FormattingSubSelectionChange,
+ * 128 = FormatModeChange — not in the API's typed enum but emitted by
+ * Desktop's OoF host).
+ */
+const TRACE: Array<{ type: number; width: number; height: number }> = [
+    { type: 2, width: 948.9655172413793, height: 710 },
+    { type: 64, width: 948.9655172413793, height: 710 },
+    { type: 128, width: 948.9655172413793, height: 710 },
+    { type: 36, width: 948.9655172413793, height: 682 },
+    { type: 2, width: 948.9655172413793, height: 682 },
+    { type: 4, width: 949, height: 682 },
+    { type: 2, width: 948.9655172413793, height: 682 },
+    { type: 36, width: 948.9655172413793, height: 710 },
+    { type: 2, width: 948.9655172413793, height: 710 },
+    { type: 4, width: 949, height: 710 },
+    { type: 2, width: 948.9655172413793, height: 710 }
+];
+
+const SCALE = 1.6111111111111112;
+
+type EmbedViewport = { width: number; height: number; scale: number };
+
+// ─── Stateful mini-store harness ─────────────────────────────────────────────
+
+/**
+ * Minimal stateful store: `set` applies the slice's partial-state
+ * updater onto a mutable state object, `get` returns it — enough for
+ * the slice's internal `get().interface` reads to observe the commits
+ * its own `set` made, exactly as the production zustand store would.
+ */
+const buildHarness = () => {
+    const embedCommits: EmbedViewport[] = [];
+    const state = {
+        updates: {
+            __hydrated__: false,
+            count: 0,
+            history: [],
+            options: null,
+            lifecycleEvents: []
+        },
+        interface: {
+            embedViewport: undefined as EmbedViewport | undefined,
+            mode: 'initializing',
+            isInFocus: false,
+            viewport: { width: 0, height: 0 },
+            setEmbedViewport: (viewport: EmbedViewport) => {
+                state.interface.embedViewport = viewport;
+                embedCommits.push(viewport);
+            },
+            setViewport: vi.fn()
+        },
+        dataset: { isFetchingAdditional: false },
+        settings: {}
+    };
+    const stateCreator = createUpdatesSlice();
+    const set = (
+        updater: (current: typeof state) => Record<string, unknown>
+    ) => {
+        const partial =
+            typeof updater === 'function' ? updater(state) : updater;
+        // Preserve the interface setters across partial merges — the
+        // slice's updater spreads `...state.interface`, so they carry
+        // through; Object.assign applies the top-level slices.
+        Object.assign(state, partial);
+    };
+    const get = () => state;
+    const slice = stateCreator(
+        set as unknown as Parameters<typeof stateCreator>[0],
+        get as unknown as Parameters<typeof stateCreator>[1],
+        {} as unknown as Parameters<typeof stateCreator>[2]
+    );
+    const drive = (update: { type: number; width: number; height: number }) => {
+        slice.setVisualUpdateOptions({
+            options: {
+                viewport: {
+                    width: update.width,
+                    height: update.height,
+                    scale: SCALE
+                },
+                type: update.type,
+                viewMode: 1,
+                editMode: 0,
+                isInFocus: false,
+                dataViews: [
+                    { metadata: { columns: [{ displayName: 'stub' }] } }
+                ]
+            } as unknown as powerbi.extensibility.visual.VisualUpdateOptions,
+            isDeveloperMode: false
+        });
+    };
+    return { state, embedCommits, drive };
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('updates slice: OoF viewport commit replay (#480 residual)', () => {
+    it('commits the OoF shrink (type 36 @ 682) to embedViewport', () => {
+        const { state, drive } = buildHarness();
+        TRACE.slice(0, 4).forEach(drive);
+        expect(state.interface.embedViewport).toEqual({
+            width: 949,
+            height: 682,
+            scale: SCALE
+        });
+    });
+
+    it('commits the OoF restore (type 36 @ 710) back to embedViewport', () => {
+        const { state, drive } = buildHarness();
+        TRACE.slice(0, 8).forEach(drive);
+        expect(state.interface.embedViewport).toEqual({
+            width: 949,
+            height: 710,
+            scale: SCALE
+        });
+    });
+
+    it('resolves every update in the sequence as viewer mode (no transition misclassification)', () => {
+        const { state, drive } = buildHarness();
+        const modes: string[] = [];
+        TRACE.forEach((update) => {
+            drive(update);
+            modes.push(state.interface.mode);
+        });
+        expect(modes).toEqual(TRACE.map(() => 'viewer'));
+    });
+
+    it('ends the full sequence with embedViewport at the restored 710', () => {
+        const { state, embedCommits, drive } = buildHarness();
+        TRACE.forEach(drive);
+        expect(state.interface.embedViewport).toEqual({
+            width: 949,
+            height: 710,
+            scale: SCALE
+        });
+        // Initial commit (first update, !embedViewport), the shrink,
+        // and the restore — nothing else in the sequence should touch
+        // the embed viewport.
+        expect(embedCommits.map((commit) => commit.height)).toEqual([
+            710, 682, 710
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

With on-object formatting enabled in Desktop, clicking a visual and then clicking off left the Vega view stuck at the shrunken title-reserve height inside the restored container (deneb-viz/deneb#480 follow-up comments). Root cause: Desktop resizes the visual's iframe *after* reporting the new viewport in `update()`, and every `denebContainer` signal write was a point-in-time DOM read triggered by update-shaped events, so the write sampled the stale pre-resize box and nothing observed the later physical change. The view now tracks the container's physical size and recovers on its own, whatever the host's ordering.

## What changed

A debounced (150ms trailing) `ResizeObserver` on the embed container becomes the single authority for physical-size truth: when the box settles, the `denebContainer` signal refreshes and the signal-bound `width`/`height` follow. The old update-driven signal effect shrinks to its unique residual value, a one-shot post-embed reconcile on `viewReady` that covers the born-stale case the observer cannot see (a view embedded from stale spec-init dims whose container never changes again). Both paths route through one guarded write: skip before a signal exists, never write a 0×0 box, suppress value-equal payloads (Vega compares signal values by reference, so an equal-but-new object still re-runs the dataflow), and only the active embed instance observes so the hidden editor twin cannot write the shared `VegaViewServices` singleton.

```mermaid
flowchart TB
    U["host update()"] --> EV[embedViewport commit]
    EV --> C[recompile with container dims]
    C --> E[re-embed: view born at spec-init size]
    E -->|viewReady| R[post-embed reconcile]
    P[physical container box changes] -->|ResizeObserver, 150ms debounce| G[shared guarded refresh]
    R --> G
    G --> S[denebContainer signal]
    S --> V[view width/height]
```

The PR also ships the dev-overlay instrumentation that isolated the bug, since Desktop has no DevTools: a clipboard copy button on both overlays (legacy `execCommand` path, the async Clipboard API is blocked in the sandboxed iframe), selectable panel text, a compacted structured dump of the update history, and per-layer sizing diagnostics on the viewport-gate overlay (host-reported / committed / last-compiled / container box / rendered element / renderId / viewReady). Divergence between adjacent layers localises a stale-size render in one capture. A learning doc capturing the investigation and the two refuted hypotheses is included under `docs/solutions/ui-bugs/`.

## Test plan

- `packages/app-core/.../container-size-observer.test.ts`: debounce timing, burst coalescing, custom duration, dispose semantics, signal value equality.
- `packages/app-core/.../vega-embed-container-observer.test.ts`: structural canary locking the wiring (observer registered, dispose returned as effect cleanup, reconcile effect deps limited to `viewReady`, both write paths share the guarded refresh).
- `src/state/__test__/updates-oof-viewport-replay.test.ts`: replays the exact 11-update sequence captured from Desktop through the real updates slice and display-mode helpers, locking in the embed-viewport commit behaviour the investigation exonerated.
- Manually verified in Power BI Desktop: the OoF click-on/click-off repro now recovers to the restored height; `npm run ci:local` passes.

## Follow-ups (deliberately out of scope)

- Viewport-only changes still trigger a full recompile and re-embed; with the observer plus signal binding they could resize the live view without teardown. Worth its own branch and Desktop soak.
- `stateManagement.viewportHeight` is still persisted during transient OoF interaction (stamps 682 mid-interaction, two extra host round-trips per click). Small separate hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Fable_5-D97757?logo=claude&logoColor=white)
