### PR TITLE
docs: retire next-branch prerequisite; main is the working trunk again

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ Per-field configuration of which support fields (`__highlight__`, `__format__`, 
 **Branching model (read first):**
 
 - **`main`** is the active development branch (single trunk). Base feature branches off it (`git checkout main && git pull && git checkout -b <type>/<short-name>`) and target it with PRs (`gh pr create --base main`).
-- **`certification`** mirrors the version currently published on AppSource. Do not branch off it or open PRs against it — it only moves when a certified release ships (or a production hotfix is needed).
+- **`certification`** mirrors the version currently published on AppSource. Do not branch off it or target it for routine work — it is reserved for release cuts and genuine production hotfixes, which branch from it and are forward-merged into `main` after shipping.
 - For re-signing or rewriting commits on a feature branch, target the actual fork point (e.g. `HEAD~N` for the last N commits on the branch).
 - During large release cycles a separate `next` integration branch may be temporarily reinstated (as it was for 2.0). If `origin/next` exists and is ahead of `main`, check [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#2-local-development-workflow) for the active model before branching.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,10 +234,10 @@ Per-field configuration of which support fields (`__highlight__`, `__format__`, 
 
 **Branching model (read first):**
 
-- **`next`** is the active integration branch. Base feature branches off it (`git checkout next && git pull && git checkout -b <type>/<short-name>`) and target it with PRs (`gh pr create --base next`).
-- **`main`** mirrors the version currently published on AppSource and is reserved for production hotfixes. Do **not** branch off `main`, do **not** rebase feature branches against `main`, and do **not** open feature PRs against `main` — `main` is typically far behind `next` and will produce a massive replay or huge unintended diff.
-- For re-signing or rewriting commits on a feature branch, target the actual fork point (e.g. `HEAD~N` for the last N commits on the branch), not `main`.
-- Hotfixes that ship from `main` are forward-merged into `next`. A release cut promotes `next` → `main`.
+- **`main`** is the active development branch (single trunk). Base feature branches off it (`git checkout main && git pull && git checkout -b <type>/<short-name>`) and target it with PRs (`gh pr create --base main`).
+- **`certification`** mirrors the version currently published on AppSource. Do not branch off it or open PRs against it — it only moves when a certified release ships (or a production hotfix is needed).
+- For re-signing or rewriting commits on a feature branch, target the actual fork point (e.g. `HEAD~N` for the last N commits on the branch).
+- During large release cycles a separate `next` integration branch may be temporarily reinstated (as it was for 2.0). If `origin/next` exists and is ahead of `main`, check [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#2-local-development-workflow) for the active model before branching.
 
 **Quick Start:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,21 +25,16 @@ Full details, including .env setup, scripts reference, webpack architecture, and
 
 ## Branching
 
-Deneb uses a two-branch trunk:
-
-- **`next`** is the active integration branch. Base your feature branch off `next` and target it with your PR.
-- **`main`** mirrors the version currently published on AppSource and is reserved for production hotfixes.
+**`main`** is the active development branch. Base your feature branch off `main` and target it with your PR.
 
 ```bash
-git checkout next && git pull
+git checkout main && git pull
 git checkout -b <type>/<short-name>     # e.g. fix/email-validation, feat/new-toolbar
 ```
 
-Do **not** branch off `main`, do **not** rebase against `main`, and do **not** open feature PRs against `main`. `main` is typically far behind `next` and will produce unintended diffs or massive replays. PRs targeted at `main` are typically parked until the next planned release from `next`, and you may be asked to rebase the work onto `next` during review.
+**`certification`** mirrors the version currently published on AppSource and is not a target for contributions. During large release cycles a separate `next` integration branch may be temporarily reinstated (as it was for 2.0). If so, this section and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#2-local-development-workflow) will say so — otherwise `main` is the branch to use.
 
-Full rationale is in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#2-local-development-workflow) under "Branching model".
-
-Branches merged to `next` are squashed on PR acceptance, and regular merges from `next` to `main` are as-is to preserve the high-level contribution history and ensure that anyone making a PR to `next` still gets credit for their contributions.
+Branches are squash-merged on PR acceptance, so each contribution lands as a single credited commit on `main` and the high-level contribution history stays readable.
 
 ## Commits
 
@@ -94,7 +89,7 @@ This guards against shipping with `LOG_LEVEL` raised, dev toggles enabled, or ot
 
 ## Pull requests
 
-- **Target `next`.** Use `gh pr create --base next "<title>"` or set the base manually in the GitHub UI.
+- **Target `main`.** Use `gh pr create --base main "<title>"` or set the base manually in the GitHub UI.
 - **Title.** Short, descriptive, conventional prefix where natural. The PR title is what appears in the release notes.
 - **Description.** Cover the _what_ and the _why_. Reference any related issue (`Fixes #123`). For UI changes, include before/after screenshots or a short clip if it helps the reviewer.
 - **Keep the diff focused.** Drive-by formatting or unrelated cleanup belongs in its own PR — it makes review and rollback much easier.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -31,22 +31,19 @@ Deneb uses a custom Webpack 5 toolchain (replacing pbiviz CLI) for faster rebuil
 
 ### Branching model
 
-Deneb uses a two-branch trunk:
-
-- **`main`** is kept as close as possible to the version currently published on AppSource. It is the safety net for production issues that need a swift hotfix without dragging along untested in-flight changes.
-- **`next`** is the active integration branch. New features, fixes, refactors, and most day-to-day work land here.
+- **`main`** is the active development branch (single trunk). New features, fixes, refactors, and day-to-day work branch from it and merge back via PR.
+- **`certification`** is kept as close as possible to the version currently published on AppSource. It is the safety net for production issues that need a swift hotfix without dragging along untested in-flight changes. It only moves when a certified release ships or a hotfix must go out ahead of one; hotfixes that land there are forward-merged into `main`.
 
 **Working on a feature or fix:**
 
-1. Branch off `next`, not `main`: `git checkout next && git pull && git checkout -b <type>/<short-name>`.
-2. Open the PR against `next` (e.g. `gh pr create --base next`).
-3. When a hotfix lands on `main`, it is merged or rebased forward into `next` — moving change in that direction is cheap; pushing untested `next` work back into an AppSource release is not.
+1. Branch off `main`: `git checkout main && git pull && git checkout -b <type>/<short-name>`.
+2. Open the PR against `main` (e.g. `gh pr create --base main`).
 
 **Implications:**
 
-- Rebases, `git diff` baselines, and `git rebase --exec` operations for current work should target `next` (or the feature branch's actual fork point such as `HEAD~N`), **not `main`**. `main` is typically far behind `next` and will produce a massive replay if used as the rebase base.
-- AI assistants and contributors new to the repo should treat `next` as the working trunk. Reach for `main` only when the work is genuinely a production hotfix that needs to ship to AppSource ahead of the next release cut.
-- A new release cut promotes `next` → `main` (typically via a release PR), at which point `main` once again mirrors the published AppSource state and the cycle repeats.
+- Rebases, `git diff` baselines, and `git rebase --exec` operations target `main` (or the feature branch's actual fork point such as `HEAD~N`).
+- Do not branch off or target `certification` unless the work is genuinely a production hotfix for the AppSource-published version.
+- During large release cycles (as with 2.0), a separate `next` integration branch may be temporarily reinstated. When that model is active, this section, CONTRIBUTING.md, and CLAUDE.md are updated to describe it; otherwise treat `main` as the working trunk.
 
 ### First-time setup
 


### PR DESCRIPTION
2.0 integration is complete and `origin/next` is fully merged into `main` (both at f30a96cd). This updates the three prescriptive guidance docs (CLAUDE.md, CONTRIBUTING.md, docs/DEVELOPMENT.md) so contributors and AI assistants branch from and target `main` again. The `certification` branch (at 0615a47d, the 1.9-era release) takes over the AppSource-mirror role: reserved for release cuts and production hotfixes, which forward-merge into `main`. Historical plans/solutions that mention `next` are deliberately untouched. Deleting the `next` branch itself is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)