### PR TITLE
fix: resolve per-row format strings for consolidated field parameters

### DIFF
--- a/docs/solutions/logic-errors/dynamic-format-string-field-parameter-consolidation-2026-08-11.md
+++ b/docs/solutions/logic-errors/dynamic-format-string-field-parameter-consolidation-2026-08-11.md
@@ -1,0 +1,154 @@
+---
+title: 'Dynamic-format-string calc-group items strip static formats from consolidated field-parameter columns'
+date: 2026-08-11
+category: logic-errors
+module: 'src/lib/dataset/processing, src/lib/dataset/support-field-provider'
+problem_type: logic_error
+component: service_object
+severity: high
+symptoms:
+    - 'Consolidated field-parameter `__format`/`__formatted` values come back empty (`["","",""]`) whenever any calculation-group item with a dynamic format string exists in the model, even if never invoked (e.g. an unused `SELECTEDMEASUREFORMATSTRING()` item)'
+    - 'Even measures with a genuinely static format string are affected once the calc item exists — deleting it immediately restores correct formatting'
+    - 'Measures with a measure-level dynamic format string lose formatting inside consolidated field parameters even with no calculation group present'
+    - 'Direct (non-parameter) fields and native Power BI visuals are unaffected'
+    - 'Power BI stops delivering static `source.format` on measure columns model-wide and only ships format strings per-row via `values[i].objects[rowIndex].general.formatString`'
+root_cause: logic_error
+resolution_type: code_fix
+related_components:
+    - packages/data-core/src/lib/support-fields/build-data-row.ts
+    - src/lib/dataset/field-parameter-detection.ts
+tags:
+    - dynamic-format-string
+    - field-parameters
+    - calculation-groups
+    - format-string
+    - dataset-mapping
+    - support-fields
+    - power-bi-dataview
+---
+
+# Dynamic-format-string calc-group items strip static formats from consolidated field-parameter columns
+
+## Problem
+
+When a Power BI semantic model contains any calculation-group item with a dynamic format string (e.g. `SELECTEDMEASUREFORMATSTRING()`) — even if that calc item is never invoked in the report — Deneb 2.0 stopped emitting `__format`/`__formatted` support-field values for measures accessed through consolidated field parameters, because two call sites in `src/lib/dataset/processing.ts` pre-resolved format strings from static `column.format` metadata that Power BI had already stripped model-wide.
+
+## Symptoms
+
+- `__format` and `__formatted` support fields for field-parameter-consolidated measures come back empty — the parameter's format array renders as `["","",""]` regardless of which component measure is selected.
+- Even measures with a genuinely *static* format string are affected once the dynamic-format calc item exists in the model — the stripping is model-wide, not limited to the dynamic measure.
+- Direct (non-parameter) fields are unaffected — they still resolve correctly via the per-row `objects[rowIndex].general.formatString` fallback.
+- Native Power BI visuals are unaffected.
+- The trigger is the mere *existence* of a dynamic-format calculation-group item in the model — it does not need to be invoked/visible in the report.
+- Deleting the calc item immediately restores correct Deneb formatting.
+
+Field report source: [r/PowerBI comment](https://www.reddit.com/r/PowerBI/comments/1vhoqs7/comment/p2u77i3/) (2026-08, during 2.0 beta testing).
+
+## What Didn't Work
+
+- **Precedence-order hypothesis.** Initial suspicion was that the 2.0 provider's fallback order — `source.format ?? objects[rowIndex].general.formatString` — was wrong. Disproven by comparing against the 1.x (AppSource, `origin/certification`) implementation in `src/lib/dataset/values.ts`, which uses identical precedence and works for plain dynamic measures. A unit harness driving the real pipeline (`buildProcessingPlan` → `createPbiSupportFieldProvider` → `buildDataRow`) with Power BI-shaped `DataView` fragments confirmed plain-measure dynamic format strings already worked correctly in 2.0.
+- **"Value1" parameter naming red herring.** During PBIP harness construction, a field parameter appeared to surface under the wrong display name. This was a harness authoring bug: `isNameInferred` left set on an explicitly-named TMDL column makes the host report the underlying source column name instead of the given name. Not a Deneb defect.
+
+## Solution
+
+Root cause location: two call sites in `src/lib/dataset/processing.ts` pre-resolved a consolidated parameter's `formatStrings` array unconditionally from static `column.format` metadata. Once populated, `buildDataRow` (`packages/data-core/src/lib/support-fields/build-data-row.ts`) treats `instruction.formatStringsArray` as authoritative and never calls `provider.getFormatString()` per row — so it never sees the per-row `objects[rowIndex].general.formatString` values that Power BI actually populates once a dynamic-format calc item exists.
+
+New helper in `src/lib/dataset/support-field-provider.ts`:
+
+```ts
+export const getStaticParameterFormatStrings = (
+    componentFormats: (string | undefined)[]
+): string[] | undefined =>
+    componentFormats.every((format) => typeof format === 'string')
+        ? (componentFormats as string[])
+        : undefined;
+```
+
+Call site 1 — detected field-parameter groups, `src/lib/dataset/processing.ts` ("Before" condensed from the block-bodied original; behavior identical):
+
+```ts
+// Before
+formatStrings: group.componentFieldIndices.map(
+    (idx) => planSourceColumns[idx]?.column?.format ?? ''
+)
+
+// After
+formatStrings: getStaticParameterFormatStrings(
+    group.componentFieldIndices.map(
+        (idx) => planSourceColumns[idx]?.column?.format
+    )
+)
+```
+
+Call site 2 — manually flagged `treatAsParameter` single-element groups, `src/lib/dataset/processing.ts`:
+
+```ts
+// Before
+formatStrings: [col.column.format ?? '']
+
+// After
+formatStrings: getStaticParameterFormatStrings([col.column.format])
+```
+
+Consumer side (unchanged — this existing fallback is what makes the fix effective) — `packages/data-core/src/lib/support-fields/build-data-row.ts`:
+
+```ts
+// Format strings array
+if (instruction.emitFormat) {
+    if (instruction.formatStringsArray) {
+        row[encodedName + FORMAT_FIELD_SUFFIX] =
+            instruction.formatStringsArray;
+    } else {
+        row[encodedName + FORMAT_FIELD_SUFFIX] =
+            componentIndices.map((idx) =>
+                provider.getFormatString(idx, rowIndex)
+            );
+    }
+}
+```
+
+When `getStaticParameterFormatStrings` returns `undefined` (any component lacks a static format), `buildDataRow` falls back to calling `provider.getFormatString(idx, rowIndex)` per row per component — the same per-row path already used for direct fields, which resolves `source.format ?? objects[rowIndex].general.formatString ?? ''`.
+
+Fix landed in commit `966aa39b` (PR [#739](https://github.com/deneb-viz/deneb/pull/739)).
+
+## Why This Works
+
+Power BI's DataView delivery is not per-column-static the way it appears: when a dynamic-format-string calculation-group item exists anywhere in the model, Power BI strips static `source.format` from **every** measure column model-wide — including measures with a genuinely fixed format string — and delivers format strings exclusively per-row via `objects[rowIndex].general.formatString`. This is a model-wide behavior change, which is why the bug manifests even for calc items that are never invoked and even for otherwise-static measures.
+
+The direct-field path already handled this, because `getFormatString` in `support-field-provider.ts` checks `source.format` first and falls back to the per-row channel — naturally adapting to whichever channel Power BI populates. The 2.0 field-parameter consolidation broke this by pre-resolving `formatStrings` once at plan-build time from the static channel and baking the result into `formatStringsArray` — permanently bypassing the per-row fallback.
+
+Making the pre-resolution conditional restores correctness without discarding the optimization: when every component genuinely has a static format, pre-resolving is provably safe because the provider's own precedence puts `source.format` first — the pre-resolved and per-row-resolved values are identical, so skipping the per-row call is a pure performance win. Only when a static format is absent for at least one component must pre-resolution be avoided so the row loop falls through to the per-row lookup.
+
+## Prevention
+
+1. **Never assume `column.format` (static DataView metadata) is populated for a measure.** Power BI strips it model-wide whenever any dynamic-format-string calculation-group item exists in the model — even unused ones. The per-row `objects[rowIndex].general.formatString` channel is the authoritative source; static metadata is an optimization opportunity only, never a guarantee.
+
+2. **Any pre-resolution/caching optimization over `DataView` metadata must be conditional on the static data actually being present**, with the per-row provider retained as the safety net. The pattern to reuse: a small `getStaticXxx(...): T | undefined` guard that returns `undefined` on any missing component, consumed by an `instruction.xxxArray ?? computePerRow(...)` fallback at the consumption site. (Edge to check when reusing: an empty component list vacuously passes `every` and returns `[]`, which the consumer treats as authoritative — harmless at the current call sites, but verify that semantics fit any new one.)
+
+3. **Regression coverage for this class of bug:**
+    - Unit harness pattern: drive the real pipeline (`buildProcessingPlan` → `createPbiSupportFieldProvider` → `buildDataRow`) with hand-built, Power BI-shaped `DataView` fragments rather than mocking the provider. See `src/lib/dataset/__test__/dynamic-format-string.test.ts` (static, per-row dynamic, and calc-item-stripped scenarios × direct fields and consolidated parameters).
+    - The DataView shape that must stay covered — static format absent, per-row format present:
+
+        ```ts
+        const valueColumn = {
+            source: { format: undefined /* stripped model-wide */ },
+            values: [100, 0.5, 1234.56],
+            objects: [
+                { general: { formatString: '$#,##0' } }, // row 0
+                { general: { formatString: '0.0%' } }, // row 1
+                { general: { formatString: '#,##0.00' } } // row 2
+            ]
+        };
+        ```
+
+    - End-to-end regression: a PBIP harness workbook (calc group with a `Dynamic FS` item = `SELECTEDMEASUREFORMATSTRING()`, measures with static/dynamic/no format, a field parameter over them) driving an 8-case matrix in Power BI Desktop — kept locally under `tools/pbi-harness/` (untracked at time of writing) — is the tool of record for re-verifying this scenario class after changes to field-parameter consolidation or format-string precedence.
+
+## Related Issues
+
+- PR [#739](https://github.com/deneb-viz/deneb/pull/739) — the fix.
+- [Reddit field report](https://www.reddit.com/r/PowerBI/comments/1vhoqs7/comment/p2u77i3/) — original repro narrative (no GitHub issue was filed).
+- Issue [#517](https://github.com/deneb-viz/deneb/issues/517) — earlier general question on dynamic format strings with measures/calc groups (closed; predates this bug).
+- Issue [#238](https://github.com/deneb-viz/deneb/issues/238) — field parameter support feature request (ancestor of the consolidation feature).
+- Issue [#506](https://github.com/deneb-viz/deneb/issues/506) — ability to turn off `__formatted`/generated columns (adjacent support-fields feature).
+- [field-parameter-multi-name-detection-2026-05-07](field-parameter-multi-name-detection-2026-05-07.md) — different bug in the same consolidation path (dropped parameter registrations due to `sourceFieldParameters[0]` indexing); same code neighborhood, different mechanism.
+- [extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24](../best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md) — adjacent support-field flag semantics guidance.

--- a/docs/solutions/logic-errors/field-parameter-multi-name-detection-2026-05-07.md
+++ b/docs/solutions/logic-errors/field-parameter-multi-name-detection-2026-05-07.md
@@ -142,6 +142,7 @@ The per-field `Set<string>` dedup is a small defensive guard. Power BI should no
 
 ## Related Issues
 
+- [docs/solutions/logic-errors/dynamic-format-string-field-parameter-consolidation-2026-08-11.md](dynamic-format-string-field-parameter-consolidation-2026-08-11.md) — a later, different failure mode in the same consolidation path: pre-resolved format strings bypassed per-row provider resolution, dropping `__format`/`__formatted` when Power BI strips static formats model-wide (dynamic-format-string calculation items).
 - [docs/solutions/best-practices/type-widening-requires-call-site-audit-2026-04-16.md](../best-practices/type-widening-requires-call-site-audit-2026-04-16.md) — the symmetric inverse: that doc covers write-side cardinality bugs (singular value written into a plural container, all-but-one entries lost). Together the two docs define both directions of the cardinality-of-one hazard class. The earlier doc's prevention scope is currently framed for write sites only; this fix demonstrates the same hazard on read sites and would broaden the pattern.
 - [docs/solutions/best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md](../best-practices/extract-shared-semantics-to-avoid-dual-maintenance-2026-04-24.md) — same subsystem (support-field flag resolution), different bug class. Useful cross-reference when reasoning about parallel field-parameter logic across detection and plan-building.
 - Plan: `docs/plans/2026-05-07-001-fix-multi-parameter-per-field-detection-plan.md`

--- a/src/lib/dataset/__test__/dynamic-format-string.test.ts
+++ b/src/lib/dataset/__test__/dynamic-format-string.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('powerbi-visuals-api', () => ({}));
+
+// Echo formatter: output pins (locale, format string, value) so each test can
+// assert exactly WHICH format string was applied to WHICH row — the failure
+// surface under investigation. Formatting fidelity belongs to the Power BI
+// library, not this harness.
+vi.mock('@deneb-viz/powerbi-compat/formatting', () => ({
+    getValueFormatter: (
+        format?: string,
+        options?: { cultureSelector?: string }
+    ) => ({
+        format: (value: unknown) =>
+            `[${options?.cultureSelector}|${format}|${value}]`
+    })
+}));
+
+import {
+    buildProcessingPlan,
+    buildDataRow
+} from '@deneb-viz/data-core/support-fields';
+import type {
+    SupportFieldConfiguration,
+    SupportFieldMasterSettings
+} from '@deneb-viz/data-core/support-fields';
+import type { PlanParameterGroup } from '@deneb-viz/data-core/support-fields';
+import {
+    createPbiSupportFieldProvider,
+    getStaticParameterFormatStrings
+} from '../support-field-provider';
+
+/**
+ * Validation harness: dynamic format string processing.
+ *
+ * Power BI delivers a measure's dynamic format string per data point in
+ * `values[i].objects[rowIndex].general.formatString`, with the column's
+ * static `source.format` UNDEFINED. This harness runs DataView shapes that
+ * mirror that contract through the real pipeline (buildProcessingPlan →
+ * createPbiSupportFieldProvider → buildDataRow) and asserts the __format /
+ * __formatted support fields row by row.
+ *
+ * The 1.x (AppSource) precedence being validated (src/lib/dataset/values.ts
+ * on origin/certification): `source.format ?? objects[row].general.formatString`.
+ */
+
+const LOCALE = 'en-US';
+
+const MASTER_SETTINGS: SupportFieldMasterSettings = {
+    crossHighlightEnabled: false,
+    crossFilterEnabled: false
+};
+
+const FORMAT_ON: SupportFieldConfiguration[string] = {
+    highlight: false,
+    highlightStatus: false,
+    highlightComparator: false,
+    format: true,
+    formatted: true
+};
+
+/** Per-row dynamic format strings, as Power BI supplies them. */
+const DYNAMIC_FORMATS = ['$#,##0', '0.0%', '#,##0.00'];
+const SALES_VALUES = [100, 0.5, 1234.56];
+const CATEGORY_VALUES = ['A', 'B', 'C'];
+
+/**
+ * DataView fragment for one category + one measure. `dynamic: true` mirrors a
+ * measure with a dynamic format string (no static source.format, per-row
+ * objects); `dynamic: false` mirrors a plain static-format measure.
+ */
+const makeDataViewFragments = (dynamic: boolean) => {
+    const categories = [
+        { source: { displayName: 'Category', format: undefined } }
+    ] as unknown as powerbi.DataViewCategoryColumn[];
+    const values = [
+        {
+            source: {
+                displayName: 'Sales',
+                format: dynamic ? undefined : '#,##0.00'
+            },
+            values: SALES_VALUES,
+            objects: dynamic
+                ? DYNAMIC_FORMATS.map((f) => ({
+                      general: { formatString: f }
+                  }))
+                : undefined,
+            highlights: null
+        }
+    ] as unknown as powerbi.DataViewValueColumns;
+    return { categories, values };
+};
+
+const makeProvider = (dynamic: boolean) => {
+    const { categories, values } = makeDataViewFragments(dynamic);
+    return createPbiSupportFieldProvider({
+        categories,
+        values,
+        hasHighlights: false,
+        // baseValues slot 0 = Category (dvCategories[0]), slot 1 = Sales (dvValues[0])
+        fieldSourceMappings: [
+            { source: 'categories', index: 0 },
+            { source: 'values', index: 0 }
+        ]
+    });
+};
+
+const PLAN_FIELDS = [
+    { encodedName: 'Category', sourceIndex: 0, role: 'grouping' as const },
+    { encodedName: 'Sales', sourceIndex: 0, role: 'aggregation' as const }
+];
+
+const buildRows = (
+    dynamic: boolean,
+    parameterGroups?: PlanParameterGroup[],
+    configuration: SupportFieldConfiguration = { Sales: FORMAT_ON }
+) => {
+    const plan = buildProcessingPlan({
+        fields: PLAN_FIELDS,
+        configuration,
+        masterSettings: MASTER_SETTINGS,
+        hasHighlights: false,
+        isLegacy: false,
+        parameterGroups
+    });
+    const provider = makeProvider(dynamic);
+    return SALES_VALUES.map((_, r) =>
+        buildDataRow({
+            plan,
+            provider,
+            baseValues: [CATEGORY_VALUES[r], SALES_VALUES[r]],
+            rowIndex: r,
+            locale: LOCALE
+        })
+    );
+};
+
+describe('dynamic format string validation harness', () => {
+    describe('plain measure (regular field instruction)', () => {
+        it('static format: emits the column format string on every row', () => {
+            const rows = buildRows(false);
+            for (let r = 0; r < rows.length; r++) {
+                expect(rows[r]['Sales__format']).toBe('#,##0.00');
+                expect(rows[r]['Sales__formatted']).toBe(
+                    `[${LOCALE}|#,##0.00|${SALES_VALUES[r]}]`
+                );
+            }
+        });
+
+        it('dynamic format: emits the per-row format string from objects[row].general.formatString', () => {
+            const rows = buildRows(true);
+            for (let r = 0; r < rows.length; r++) {
+                expect(rows[r]['Sales__format']).toBe(DYNAMIC_FORMATS[r]);
+            }
+        });
+
+        it('dynamic format: formats each row value with that row format string', () => {
+            const rows = buildRows(true);
+            for (let r = 0; r < rows.length; r++) {
+                expect(rows[r]['Sales__formatted']).toBe(
+                    `[${LOCALE}|${DYNAMIC_FORMATS[r]}|${SALES_VALUES[r]}]`
+                );
+            }
+        });
+    });
+
+    describe('measure consolidated into a field parameter', () => {
+        // Groups are wired the way processing.ts wires them:
+        // getStaticParameterFormatStrings() pre-resolves ONLY when every
+        // component has a static column format; otherwise it returns
+        // undefined and buildDataRow resolves per-row via the provider.
+        const makeGroup = (
+            staticFormats: (string | undefined)[]
+        ): PlanParameterGroup[] => [
+            {
+                parameterName: 'Param',
+                componentFieldIndices: [1],
+                componentNames: ['Sales'],
+                componentRoles: ['aggregation'],
+                formatStrings: getStaticParameterFormatStrings(staticFormats)
+            }
+        ];
+        const paramConfig: SupportFieldConfiguration = { Param: FORMAT_ON };
+
+        it('dynamic format: __format carries the per-row format string', () => {
+            // Dynamic-format measure → no static column format
+            const rows = buildRows(true, makeGroup([undefined]), paramConfig);
+            for (let r = 0; r < rows.length; r++) {
+                expect(rows[r]['Param__format']).toEqual([DYNAMIC_FORMATS[r]]);
+            }
+        });
+
+        it('dynamic format: __formatted uses the per-row format string', () => {
+            const rows = buildRows(true, makeGroup([undefined]), paramConfig);
+            for (let r = 0; r < rows.length; r++) {
+                expect(rows[r]['Param__formatted']).toEqual([
+                    `[${LOCALE}|${DYNAMIC_FORMATS[r]}|${SALES_VALUES[r]}]`
+                ]);
+            }
+        });
+
+        it('static format: pre-resolved row-invariant formats are emitted', () => {
+            const rows = buildRows(false, makeGroup(['#,##0.00']), paramConfig);
+            for (let r = 0; r < rows.length; r++) {
+                expect(rows[r]['Param__format']).toEqual(['#,##0.00']);
+                expect(rows[r]['Param__formatted']).toEqual([
+                    `[${LOCALE}|#,##0.00|${SALES_VALUES[r]}]`
+                ]);
+            }
+        });
+
+        it('calc-item scenario: static formats stripped model-wide resolve per-row from objects', () => {
+            // When any dynamic-format calculation item exists in the model,
+            // Power BI removes static source.format from ALL measure columns
+            // and delivers formats per-row via objects — same DataView shape
+            // as a dynamic measure, so the per-row fallback covers it.
+            const rows = buildRows(true, makeGroup([undefined]), paramConfig);
+            for (let r = 0; r < rows.length; r++) {
+                expect(rows[r]['Param__format']).toEqual([DYNAMIC_FORMATS[r]]);
+            }
+        });
+    });
+});

--- a/src/lib/dataset/processing.ts
+++ b/src/lib/dataset/processing.ts
@@ -58,7 +58,8 @@ import {
 } from '../interactivity';
 import {
     buildFieldSourceMappings,
-    createPbiSupportFieldProvider
+    createPbiSupportFieldProvider,
+    getStaticParameterFormatStrings
 } from './support-field-provider';
 import { isLegacySpec } from './support-field-migration';
 import {
@@ -376,11 +377,10 @@ export const getMappedDataset = (
                         componentFieldIndices: group.componentFieldIndices,
                         componentNames: group.componentNames,
                         componentRoles: group.componentRoles,
-                        formatStrings: group.componentFieldIndices.map(
-                            (idx) => {
-                                const col = planSourceColumns[idx];
-                                return col?.column?.format ?? '';
-                            }
+                        formatStrings: getStaticParameterFormatStrings(
+                            group.componentFieldIndices.map(
+                                (idx) => planSourceColumns[idx]?.column?.format
+                            )
                         )
                     }));
                 }
@@ -411,7 +411,9 @@ export const getMappedDataset = (
                                     ? 'aggregation'
                                     : 'grouping'
                             ],
-                            formatStrings: [col.column.format ?? '']
+                            formatStrings: getStaticParameterFormatStrings([
+                                col.column.format
+                            ])
                         });
                     }
                 }

--- a/src/lib/dataset/support-field-provider.ts
+++ b/src/lib/dataset/support-field-provider.ts
@@ -117,6 +117,25 @@ export const createPbiSupportFieldProvider = (
 };
 
 /**
+ * Pre-resolve a parameter group's format strings from static column metadata
+ * — but only when EVERY component has one. A measure with a dynamic format
+ * string carries no static `column.format` (and when any dynamic-format
+ * calculation item exists in the model, Power BI strips static formats from
+ * ALL measure columns, delivering them per-row via
+ * `objects[rowIndex].general.formatString` instead). Returning undefined
+ * makes `buildDataRow` fall back to per-row provider resolution, which
+ * handles both channels. When every component does have a static format the
+ * pre-resolved array is equivalent (the provider checks `source.format`
+ * first) and skips the per-row lookup.
+ */
+export const getStaticParameterFormatStrings = (
+    componentFormats: (string | undefined)[]
+): string[] | undefined =>
+    componentFormats.every((format) => typeof format === 'string')
+        ? (componentFormats as string[])
+        : undefined;
+
+/**
  * Build the per-field DataView source mappings the provider indexes by, one per
  * source column (categories/values) in planSourceColumns order.
  *


### PR DESCRIPTION
## Summary

Fixes the field report from [r/PowerBI](https://www.reddit.com/r/PowerBI/comments/1vhoqs7/comment/p2u77i3/): when any calculation item with a dynamic format string exists in the model (even uninvoked, e.g. `SELECTEDMEASUREFORMATSTRING()`), Deneb stopped emitting `__format`/`__formatted` values for fields consolidated into a field parameter.

## Root cause

Power BI strips static `source.format` from **all** measure columns model-wide whenever a dynamic-format calculation item exists, delivering format strings exclusively per-row via `objects[rowIndex].general.formatString`. Direct fields were unaffected (the provider already falls back per-row), but the field-parameter consolidation path pre-resolved format strings from static `column.format ?? ''` only — so consolidated parameters emitted empty formats. The same gap independently broke measures with measure-level dynamic format strings inside parameters, calc item or not.

## Fix

New `getStaticParameterFormatStrings()` helper: parameter groups pre-resolve format strings only when **every** component carries a static format (pure optimization — provider precedence is `source.format` first, so results are identical); otherwise `formatStrings` is omitted and `buildDataRow` falls back to per-row provider resolution. Applied to both the detection-group and `treatAsParameter` call sites.

## Testing

- New unit validation harness (`dynamic-format-string.test.ts`, 7 tests) covering static, per-row dynamic, and calc-group-stripped scenarios for direct fields and consolidated parameters, running the real plan → provider → row pipeline against Power BI-shaped DataView fragments.
- Manual 8-case matrix in Power BI Desktop (calc item present/absent × static/dynamic/no-format measures × consolidation on/off) against a dedicated harness workbook: all cases correct post-fix, previously-failing parameter cases now emit per-row formats; no change to direct-field behavior.
- `npm run ci:local` green.

The harness workbook (PBIP with calc group, dynamic-format measure, and field parameter) is kept untracked locally for now while we decide how to source-control Desktop-rewritten assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)