### PR TITLE
fix: pin react-dropzone to 14.2.3 to prevent WebView2 crash on drag-and-drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11210,18 +11210,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/file-selector": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
-            "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.7.0"
-            },
-            "engines": {
-                "node": ">= 12"
-            }
-        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -15142,23 +15130,6 @@
             },
             "peerDependencies": {
                 "react": "^19.2.4"
-            }
-        },
-        "node_modules/react-dropzone": {
-            "version": "14.4.1",
-            "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.1.tgz",
-            "integrity": "sha512-QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==",
-            "license": "MIT",
-            "dependencies": {
-                "attr-accept": "^2.2.4",
-                "file-selector": "^2.1.0",
-                "prop-types": "^15.8.1"
-            },
-            "engines": {
-                "node": ">= 10.13"
-            },
-            "peerDependencies": {
-                "react": ">= 16.8 || 18.0.0"
             }
         },
         "node_modules/react-error-boundary": {
@@ -19518,7 +19489,7 @@
                 "monaco-editor": "0.46.0",
                 "overlayscrollbars": "^2.10.1",
                 "overlayscrollbars-react": "^0.5.6",
-                "react-dropzone": "^14.2.3",
+                "react-dropzone": "14.2.3",
                 "react-hotkeys-hook": "^5.2.0",
                 "use-resize-observer": "^9.1.0",
                 "zustand": "^4.5.5"
@@ -19587,6 +19558,18 @@
                 "d3-time": "1 - 2"
             }
         },
+        "packages/app-core/node_modules/file-selector": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
+            "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "packages/app-core/node_modules/internmap": {
             "version": "1.0.1",
             "license": "ISC"
@@ -19594,6 +19577,23 @@
         "packages/app-core/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "license": "MIT"
+        },
+        "packages/app-core/node_modules/react-dropzone": {
+            "version": "14.2.3",
+            "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
+            "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+            "license": "MIT",
+            "dependencies": {
+                "attr-accept": "^2.2.2",
+                "file-selector": "^0.6.0",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">= 10.13"
+            },
+            "peerDependencies": {
+                "react": ">= 16.8 || 18.0.0"
+            }
         },
         "packages/configuration": {
             "name": "@deneb-viz/configuration",

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -72,7 +72,7 @@
         "monaco-editor": "0.46.0",
         "overlayscrollbars": "^2.10.1",
         "overlayscrollbars-react": "^0.5.6",
-        "react-dropzone": "^14.2.3",
+        "react-dropzone": "14.2.3",
         "react-hotkeys-hook": "^5.2.0",
         "use-resize-observer": "^9.1.0",
         "zustand": "^4.5.5"


### PR DESCRIPTION
Fixes #740

## Problem

Dragging a template file onto the Deneb landing page crashed Power BI Desktop with a WebView2 error (browse and copy/paste worked fine). Web service was unaffected.

## Root cause

`packages/app-core/package.json` declared `react-dropzone: ^14.2.3` — a caret range, not a pin. A lockfile regeneration floated it to 14.4.1, which swaps `file-selector` 0.6.0 for 2.x. On drop events, file-selector 2.x calls `DataTransferItem.getAsFileSystemHandle()` (File System Access API) whenever the context is secure; this crashes the WebView2 renderer in Power BI Desktop's sandboxed visual host. Browsers support the API fully, which is why the crash was Desktop-only, and only the drag-and-drop path goes through `fromDataTransferItem` — matching the exact symptom triad in the issue.

## Fix

Exact-pin `react-dropzone` to `14.2.3` and regenerate the lockfile, restoring the 1.9-shipped dependency pair (react-dropzone 14.2.3 + file-selector 0.6.0, plain `getAsFile()`).

## Verification

- Installed `file-selector` contains zero references to `getAsFileSystemHandle`
- `npm run ci:local` passes
- Manual Desktop smoke test: drag-and-drop of a template onto the landing page now imports normally (Power BI Desktop, matching-channel build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)