### PR TITLE
ci: require versioned alpha tag and name alpha releases from it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,11 @@ jobs:
             - name: Resolve versioned alpha tag
               id: version_tag
               run: |
-                  VERSION_TAG=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.alpha-[0-9]+$' | sort -V | tail -n 1)
+                  # `|| true`: keep a no-match grep from failing the
+                  # assignment if this step ever runs under pipefail
+                  # (e.g. an explicit `shell: bash`), so the guard below
+                  # prints its instructions instead of a bare exit.
+                  VERSION_TAG=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.alpha-[0-9]+$' | sort -V | tail -n 1 || true)
                   if [ -z "$VERSION_TAG" ]; then
                       echo "::error::No versioned alpha tag (e.g. 2.0.0.alpha-1) found on this commit. Tag the commit with '<major>.<minor>.<patch>.alpha-<n>' and re-push the 'alpha' tag to release."
                       exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,20 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+            # The moving `alpha` tag must be accompanied by a versioned
+            # alpha tag (e.g. `2.0.0.alpha-2`) on the same commit — it
+            # names the published .pbiviz and the release title. Fail
+            # fast (before install/build) if it is missing.
+            - name: Resolve versioned alpha tag
+              id: version_tag
+              run: |
+                  VERSION_TAG=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.alpha-[0-9]+$' | sort -V | tail -n 1)
+                  if [ -z "$VERSION_TAG" ]; then
+                      echo "::error::No versioned alpha tag (e.g. 2.0.0.alpha-1) found on this commit. Tag the commit with '<major>.<minor>.<patch>.alpha-<n>' and re-push the 'alpha' tag to release."
+                      exit 1
+                  fi
+                  echo "tag=$VERSION_TAG" >> $GITHUB_OUTPUT
+                  echo "Versioned alpha tag: $VERSION_TAG"
             - name: Use CI .env file
               run: cp .env.ci .env
             - name: Setup Node
@@ -176,6 +190,11 @@ jobs:
               run: npm run validate-config-for-commit
             - name: Build Alpha Package
               run: npm run package-alpha
+            # mv fails the job if the glob matches zero or multiple
+            # files, so a missing/ambiguous build artifact is caught here
+            # rather than publishing a mis-named release.
+            - name: Rename package to versioned alpha filename
+              run: mv dist/ALPHA*.pbiviz "dist/deneb.${{ steps.version_tag.outputs.tag }}.pbiviz"
             - name: Delete existing alpha release
               run: gh release delete ${{ github.ref_name }} --yes || true
               env:
@@ -185,7 +204,10 @@ jobs:
             - name: Get last versioned tag
               id: last_tag
               run: |
-                  LAST_TAG=$(git tag -l '[0-9]*' --sort=-v:refname | head -n 1)
+                  # Exclude versioned alpha tags (x.y.z.alpha-n) so the
+                  # changelog baseline stays the last full release, not
+                  # the alpha tag on this very commit.
+                  LAST_TAG=$(git tag -l '[0-9]*' --sort=-v:refname | grep -v '\.alpha-' | head -n 1)
                   echo "tag=$LAST_TAG" >> $GITHUB_OUTPUT
                   echo "Last versioned tag: $LAST_TAG"
             - name: Generate changelog
@@ -201,7 +223,7 @@ jobs:
               uses: softprops/action-gh-release@v2
               with:
                   prerelease: true
-                  name: 'Alpha Channel: ${{ github.ref_name }}'
+                  name: 'Alpha Channel: Latest Build (${{ steps.version_tag.outputs.tag }})'
                   body: |
                       Deneb Alpha Channel build, which is the latest release candidate for early adopters.
 
@@ -219,6 +241,6 @@ jobs:
 
                       ${{ steps.changelog.outputs.changes }}
                   files: |
-                      dist/ALPHA*.pbiviz
+                      dist/deneb.${{ steps.version_tag.outputs.tag }}.pbiviz
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@
## Summary

Changes the `alpha-release` CI job so alpha releases are driven by a versioned alpha tag on the same commit:

- **Guard (fail fast):** the job now fails immediately after checkout unless the tagged commit also carries a tag matching `<major>.<minor>.<patch>.alpha-<n>` (e.g. `2.0.0.alpha-2`). If several match, the highest by version sort wins.
- **Artifact naming:** the packaged `.pbiviz` is renamed to `deneb.<version-tag>.pbiviz` (e.g. `deneb.2.0.0.alpha-2.pbiviz`) before upload; the release `files:` glob points at that exact name, and the `mv` fails the job if the build artifact is missing or ambiguous.
- **Release title:** now `Alpha Channel: Latest Build (<version-tag>)`.
- **Changelog baseline fix:** the "Get last versioned tag" step now excludes `.alpha-` tags — otherwise the new version tags would win the `[0-9]*` sort and the changelog would be computed against the very commit being released (empty).

## Release procedure (after merge)

```
git tag 2.0.0.alpha-2 <commit>
git tag -f alpha <commit>
git push origin 2.0.0.alpha-2
git push -f origin alpha
```

Pushing `alpha` without the versioned tag now fails the job with an explanatory error instead of publishing.

## Verification

- `npm run ci:local` passes.
- Workflow YAML parses cleanly.
- Tag regex/sort logic verified against edge cases (`alpha-10` vs `alpha-2` numeric ordering; malformed tags like `2.0.0.alpha` and `2.0.0-alpha-3` rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@