### PR TITLE
fix: ensure that signal values aren't stale on view remount

### DIFF
--- a/docs/solutions/logic-errors/deneb-container-scroll-extents-zero-until-first-scroll-2026-08-19.md
+++ b/docs/solutions/logic-errors/deneb-container-scroll-extents-zero-until-first-scroll-2026-08-19.md
@@ -75,7 +75,22 @@ useEffect(() => {
 }, [isActive, viewReady, refreshGeometry, refreshScrollSignal]);
 ```
 
-Shipped in PR #746 (`0f0ab656`).
+Shipped in PR #746 (`0f0ab656`) — **incomplete on its own**. Zeros still appeared after some
+compiles and on first editor open, because `useVegaEmbed` re-embeds on deep change of
+`[spec, options]` while the `viewReady` window (`shouldOpenEmbedWindow`) only opens on a spec
+change. An options-only re-embed (zoom/`embedScaleFactor`, `logLevel`, `renderMode`) births a
+fresh view with the 0-seed and never toggles `viewReady`, so Trigger 2 never re-fired. Second
+part of the fix (PR #747): key the reconcile on `state.interface.renderId` as well — the token
+`handleEmbed` bumps for **every** fresh view:
+
+```ts
+const renderId = useDenebState((state) => state.interface.renderId);
+useEffect(() => {
+    if (!isActive || !viewReady) return;
+    refreshGeometry();
+    refreshScrollSignal();
+}, [isActive, viewReady, renderId, refreshGeometry, refreshScrollSignal]);
+```
 
 ## Why This Works
 
@@ -99,6 +114,11 @@ scroll channels and reasoned "the box matches the init by construction, so only 
   asserts Trigger 2's effect body calls `refreshGeometry()` **and** `refreshScrollSignal()`
   back-to-back. The workspace has no `@testing-library/react`, so hook wiring is locked by
   source-regex canaries plus behaviour tests on the pure helpers.
+- Diagnostic shortcut: a _measured_ write can never yield `scrollHeight: 0` alongside a non-zero
+  `height` (an element with a box has `scrollHeight >= clientHeight`). Seeing that shape means the
+  write was **skipped**, not miscomputed — go hunt the guard/trigger, not the measurement.
+- `viewReady` is the embed-window flag, not a per-view token; `renderId` is. Anything that must
+  run "once per fresh view" keys on `renderId`.
 - Rule for this hook: **a lifecycle trigger that establishes a new view must exercise every
   write channel**, not just the one whose field it "obviously" changes. Splitting channels for
   cost reasons must be paired with an explicit "who seeds the other channel's fields on view

--- a/docs/solutions/logic-errors/signal-viewer-stale-memo-on-view-replacement-2026-05-20.md
+++ b/docs/solutions/logic-errors/signal-viewer-stale-memo-on-view-replacement-2026-05-20.md
@@ -6,26 +6,26 @@ module: app-core/features/debug-area/signal-viewer
 problem_type: logic_error
 component: tooling
 symptoms:
-  - Signal Viewer table displays the previous spec's signal value after re-running a spec with a changed `params[].value`
-  - "Switching to the Data tab and back forces the cell to refresh (component unmount/remount makes `useState`'s lazy initializer re-read from the new view)"
-  - "No listener event fires for signals whose new value was baked in at View construction, so the cell stays at the prior view's value indefinitely"
-  - "No console errors, no listener exceptions, no missing renders — the cell silently caches a stale display string"
+    - Signal Viewer table displays the previous spec's signal value after re-running a spec with a changed `params[].value`
+    - "Switching to the Data tab and back forces the cell to refresh (component unmount/remount makes `useState`'s lazy initializer re-read from the new view)"
+    - "No listener event fires for signals whose new value was baked in at View construction, so the cell stays at the prior view's value indefinitely"
+    - 'No console errors, no listener exceptions, no missing renders — the cell silently caches a stale display string'
 root_cause: logic_error
 resolution_type: code_fix
 severity: medium
 related_components:
-  - vega-react (VegaViewServices.getSignalByName)
-  - app-core/components/visual-viewer/components/vega-embed.tsx (renderId bump on handleEmbed)
-  - react-data-table-component (preserves row component instances across re-renders by key)
+    - vega-react (VegaViewServices.getSignalByName)
+    - app-core/components/visual-viewer/components/vega-embed.tsx (renderId bump on handleEmbed)
+    - react-data-table-component (preserves row component instances across re-renders by key)
 tags:
-  - react-usememo
-  - stale-state
-  - render-id
-  - vega-view
-  - signal-viewer
-  - debug-pane
-  - view-replacement
-  - missing-dependency
+    - react-usememo
+    - stale-state
+    - render-id
+    - vega-view
+    - signal-viewer
+    - debug-pane
+    - view-replacement
+    - missing-dependency
 ---
 
 # Signal Viewer shows stale signal values after spec re-run due to incomplete useMemo deps
@@ -137,10 +137,35 @@ Cover at minimum: post-fix dep array has 3 slots; `renderId` change alone recomp
 
 This is the `useMemo` corollary of the `useEffect` rule in [`docs/solutions/best-practices/lifecycle-owns-effect-rebind-identity-token-2026-04-28.md`](../best-practices/lifecycle-owns-effect-rebind-identity-token-2026-04-28.md): `renderId` is owned by `handleEmbed` and consumed by every hook keyed to the current `View`, regardless of which hook variant (`useEffect`, `useMemo`, `useCallback`) the consumer happens to be.
 
+## Addendum (2026-08-19): same-commit write race — re-read after re-attaching
+
+Recomputing the memo on `renderId` was not sufficient on its own. `denebContainer` showed the
+0-seed (`scrollHeight: 0` beside a non-zero `height`) after every recompile, and remounting the
+cell showed the correct value — so the _view_ was right and the _cell_ was stale.
+
+Mechanism: `handleEmbed` batches `setViewReady(true)` + `generateRenderId()` into one commit.
+In that commit `SignalValue` renders (memo reads the fresh view's 0-seed), then passive effects
+run in tree order — `VisualViewer`'s container-signal owner effect writes the seeded signal
+first, and Vega dispatches signal listeners **synchronously** inside `runAsync` (evaluate runs
+to its first `await`); only afterwards does `SignalValue`'s `renderId` effect attach the
+new-view listener. No later event, no dep change → stale until remount.
+
+Fix (`signal-value.tsx`, `renderId` effect): after `cycleListeners(viewAtEntry)`, force a re-read
+with a fresh-reference state write:
+
+```ts
+setSignalValue(() => ({ value: getSignalValues().display }));
+```
+
+Rule: an effect that re-attaches a listener to a replaced source must also re-read the current
+value — anything written by earlier-in-tree effects in the same commit is already gone as an
+event. Canary: `signal-value-memo-deps.test.ts` ("re-read after listener cycle").
+
 ## Related Issues
 
 - [`docs/solutions/best-practices/lifecycle-owns-effect-rebind-identity-token-2026-04-28.md`](../best-practices/lifecycle-owns-effect-rebind-identity-token-2026-04-28.md) — establishes `renderId` as the single-owner identity token for `useEffect` rebinding on Vega `View` replacement. This doc extends the same rule to `useMemo` consumers.
 - [`docs/solutions/best-practices/dedup-synthetic-identity-token-rebind-trigger-2026-04-28.md`](../best-practices/dedup-synthetic-identity-token-rebind-trigger-2026-04-28.md) — companion doc on the write side of the same token; covers dedup of `renderId` bumps.
 - [`docs/solutions/best-practices/singleton-worker-addEventListener-ownership-filter-2026-04-28.md`](../best-practices/singleton-worker-addEventListener-ownership-filter-2026-04-28.md) — same family ("closure captured across lifetimes leaks stale state"), different mechanism (worker handler ownership).
 - [`docs/solutions/ui-bugs/viewer-bounce-on-editor-exit-2026-05-04.md`](../ui-bugs/viewer-bounce-on-editor-exit-2026-05-04.md) and [`docs/solutions/ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md`](../ui-bugs/freeze-on-viewer-editor-transition-2026-05-01.md) — touch the Vega `View` replacement boundary from the mount/teardown ordering angle (different symptom, same boundary).
+- [`docs/solutions/logic-errors/deneb-container-scroll-extents-zero-until-first-scroll-2026-08-19.md`](./deneb-container-scroll-extents-zero-until-first-scroll-2026-08-19.md) — the owner-side seed whose same-commit write this addendum's race missed.
 - [`docs/solutions/best-practices/local-green-is-not-ci-or-production-green-2026-07-13.md`](../best-practices/local-green-is-not-ci-or-production-green-2026-07-13.md) — the canonical node-env-vitest reference; the pure dep-array characterization approach used here (no `@testing-library/react`) is written up there as the house testing convention.

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/__tests__/signal-value-memo-deps.test.ts
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/__tests__/signal-value-memo-deps.test.ts
@@ -130,7 +130,7 @@ describe('SignalValue renderId effect — re-read after listener cycle', () => {
             'utf8'
         );
         expect(source).toMatch(
-            /cycleListeners\(viewAtEntry\);(?:\s|\/\/[^\n]*)*setSignalValue\(\(\) => \(\{ value: getSignalValues\(\)\.display \}\)\);\s*return \(\) => \{\s*removeListener\(viewAtEntry\);\s*\};\s*\}, \[renderId\]\);/
+            /cycleListeners\(viewAtEntry\);[\s\S]*?setSignalValue\(\(\) => \(\{ value: getSignalValues\(\)\.display \}\)\);\s*return \(\) => \{\s*removeListener\(viewAtEntry\);\s*\};\s*\}, \[renderId\]\);/
         );
     });
 });

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/__tests__/signal-value-memo-deps.test.ts
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/__tests__/signal-value-memo-deps.test.ts
@@ -59,8 +59,10 @@ const buildPostFixDeps = (
  * the regression — a `renderId`-only change must NOT recompute under this
  * shape.
  */
-const buildPreFixDeps = (getSignalValues: () => unknown, signalValue: unknown) =>
-    [getSignalValues, signalValue] as const;
+const buildPreFixDeps = (
+    getSignalValues: () => unknown,
+    signalValue: unknown
+) => [getSignalValues, signalValue] as const;
 
 describe('SignalValue currentValues memo — dep-array characterization', () => {
     it('recomputes when renderId changes (view replacement on re-run — the bug case)', () => {
@@ -107,5 +109,28 @@ describe('SignalValue currentValues memo — dep-array characterization', () => 
         const prev = buildPreFixDeps(fn, 5);
         const next = buildPreFixDeps(fn, 5);
         expect(shouldMemoRecompute(prev, next)).toBe(false);
+    });
+});
+
+/**
+ * Structural canary for the renderId effect. Re-attaching the listener is not
+ * enough: the owner hook seeds `denebContainer` in the SAME commit's effect
+ * phase, and VisualViewer's effects run before the debug pane's in tree order,
+ * so the write (and Vega's synchronous listener dispatch inside `runAsync`)
+ * completes before the new-view listener is attached. The effect must
+ * therefore also re-read the value with a fresh-reference state write so the
+ * memo recomputes against the current view.
+ */
+describe('SignalValue renderId effect — re-read after listener cycle', () => {
+    it('re-reads the signal value (fresh object) after cycling listeners on renderId change', async () => {
+        const { readFileSync } = await import('node:fs');
+        const { resolve } = await import('node:path');
+        const source = readFileSync(
+            resolve(__dirname, '..', 'signal-value.tsx'),
+            'utf8'
+        );
+        expect(source).toMatch(
+            /cycleListeners\(viewAtEntry\);(?:\s|\/\/[^\n]*)*setSignalValue\(\(\) => \(\{ value: getSignalValues\(\)\.display \}\)\);\s*return \(\) => \{\s*removeListener\(viewAtEntry\);\s*\};\s*\}, \[renderId\]\);/
+        );
     });
 });

--- a/packages/app-core/src/features/debug-area/components/signal-viewer/signal-value.tsx
+++ b/packages/app-core/src/features/debug-area/components/signal-viewer/signal-value.tsx
@@ -162,6 +162,14 @@ export const SignalValue = ({
         const viewAtEntry = VegaViewServices.getView();
         logDebug(`Render ID has changed to ${renderId}. Updating...`);
         cycleListeners(viewAtEntry);
+        // Re-read after attaching: signal writes made in this same commit's
+        // effect phase by earlier-in-tree effects (the container-signal owner
+        // seeding `denebContainer` on a fresh view — Vega dispatches those
+        // listeners synchronously inside `runAsync`) happened BEFORE our
+        // listener existed, and this render's memo already captured the
+        // pre-write value. Fresh object reference so `useState` cannot
+        // bail out on an equal display string.
+        setSignalValue(() => ({ value: getSignalValues().display }));
         return () => {
             removeListener(viewAtEntry);
         };

--- a/packages/app-core/src/features/visual-viewer/__tests__/container-signal-owner-wiring.test.ts
+++ b/packages/app-core/src/features/visual-viewer/__tests__/container-signal-owner-wiring.test.ts
@@ -33,6 +33,17 @@ describe('useContainerSignalOwner wiring', () => {
         );
     });
 
+    it('post-embed reconcile re-fires per fresh view (renderId), not only per viewReady toggle', () => {
+        // `useVegaEmbed` re-embeds on deep change of [spec, options] but the
+        // viewReady window only opens on spec change — an options-only
+        // re-embed (zoom, log level, render mode) births a view with the
+        // 0-seeded scroll fields and no viewReady toggle. `renderId` bumps
+        // on EVERY handleEmbed, so it must be in the reconcile's deps.
+        expect(hookSource).toMatch(
+            /refreshScrollSignal\(\);\s*\}, \[\s*isActive,\s*viewReady,\s*renderId,/
+        );
+    });
+
     it('registers the debounced ResizeObserver on the measured container', () => {
         expect(hookSource).toMatch(/observeContainerResize\(/);
     });

--- a/packages/app-core/src/features/visual-viewer/use-container-signal-owner.ts
+++ b/packages/app-core/src/features/visual-viewer/use-container-signal-owner.ts
@@ -87,6 +87,12 @@ export const useContainerSignalOwner = ({
     const refreshContainerDimensions = useDenebState(
         (state) => state.compilation.refreshContainerDimensions
     );
+    // Per-view token: bumped in `handleEmbed` for EVERY fresh Vega view.
+    // `viewReady` alone is not enough — it only toggles when the spec
+    // deep-changes, but `useVegaEmbed` also re-embeds on options-only
+    // changes (zoom/embedScaleFactor, logLevel, renderMode), birthing a
+    // view with the 0-seeded scroll fields and no viewReady transition.
+    const renderId = useDenebState((state) => state.interface.renderId);
 
     /**
      * Geometry channel: route box changes through the compilation
@@ -132,12 +138,20 @@ export const useContainerSignalOwner = ({
     // fields. The compile-time init only carries width/height (scroll
     // extents are 0), so without this write `scrollWidth`/`scrollHeight`
     // would stay 0 until the user's first scroll (1.x populated all six
-    // fields on view creation).
+    // fields on view creation). Keyed on `renderId` so it re-runs for
+    // every fresh view, including options-only re-embeds that never
+    // toggle `viewReady`.
     useEffect(() => {
         if (!isActive || !viewReady) return;
         refreshGeometry();
         refreshScrollSignal();
-    }, [isActive, viewReady, refreshGeometry, refreshScrollSignal]);
+    }, [
+        isActive,
+        viewReady,
+        renderId,
+        refreshGeometry,
+        refreshScrollSignal
+    ]);
 
     // Trigger 3: throttled scroll → signal write (gated on viewReady —
     // before the view exists there is no signal to update).


### PR DESCRIPTION
Found while documenting #745