### PR TITLE
fix: ensure that signal viewer uses optimal width for space

### DIFF
--- a/docs/solutions/logic-errors/deneb-container-scroll-extents-zero-until-first-scroll-2026-08-19.md
+++ b/docs/solutions/logic-errors/deneb-container-scroll-extents-zero-until-first-scroll-2026-08-19.md
@@ -1,0 +1,123 @@
+---
+title: 'denebContainer scrollWidth/scrollHeight stayed 0 until the first scroll: post-embed reconcile fed only the geometry channel'
+date: 2026-08-19
+category: logic-errors
+module: app-core/visual-viewer
+problem_type: logic_error
+component: viewer
+severity: high
+symptoms:
+    - 'Signals tab shows `denebContainer` as `{ height: 440, width: 440, scrollHeight: 0, scrollWidth: 0, ... }` on load'
+    - 'Specs referencing `denebContainer.scrollHeight`/`scrollWidth` compute against 0 until the user scrolls once'
+    - 'Values snap to correct on the first scroll event and stay correct afterwards'
+root_cause: logic_error
+resolution_type: code_fix
+related_components:
+    - vega-runtime/signals
+    - compilation-slice
+tags:
+    - deneb-container
+    - container-signal
+    - scroll-extent
+    - post-embed-reconcile
+    - use-container-signal-owner
+    - viewready
+    - regression-1x-parity
+---
+
+# denebContainer scrollWidth/scrollHeight stayed 0 until the first scroll
+
+## Problem
+
+On visual load the `denebContainer` Vega signal carried the correct box (`width`/`height`) but
+`scrollWidth`/`scrollHeight` were `0` — and stayed `0` until the user scrolled once. Any spec
+sizing or positioning against the content extent was wrong on first paint. This was a 2.0
+regression against 1.x, which populated all six fields at view creation.
+
+## Symptoms
+
+- Signals tab: `{ "height": 440, "width": 440, "scrollHeight": 0, "scrollWidth": 0, "scrollTop": 0, "scrollLeft": 0 }`
+- One scroll event later the same signal reads `scrollHeight: 440, scrollWidth: 440` (or the
+  real content extent) and behaves normally from then on.
+
+## What Didn't Work
+
+- **"Zeros are by design — content extent isn't known at compile time."** Half true: the compile
+  seed (`getDenebContainerSignalFromDimensions` in
+  `packages/vega-runtime/src/lib/signals/deneb-container.ts`) legitimately only carries
+  width/height. But 1.x's `bindContainerSignals` (tag `1.9.1.0`,
+  `packages/vega-runtime/src/lib/view/service.ts`) wrote all six fields from `view.container()`
+  the moment the view existed, so "0 until scroll" was never the shipped contract.
+- **"The ResizeObserver trigger will catch it."** It only fires on physical box changes. A
+  container that is the right size at embed and never resizes gets no observer callback, so a
+  static visual with scrollable content never received a corrective write.
+
+## Solution
+
+`packages/app-core/src/features/visual-viewer/use-container-signal-owner.ts` has two write
+channels — geometry (`refreshGeometry` → `compilation.refreshContainerDimensions`, a cheap
+re-embed of the init dims) and scroll (`refreshScrollSignal`, a guarded six-field
+`setSignalByName`). Trigger 2 (post-embed reconcile on `viewReady`) only fed geometry. It now
+feeds both:
+
+```ts
+// Before
+useEffect(() => {
+    if (!isActive || !viewReady) return;
+    refreshGeometry();
+}, [isActive, viewReady, refreshGeometry]);
+
+// After
+useEffect(() => {
+    if (!isActive || !viewReady) return;
+    refreshGeometry();
+    refreshScrollSignal();
+}, [isActive, viewReady, refreshGeometry, refreshScrollSignal]);
+```
+
+Shipped in PR #746 (`0f0ab656`).
+
+## Why This Works
+
+`viewReady` flips true after `vegaEmbed` resolves, so the canvas is laid out and the measured
+scroll container's `scrollWidth/Height` are real. `refreshScrollSignal` reads all six fields
+from that one element via `getMeasuredContainerRefresh`, which is guarded by value-equality
+(Vega compares signal values by reference, so equal-but-new objects would re-run the dataflow),
+making the extra call a no-op whenever nothing changed. If `refreshGeometry` also triggers a
+re-embed, `viewReady` cycles again and both refreshes re-run against the new view — the
+reconcile still terminates because the second pass is value-equal.
+
+How the regression crept in: the design doc
+(`docs/plans/2026-07-23-001-container-signal-consolidation-design.md`) originally listed the
+post-embed reconcile as a "Full refresh". Revision 2 split the triggers into geometry vs.
+scroll channels and reasoned "the box matches the init by construction, so only offsets change"
+— which quietly assumed the scroll _extents_ were already seeded. They never were.
+
+## Prevention
+
+- Canary in `packages/app-core/src/features/visual-viewer/__tests__/container-signal-owner-wiring.test.ts`
+  asserts Trigger 2's effect body calls `refreshGeometry()` **and** `refreshScrollSignal()`
+  back-to-back. The workspace has no `@testing-library/react`, so hook wiring is locked by
+  source-regex canaries plus behaviour tests on the pure helpers.
+- Rule for this hook: **a lifecycle trigger that establishes a new view must exercise every
+  write channel**, not just the one whose field it "obviously" changes. Splitting channels for
+  cost reasons must be paired with an explicit "who seeds the other channel's fields on view
+  birth?" answer.
+- When a signal is compile-seeded with partial fields, treat the seed as a placeholder and
+  verify in the Signals tab that a fresh load (no interaction) shows fully-populated values.
+- **Known remaining gap (flagged, not fixed):** 1.x also had `view.addResizeListener` refreshing
+  the signal when the _view_ resized without the container changing (e.g. an autosize spec
+  growing after an incremental data update). 2.0 has no equivalent, so `scrollHeight` could go
+  stale in that narrow case until a scroll/resize/re-embed. Wire it via the owner hook if
+  reported — never via `VegaEmbed` (single-owner contract).
+
+## Related Issues
+
+- `docs/solutions/architecture-patterns/single-owner-container-signal-element-measured-truth-2026-07-23.md`
+  — the single-owner / two-channel architecture this bug lives inside.
+- `docs/solutions/ui-bugs/vega-view-stuck-after-host-late-iframe-resize-2026-07-23.md` —
+  the #480 residual fix that introduced the post-embed reconcile trigger.
+- `docs/plans/2026-07-23-001-container-signal-consolidation-design.md` — Revision 2 channel
+  split (the origin of the gap); its later trigger note now matches the code.
+- Historical precursors: #431 (add scrollTop/scrollLeft signals), #475 (pbiContainer
+  height/width wrong on scroll).

--- a/docs/solutions/ui-bugs/fluent-datagrid-fill-column-autofit-container-width-offset-2026-08-19.md
+++ b/docs/solutions/ui-bugs/fluent-datagrid-fill-column-autofit-container-width-offset-2026-08-19.md
@@ -1,0 +1,110 @@
+---
+title: 'Fluent DataGrid fill-the-rest column: per-viewer autoFitColumns plus containerWidthOffset for row padding'
+date: 2026-08-19
+category: ui-bugs
+module: app-core
+problem_type: ui_bug
+component: tooling
+severity: medium
+symptoms:
+    - 'Signals tab value column clips at exactly 500px with empty space to its right'
+    - 'After enabling autoFitColumns, a ~10px horizontal scrollbar appears on a table that fits'
+root_cause: wrong_api
+resolution_type: code_fix
+related_components:
+    - debug-area
+    - data-table
+    - signal-viewer
+tags:
+    - fluent-ui
+    - datagrid
+    - autofitcolumns
+    - containerwidthoffset
+    - column-sizing
+    - debug-pane
+    - signal-viewer
+    - rdt-migration
+---
+
+# Fluent DataGrid fill-the-rest column: per-viewer `autoFitColumns` plus `containerWidthOffset`
+
+## Problem
+
+After `DataTableViewer` moved from react-data-table-component (rdt) to Fluent UI `DataGrid`
+(#723), the debug pane's Signals tab value column stopped filling the available width and
+clipped at a fixed 500px. rdt's `grow: 5` weight had no equivalent once auto-fit was disabled
+grid-wide.
+
+## Symptoms
+
+- Value cell starts at x≈235 and clips at x≈735 — exactly `SIGNAL_VALUE_COLUMN_WIDTH` (500).
+- First fix attempt (autofit on) produced a phantom horizontal scrollbar of ~10px on a table
+  that visibly fits its container.
+
+## What Didn't Work
+
+- **Cell-level CSS (`flex: 1`, `width: 100%` on the value cell).** Fluent tracks column widths
+  in DataGrid's own sizing state (`node_modules/@fluentui/react-table/lib/utils/columnResizeUtils.js`)
+  and applies them as inline `width/minWidth/maxWidth`; class-level CSS on the cell is not the
+  lever.
+- **Just flipping `autoFitColumns` on for everyone.** The dataset viewer depends on
+  worker-measured widths overflowing horizontally (see the 2026-07-20 landmines doc, item 4);
+  autofit would compress those to `minWidth`.
+- **Autofit alone.** `adjustColumnWidthsToFitContainer` makes column widths sum to the
+  _measured grid width_, but our header/body rows carry `paddingLeft: DATA_TABLE_ROW_PADDING_LEFT`
+  (10px). Fitted row = container + 10px → scrollbar.
+
+## Solution
+
+1. Opt-in prop on `DataTableViewer` (`data-table-viewer-types.ts`), default `false`; the signal
+   viewer passes it:
+
+    ```tsx
+    // data-table.tsx — was hard-coded { autoFitColumns: false }
+    resizableColumnsOptions={{ autoFitColumns }}
+
+    // signal-viewer.tsx
+    <DataTableViewer columns={columns} data={values} autoFitColumns />
+    ```
+
+    With autofit on, Fluent stretches the **last** column to absorb remaining width and
+    compresses toward `minWidth` when the container is narrower — the `grow` semantics we lost.
+
+2. Tell autofit about the row padding using DataGrid's `containerWidthOffset` (documented as
+   "make sure the columns don't overflow the table"):
+
+    ```tsx
+    containerWidthOffset={-DATA_TABLE_ROW_PADDING_LEFT}
+    ```
+
+    Set once in `data-table.tsx`; inert for non-autofit viewers (only autofit consumes the
+    container width).
+
+Shipped in `4ff259d9`.
+
+## Why This Works
+
+Fluent's autofit is a reducer over `containerWidth` (from `useMeasureElement` on the grid) plus
+`containerWidthOffset`. Subtracting exactly our own row padding makes the fitted row land
+flush; there is no need for an artificial cap. Keeping the flag per-viewer preserves the
+dataset viewer's honour-measured-widths behaviour while giving two-column "key / value" tables
+the fill behaviour they had under rdt.
+
+## Prevention
+
+- **Rule:** any `DataGrid`/`DataTableViewer` instance that turns on `autoFitColumns` must also
+  account for our row chrome via `containerWidthOffset` (currently `-DATA_TABLE_ROW_PADDING_LEFT`
+  from `packages/app-core/src/features/debug-area/constants.ts`). If row padding changes, the
+  offset changes with it — keep them referencing the same constant.
+- Keep `autoFitColumns` opt-in at the viewer level, never grid-wide; the dataset/source tabs'
+  horizontal overflow is load-bearing.
+- Diagnose Fluent width issues from the sizing state, not CSS: read
+  `columnResizeUtils.js` (`adjustColumnWidthsToFitContainer`, `getTotalWidth` includes 16px
+  per-column padding) and check for exact-pixel matches against your `idealWidth`.
+
+## Related Issues
+
+- `docs/solutions/ui-bugs/fluent-datagrid-migration-landmines-2026-07-20.md` — item 4 is the
+  "disable autofit" rule this doc refines to per-viewer.
+- `docs/solutions/tooling-decisions/debug-table-fluent-datagrid-over-rdt-v8-2026-07-20.md` —
+  the migration decision that created `DataTableViewer`.

--- a/docs/solutions/ui-bugs/fluent-datagrid-migration-landmines-2026-07-20.md
+++ b/docs/solutions/ui-bugs/fluent-datagrid-migration-landmines-2026-07-20.md
@@ -59,11 +59,11 @@ All were diagnosed by reading the installed library source under
    When sorting is handled externally (the grid only ever receives one page of rows, so its
    internal compare must not be used), the no-op must still declare two parameters:
 
-   ```ts
-   compare: column.sortable
-       ? (_a: unknown, _b: unknown) => 0 // arity 2 → header sortable
-       : () => 0 // arity 0 → suppresses the sort affordance entirely
-   ```
+    ```ts
+    compare: column.sortable
+        ? (_a: unknown, _b: unknown) => 0 // arity 2 → header sortable
+        : () => 0; // arity 0 → suppresses the sort affordance entirely
+    ```
 
 2. **The `extra-small` size variant drops the built-in row border.** `medium` and `small`
    `TableRow` variants carry `borderBottom`; `extra-small` sets only `fontSize`. Any divider
@@ -77,6 +77,11 @@ All were diagnosed by reading the installed library source under
    `resizableColumnsOptions.autoFitColumns` defaults to `true`, shrinking columns toward
    `minWidth` to fit the container. To honour pre-measured pixel widths with horizontal
    overflow (classic data-table behavior): `resizableColumnsOptions={{ autoFitColumns: false }}`.
+   Per-viewer exception (2026-08-19): a two-column "key / value" table that wants rdt's
+   `grow` fill opts back in via `DataTableViewer`'s `autoFitColumns` prop AND must pass
+   `containerWidthOffset={-DATA_TABLE_ROW_PADDING_LEFT}` or the row padding produces a
+   phantom horizontal scrollbar — see
+   `fluent-datagrid-fill-column-autofit-container-width-offset-2026-08-19.md`.
 
 ## Why This Works
 

--- a/packages/app-core/src/features/debug-area/components/data-table/__tests__/data-table-autofit-wiring.test.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/__tests__/data-table-autofit-wiring.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Structural canary for the per-viewer `autoFitColumns` contract
+ * (docs/solutions/ui-bugs/fluent-datagrid-fill-column-autofit-container-width-offset-2026-08-19.md).
+ *
+ * Behavioural coverage of Fluent's autofit under wide/narrow containers is
+ * not achievable in this workspace: vitest runs in the `node` environment
+ * with no DOM/ResizeObserver and no `@testing-library/react`, and
+ * `@fluentui/react-table`'s exports map hides the
+ * `adjustColumnWidthsToFitContainer` reducer from a contract test. This
+ * locks the wiring instead, so the two regressions it guards (value column
+ * clipped at its ideal width; phantom horizontal scrollbar from unoffset
+ * row padding) cannot silently return through a refactor.
+ */
+const read = (...segments: string[]) =>
+    readFileSync(resolve(__dirname, '..', ...segments), 'utf8');
+
+describe('DataTableViewer autoFitColumns wiring', () => {
+    const dataTableSource = read('data-table.tsx');
+    const typesSource = read('data-table-viewer-types.ts');
+
+    it('exposes autoFitColumns as an opt-in prop that defaults to false', () => {
+        expect(typesSource).toMatch(/autoFitColumns\?: boolean;/);
+        expect(dataTableSource).toMatch(/autoFitColumns = false/);
+    });
+
+    it('threads the prop into Fluent instead of hard-coding autofit off', () => {
+        expect(dataTableSource).toMatch(
+            /resizableColumnsOptions=\{\{ autoFitColumns \}\}/
+        );
+        expect(dataTableSource).not.toMatch(/autoFitColumns: false/);
+    });
+
+    it('offsets our row padding so an autofitted row does not overflow', () => {
+        // Fluent sizes autofitted columns to the measured grid width; our
+        // rows carry DATA_TABLE_ROW_PADDING_LEFT, so the fitted row would
+        // overflow by exactly that much without this offset.
+        expect(dataTableSource).toMatch(
+            /containerWidthOffset=\{\s*-DATA_TABLE_ROW_PADDING_LEFT\s*\}/
+        );
+    });
+});
+
+describe('viewer opt-in', () => {
+    it('signal viewer opts in (value column fills remaining width)', () => {
+        const source = read('..', 'signal-viewer', 'signal-viewer.tsx');
+        expect(source).toMatch(
+            /<DataTableViewer[\s\S]*?autoFitColumns[\s\S]*?\/>/
+        );
+    });
+
+    it.each(['data-tab.tsx', 'source-tab.tsx'])(
+        'dataset viewer %s does NOT opt in (worker-measured widths overflow horizontally)',
+        (file) => {
+            const source = read('..', 'dataset-viewer', file);
+            expect(source).not.toMatch(/autoFitColumns/);
+        }
+    );
+});

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table-viewer-types.ts
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table-viewer-types.ts
@@ -56,4 +56,11 @@ export interface DataTableViewerProps<T> {
     onChangePage?: (page: number) => void;
     /** Initial (1-based) page to display. */
     paginationDefaultPage?: number;
+    /**
+     * Stretch/compress columns to fill the container (Fluent's
+     * `autoFitColumns`). Off by default so worker-measured widths are
+     * honoured and overflow scrolls horizontally; the signal viewer opts in
+     * so its value column fills the remaining width (the old `grow` weights).
+     */
+    autoFitColumns?: boolean;
 }

--- a/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
+++ b/packages/app-core/src/features/debug-area/components/data-table/data-table.tsx
@@ -117,7 +117,8 @@ export const DataTableViewer = ({
     defaultSortAsc = false,
     onSort,
     onChangePage,
-    paginationDefaultPage
+    paginationDefaultPage,
+    autoFitColumns = false
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }: DataTableViewerProps<any>) => {
     const { debugTableRowsPerPage } = useDenebState((state) => ({
@@ -288,14 +289,21 @@ export const DataTableViewer = ({
                                 sortState={sortState}
                                 onSortChange={handleSortChange}
                                 resizableColumns
-                                // Honour the worker-measured widths instead of
-                                // compressing columns to fit the container —
-                                // cumulative overflow scrolls horizontally in
-                                // the enclosure, matching the previous rdt
-                                // behaviour.
-                                resizableColumnsOptions={{
-                                    autoFitColumns: false
-                                }}
+                                // Default: honour the worker-measured widths
+                                // instead of compressing columns to fit the
+                                // container — cumulative overflow scrolls
+                                // horizontally in the enclosure, matching the
+                                // previous rdt behaviour. Viewers with a
+                                // "fill the rest" column opt in.
+                                resizableColumnsOptions={{ autoFitColumns }}
+                                // Autofit sizes columns to the measured grid
+                                // width, but our rows carry a left padding —
+                                // without subtracting it the fitted row
+                                // overflows by exactly that much and shows a
+                                // needless horizontal scrollbar.
+                                containerWidthOffset={
+                                    -DATA_TABLE_ROW_PADDING_LEFT
+                                }
                                 columnSizingOptions={sizingOptions}
                                 // 24px rows — matches DATA_TABLE_ROW_HEIGHT
                                 // and rdt's `dense` chrome; Fluent's default

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/signal-viewer.tsx
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/signal-viewer.tsx
@@ -47,6 +47,9 @@ export const SignalViewer = ({ renderId }: SignalViewerProps) => {
                             columns={columns}
                             data={values}
                             defaultSortFieldId={undefined}
+                            // Value column fills the remaining width instead
+                            // of clipping at its fixed ideal width.
+                            autoFitColumns
                         />
                     </div>
                 </div>
@@ -84,9 +87,9 @@ const getTableColumns = (
             id: 'key',
             selector: (row) => row.key,
             sortable: true,
-            // Fixed ideal widths in a ~2:5 ratio replace the previous
-            // `grow` weights (auto-fit is disabled grid-wide, so these are
-            // actual pixel sizes, user-resizable).
+            // Ideal widths in a ~2:5 ratio replace the previous `grow`
+            // weights; with `autoFitColumns` on, the last (value) column
+            // absorbs any remaining container width.
             width: SIGNAL_KEY_COLUMN_WIDTH,
             cell: (row) => (
                 <DataTableCell


### PR DESCRIPTION
Discovered during documentation of #745