### PR TITLE
feat: compact JSONC formatting (including comments) (#578)

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -292,6 +292,11 @@
                     "type": {
                         "numeric": true
                     }
+                },
+                "formattingMaxLineLength": {
+                    "type": {
+                        "numeric": true
+                    }
                 }
             }
         },

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -252,7 +252,7 @@ Behaviour to be aware of:
 
 - **Compaction rule** — a container is written on one line when its single-line form (including indent, `"key": ` prefix and trailing comma) fits within the max line length and contains no comments; otherwise one child per line. Nested containers are decided independently.
 - **Comments force expansion** — any comment inside a container expands it and every ancestor. Comments above a value stay above it; same-line trailing comments stay on the line (a comment following `1, ` on the same line trails `1`, not the next element); comments after the last entry stay before the closer. A comment between a key and its value is moved above the next entry (or to the end of the object if there is none).
-- **Range formatting snaps outward** — the smallest complete value or property containing the selection is reformatted. Selecting a key or value reformats the whole property.
+- **Range formatting snaps outward** — the smallest complete value or property containing the selection is reformatted. Selecting a key or value reformats the whole property. It widens further when the selection's span contains a comment that only an ancestor's rendering can carry (e.g. a comment between a key and its value belongs to the next entry) — the edit grows until no comment would be lost, at worst reformatting the whole document.
 - **Invalid JSON is left untouched** — nothing happens until parse errors (including trailing commas) are resolved.
 - **Layout is deterministic** — existing line breaks are not preserved; formatting is idempotent. Output adopts the editor document's existing line-ending style.
 - **Literals are copied verbatim** — `1.0` stays `1.0`; escapes are not rewritten.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -244,6 +244,21 @@ Features in `packages/app-core/src/features/` must not cross-import from sibling
 
 The `import-x/no-cycle` ESLint rule (via `eslint-plugin-import-x`) warns on circular import chains. Run `npm run eslint` to check for violations. Note that this rule only detects **circular** imports — the broader boundary rule (no sibling-to-sibling imports, even non-circular) is enforced by code review. Some pre-existing violations exist and are being cleaned up incrementally.
 
+### JSON formatting (compact JSONC)
+
+All spec/config formatting — Format Document / Format Selection in the editor, and template import/export — goes through `formatJsoncCompact` / `formatJsoncCompactRange` in `@deneb-viz/utils/jsonc`. It walks the jsonc-parser AST and applies the same fit rule as `json-stringify-pretty-compact` (Vega Editor's formatter), but preserves comments. The Monaco JSON worker's own formatter is disabled in `editor-init-service.ts`; the `formattingMaxLineLength` editor property (default 80, range 40–200) sets the width.
+
+Behaviour to be aware of:
+
+- **Compaction rule** — a container is written on one line when its single-line form (including indent, `"key": ` prefix and trailing comma) fits within the max line length and contains no comments; otherwise one child per line. Nested containers are decided independently.
+- **Comments force expansion** — any comment inside a container expands it and every ancestor. Comments above a value stay above it; same-line trailing comments stay on the line (a comment following `1, ` on the same line trails `1`, not the next element); comments after the last entry stay before the closer. A comment between a key and its value is moved above the next entry (or to the end of the object if there is none).
+- **Range formatting snaps outward** — the smallest complete value or property containing the selection is reformatted. Selecting a key or value reformats the whole property.
+- **Invalid JSON is left untouched** — nothing happens until parse errors (including trailing commas) are resolved.
+- **Layout is deterministic** — existing line breaks are not preserved; formatting is idempotent. Output adopts the editor document's existing line-ending style.
+- **Literals are copied verbatim** — `1.0` stays `1.0`; escapes are not rewritten.
+
+Design record: [docs/brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md](brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md).
+
 ## 6. Feature Flags
 
 JSON feature flags are defined in `config/features.json` and can be overridden in `config/package-custom.json` for custom builds. These are primarily used to gate visual behaviors that must remain stable and off by default in the certified build.

--- a/docs/brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md
+++ b/docs/brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md
@@ -1,0 +1,157 @@
+---
+date: 2026-08-21
+topic: compact-jsonc-formatting
+issue: 578
+target: 2.1
+---
+
+# Compact JSONC Formatting
+
+## Summary
+
+Replace the verbose, one-value-per-line JSON formatting that Deneb applies today (jsonc-parser `format()`) with a comment-preserving compact formatter that packs short objects and arrays onto a single line, Vega Editor style. The maximum line length is a new user setting (`formattingMaxLineLength`, default 80, range 40–200) in the Advanced editor → JSON editor property group. The formatter is applied everywhere Deneb formats spec/config text: the editor's Format Document command, a new Format Selection capability, and template import/export. No new dependencies.
+
+---
+
+## Problem Frame
+
+Issue #578: users find Deneb's formatted specs long and hard to read compared to Vega Editor, and round-trip through Vega Editor to get compact output. Vega Editor uses `json-stringify-pretty-compact` (`maxLength`-aware) but strips comments to do so; Deneb moved to jsonc-parser's `format()` in 1.7 to support comments, and that API exposes no line-length control (its options are `tabSize`, `insertSpaces`, `eol`, `insertFinalNewline`, `keepLines`). The Monaco JSON worker formats via the same library, so there is no configuration-only fix.
+
+What has changed since the issue was triaged: jsonc-parser exposes a full AST with source offsets (`parseTree`), comment locations (`visit({ onComment })`), and node lookup (`findNodeAtOffset`). That is enough to implement the pretty-compact algorithm directly over JSONC, preserving comments, in a self-contained function. Monaco allows the worker's formatter to be disabled (`setModeConfiguration`) and replaced with a registered provider.
+
+---
+
+## Requirements
+
+### R1 — Compact formatter (`@deneb-viz/utils`)
+
+Add to `packages/utils/src/lib/jsonc.ts`:
+
+```ts
+export interface JsoncCompactFormatOptions {
+    tabSize: number;
+    maxLineLength: number;
+}
+export interface JsoncTextEdit {
+    offset: number;
+    length: number;
+    content: string;
+}
+export const formatJsoncCompact = (
+    content: string,
+    options: JsoncCompactFormatOptions
+): string;
+export const formatJsoncCompactRange = (
+    content: string,
+    range: { offset: number; length: number },
+    options: JsoncCompactFormatOptions
+): JsoncTextEdit | undefined;
+```
+
+`formatJsoncCompact` is `formatJsoncCompactRange` applied to the root node, with the edit applied. Both are pure functions of their inputs.
+
+**Algorithm**
+
+1. `parseTree(content, errors)`. If `errors` is non-empty or there is no root node, the document is returned unchanged (`formatJsoncCompactRange` returns `undefined`). Broken JSON is never reformatted.
+2. Collect comments with `visit(content, { onComment })` as `{ offset, length, text }`. Each comment is attached to a node:
+   - **Leading** — the comment precedes a node's first token (on an earlier line or the same line before it): attached to that node, emitted on its own line(s) above the node at the node's indent.
+   - **Trailing** — the comment sits on the same line as the end of a preceding value/property: attached to that node, emitted after the node (and its comma, if any) on the same line.
+   - Comments after the last token of the document are emitted at the end, each on its own line.
+   - Block comments (`/* */`) spanning multiple lines have their inner lines re-indented to the current indent. Line comments (`//`) and single-line block comments are emitted verbatim.
+3. `render(node, depth)`:
+   - **Scalars** (`string`, `number`, `boolean`, `null`): the raw source slice `content.substr(node.offset, node.length)`. This preserves `1.0`, `1e3`, unicode escapes, and any other lexical detail `JSON.parse` would normalise away.
+   - **Property**: `render(key) + ": " + render(value)`.
+   - **Object / array**: attempt the flat form first — `{"a": 1, "b": [1, 2]}` / `[1, 2, 3]` (a space after `:` and after `,`, no padding inside braces/brackets — matches `json-stringify-pretty-compact`). Accept the flat form when `depth * tabSize + prefixLength + flat.length <= maxLineLength` **and** no comment is attached to any node in the subtree. `prefixLength` is the length of the `"key": ` prefix when the container is a property value, otherwise 0. Otherwise render expanded: opener, each child on its own line at `depth + 1`, comma separators, closer at `depth`.
+   - Empty containers render as `{}` / `[]`.
+4. Output uses `\n` line endings, `tabSize` spaces per indent, and no trailing newline (matches the current `getTextFormattedAsJsonC` output shape).
+
+**Range formatting**
+
+1. Locate `findNodeAtOffset(root, range.offset)` and `findNodeAtOffset(root, range.offset + range.length)`; walk `.parent` to their nearest common ancestor. If the ancestor is a property's key or value, use the whole `property` node. This is the smallest complete node containing the selection.
+2. Depth is structural: the count of `object`/`array` ancestors above the node. Existing whitespace is not consulted.
+3. Render that node at that depth, bounding comment collection to its span, and return a single edit covering exactly `[node.offset, node.offset + node.length)`.
+
+### R2 — Setting: `formattingMaxLineLength`
+
+| Layer | Change |
+| --- | --- |
+| `capabilities.json` | `objects.editor.properties.formattingMaxLineLength`, type `numeric` |
+| `src/lib/persistence/model/settings-editor.ts` | `NumUpDown`, min 40 / max 200 / default 80, in the JSON editor group (alongside font size, word wrap, line numbers) |
+| `stringResources/en-US/resources.resjson` | `Objects_Editor_FormattingMaxLineLength` ("Max line length when formatting") and `_Description` |
+| `packages/configuration/src/index.ts` | `EDITOR_DEFAULTS.formattingMaxLineLength: { default: 80, min: 40, max: 200 }` |
+| `src/lib/state/editor-preferences-sync-mappings.ts` | Map to new slice key `jsonEditorFormattingMaxLineLength` |
+| `packages/app-core/src/state/editor-preferences.ts` | Add `jsonEditorFormattingMaxLineLength: number` to `EditorPreferencesSliceProperties` and the initial state |
+
+Pattern is identical to `debouncePeriod`; no new UI beyond the formatting-pane property.
+
+### R3 — Monaco integration (`packages/app-core/src/lib/monaco/editor-init-service.ts`)
+
+1. `monaco.languages.json.jsonDefaults.setModeConfiguration({ ...defaults, documentFormattingEdits: false, documentRangeFormattingEdits: false })`. All other worker features (diagnostics, completions, hover, folding, selection ranges, colors, tokens) remain enabled — the configuration must spell them out as `true` because `setModeConfiguration` replaces the whole object.
+2. Register `monaco.languages.registerDocumentFormattingEditProvider('json', …)` and `registerDocumentRangeFormattingEditProvider('json', …)`. Both:
+   - read `tabSize` from `model.getOptions()`,
+   - read `maxLineLength` from `getDenebState().editorPreferences.jsonEditorFormattingMaxLineLength` at invocation time (so changing the property takes effect on the next format without re-registration),
+   - return `[]` when the formatter returns the content unchanged / `undefined`,
+   - are tracked as disposables (same pattern as `completionProviderDisposable`) so a retried initialisation does not stack providers.
+3. Replace the `Ctrl+Alt+R → editor.action.formatDocument` keybinding with a registered command `deneb.formatDocumentOrSelection`: if the editor's selection is non-empty, run `editor.action.formatSelection`; otherwise `editor.action.formatDocument`. Monaco's context menu will additionally surface **Format Selection** automatically whenever a range provider is registered and a selection exists.
+4. `plaintext` editors (cell inspector scalar view) are unaffected; providers are language-scoped to `json`.
+
+### R4 — Call sites
+
+- `getTextFormattedAsJsonC(content, tabSize, maxLineLength = EDITOR_DEFAULTS.formattingMaxLineLength.default)` in `packages/json-processing/src/processing.ts` delegates to `formatJsoncCompact`. Existing two-argument callers keep working; no new public surface is added to `json-processing` (the package is slated for dissolution — the helper is retained only as a delegating shim).
+- Template export (`packages/json-processing/src/template-usermeta.ts`, three sites) and template/spec import (`import-dropzone.tsx`, `select-included-template.tsx`) pass the user's `jsonEditorFormattingMaxLineLength` where the app-core store is reachable; `json-processing` internals use the default.
+
+### R5 — Documentation: formatting behaviour & quirks
+
+A section for the user docs (deneb-viz.github.io) and `docs/DEVELOPMENT.md`, covering:
+
+- **Compaction rule** — a container is written on one line when it fits within the max line length (including its indent and key) and contains no comments; otherwise one child per line. Nested containers are decided independently, so a long array inside a short object expands while sibling values stay compact.
+- **Comments force expansion** — any comment inside a container expands that container (and every ancestor). Leading comments go on their own line above the value; same-line trailing comments stay on the line.
+- **Range formatting snaps outward** — formatting a selection reformats the smallest complete value or property that contains the selection. Selecting three properties inside `"encoding"` reformats the whole `"encoding"` object.
+- **Invalid JSON is left untouched** — formatting does nothing until parse errors are resolved.
+- **Layout is deterministic** — the user's existing line breaks are not preserved; formatting the same content twice yields identical output.
+- **Literals are preserved verbatim** — `1.0` stays `1.0`, escapes are not rewritten.
+
+---
+
+## Testing
+
+**Unit (`packages/utils/src/lib/__tests__/jsonc.test.ts`, vitest)**
+
+- Parity oracle: for comment-free inputs, `formatJsoncCompact(x, { tabSize: 2, maxLineLength: 80 })` equals `json-stringify-pretty-compact`'s `stringify(JSON.parse(x), { indent: 2, maxLength: 80 })` byte-for-byte, across a set of Vega/Vega-Lite fixture specs and edge cases (empty containers, deeply nested, long strings that cannot fit). `json-stringify-pretty-compact` is already a dependency, so the oracle costs nothing.
+- Comments: leading line, trailing line, single-line block, multi-line block, comment in an otherwise-fitting container, comment after the last token.
+- Literal fidelity: `1.0`, `1e3`, `-0`, `"é"`, strings containing `{`, `[`, `//`, `/*`.
+- Invalid JSON: returned unchanged; range variant returns `undefined`.
+- Range: selection inside a nested object snaps to that object; selection spanning two siblings snaps to their parent; selection over a key snaps to the property; depth-derived indent is correct for a node three levels deep.
+- Idempotence: `format(format(x)) === format(x)` for every fixture.
+- `tabSize` 4 produces 4-space indents.
+
+**Existing tests**
+
+- `getTextFormattedAsJsonC` test in `packages/json-processing/src/__test__/processing.test.ts` changes its expectation from the expanded form to `{"name": "John", "age": 30}` — the input fits on one line. This change is intended.
+
+**Manual (Desktop dev build)**
+
+- Ctrl+Alt+R with no selection formats the whole document; with a selection formats the enclosing node only.
+- Context menu shows Format Document always and Format Selection when a selection exists; both behave as above.
+- Changing `formattingMaxLineLength` in the formatting pane and re-formatting reflects the new width without reloading.
+- Export a template; inspect the JSON is compact. Re-import it; the editor shows compact content.
+- A spec with comments formats with comments intact and in place.
+
+**Bundle**
+
+- No new dependency; net bundle change expected ≈ 0. The Monaco worker's own formatter code remains in the worker bundle (not tree-shakeable) — accepted.
+
+---
+
+## Out of Scope
+
+- A "never compact" escape hatch (e.g. `0` = disable). The range floor of 40 effectively expands everything but trivial values; a separate toggle can be added later if requested.
+- Preserving user line breaks (`keepLines`-style behaviour).
+- Format-on-paste / format-on-type.
+- Changes to `formatJson` / `getObjectFormattedAsText` in `utils/object.ts` (compiled-Vega pane, inspector popover) — these already use `json-stringify-pretty-compact` on plain objects and are unaffected.
+
+---
+
+## Release
+
+Targeted at **2.1**. The 2.0 certification cut must be taken from `main` (fast-forward `certification` to the chosen commit) **before** this work merges, so that `certification` remains a strict ancestor of `main`. Work stays on a feature branch until then.

--- a/docs/brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md
+++ b/docs/brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md
@@ -58,6 +58,105 @@ export const formatJsoncCompactRange = (
    - **Trailing** — the comment sits on the same line as the end of a preceding value/property: attached to that node, emitted after the node (and its comma, if any) on the same line.
    - Comments after the last token of the document are emitted at the end, each on its own line.
    - Block comments (`/* */`) spanning multiple lines have their inner lines re-indented to the current indent. Line comments (`//`) and single-line block comments are emitted verbatim.
+
+   **Examples** (`tabSize: 2`, `maxLineLength: 80`)
+
+   *No comments — everything that fits is packed:*
+
+   ```jsonc
+   // input
+   {
+     "mark": {
+       "type": "bar",
+       "tooltip": true
+     },
+     "encoding": {
+       "x": { "field": "Category", "type": "nominal" },
+       "y": { "field": "Sales", "type": "quantitative", "aggregate": "sum" }
+     }
+   }
+   ```
+
+   ```jsonc
+   // output
+   {
+     "mark": {"type": "bar", "tooltip": true},
+     "encoding": {
+       "x": {"field": "Category", "type": "nominal"},
+       "y": {"field": "Sales", "type": "quantitative", "aggregate": "sum"}
+     }
+   }
+   ```
+
+   `"encoding"` does not fit on one line, so it expands; its children are decided independently and each fits.
+
+   *Leading comment — stays above the value it precedes, and forces the container to expand:*
+
+   ```jsonc
+   // input
+   {"mark": {
+     // keep bars thin
+     "type": "bar", "width": 4}, "data": {"name": "dataset"}}
+   ```
+
+   ```jsonc
+   // output
+   {
+     "mark": {
+       // keep bars thin
+       "type": "bar",
+       "width": 4
+     },
+     "data": {"name": "dataset"}
+   }
+   ```
+
+   `"mark"` would fit within 80 characters but contains a comment, so it expands (and so does the root, which contains it). `"data"` has no comments and stays compact.
+
+   *Trailing comment — stays on the same line as the value it follows:*
+
+   ```jsonc
+   // input
+   {
+     "width": 400, // matches the report page
+     "height": 300
+   }
+   ```
+
+   ```jsonc
+   // output
+   {
+     "width": 400, // matches the report page
+     "height": 300
+   }
+   ```
+
+   *Comment after the last token, and a multi-line block comment re-indented:*
+
+   ```jsonc
+   // input
+   {
+     "transform": [
+       /* Filter out
+            nulls first */
+       {"filter": "datum.Sales != null"}
+     ]
+   }
+   // TODO: add a legend
+   ```
+
+   ```jsonc
+   // output
+   {
+     "transform": [
+       /* Filter out
+          nulls first */
+       {"filter": "datum.Sales != null"}
+     ]
+   }
+   // TODO: add a legend
+   ```
+
 3. `render(node, depth)`:
    - **Scalars** (`string`, `number`, `boolean`, `null`): the raw source slice `content.substr(node.offset, node.length)`. This preserves `1.0`, `1e3`, unicode escapes, and any other lexical detail `JSON.parse` would normalise away.
    - **Property**: `render(key) + ": " + render(value)`.

--- a/docs/plans/2026-08-21-001-compact-jsonc-formatting-plan.md
+++ b/docs/plans/2026-08-21-001-compact-jsonc-formatting-plan.md
@@ -1,0 +1,1888 @@
+# Compact JSONC Formatting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Deneb's verbose jsonc-parser formatting with a comment-preserving, Vega-Editor-style compact formatter, driven by a new `formattingMaxLineLength` editor property, applied to the Monaco Format Document / Format Selection commands and to template import/export.
+
+**Architecture:** A pure formatter in `@deneb-viz/utils` walks the jsonc-parser AST (`parseTree`) and re-emits it using the `json-stringify-pretty-compact` fit rule (render a container on one line if it fits within the max line length and contains no comment; otherwise one child per line). Comments are located with `visit({ onComment })` and attached to the node they precede (leading), the node they follow on the same line (trailing), the container they sit at the end of (inner), or the document tail (after). Range formatting snaps the selection outward to the smallest complete node and renders only that node. `json-processing`'s `getTextFormattedAsJsonC` becomes a delegating shim; Monaco's worker formatter is disabled and replaced with providers that call the new formatter.
+
+**Tech Stack:** TypeScript 5.6, jsonc-parser 3.3.1, monaco-editor 0.46, Zustand, Power BI formatting model, Vitest. No new dependencies.
+
+**Spec:** [docs/brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md](../brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md)
+
+**Branch:** `feat/compact-jsonc-formatting` (already created off `main`; spec is committed there).
+
+---
+
+## Conventions for this plan
+
+- Prettier: 4-space indent, single quotes, no trailing commas, `printWidth` 80. Run `npm run prettier-format` before each commit if unsure.
+- Run package tests from the repo root with `npm test -w <package> -- <path>`. Each package's `test` script is `vitest run`, so the trailing path filters to that file.
+- `@deneb-viz/app-core` and `@deneb-viz/json-processing` consume `@deneb-viz/utils` from its **built** `dist/`. After changing `packages/utils/src`, run `npm run build -w @deneb-viz/utils` before running tests in dependent packages.
+- Commit messages end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `packages/utils/src/lib/jsonc-format.ts` (new) | The compact formatter: comment attachment, flat/expanded rendering, range targeting. Pure functions only. |
+| `packages/utils/src/lib/jsonc.ts` | Re-exports the formatter so consumers keep importing from `@deneb-viz/utils/jsonc`. |
+| `packages/utils/src/lib/__tests__/jsonc-format.test.ts` (new) | Parity oracle against `json-stringify-pretty-compact`, comment cases, fidelity, range, idempotence. |
+| `packages/configuration/src/index.ts` | `EDITOR_DEFAULTS.formattingMaxLineLength`. |
+| `packages/app-core/src/state/editor-preferences.ts` | `jsonEditorFormattingMaxLineLength` slice property. |
+| `capabilities.json`, `src/lib/persistence/model/settings-editor.ts`, `stringResources/en-US/resources.resjson`, `src/lib/state/editor-preferences-sync-mappings.ts` | Power BI property → formatting pane → store sync. |
+| `packages/json-processing/src/processing.ts` | `getTextFormattedAsJsonC` delegates to the formatter. |
+| `packages/json-processing/src/template-usermeta.ts` | Threads an optional `maxLineLength` through export/import helpers. |
+| `packages/app-core/src/features/project-export/components/export-buttons.tsx`, `.../project-create/components/import-dropzone.tsx`, `.../project-create/components/select-included-template.tsx` | Pass the user's max line length at the three call sites. |
+| `packages/app-core/src/lib/monaco/editor-init-service.ts` | Disable worker formatting; register document + range providers; smart Ctrl+Alt+R action. |
+| `packages/app-core/src/i18n/en-US.json` | Label for the new editor action (shown in the F1 command palette). |
+| `docs/DEVELOPMENT.md` | "JSON formatting" subsection with the behaviour/quirks list. |
+
+---
+
+### Task 1: Formatter core — containers, scalars, fit rule (no comments yet)
+
+**Files:**
+- Create: `packages/utils/src/lib/jsonc-format.ts`
+- Create: `packages/utils/src/lib/__tests__/jsonc-format.test.ts`
+
+- [ ] **Step 1: Write the failing parity and fidelity tests**
+
+```ts
+// packages/utils/src/lib/__tests__/jsonc-format.test.ts
+import { describe, expect, it } from 'vitest';
+import stringify from 'json-stringify-pretty-compact';
+import { formatJsoncCompact } from '../jsonc-format';
+
+const OPTIONS = { tabSize: 2, maxLineLength: 80 };
+
+/**
+ * For comment-free JSON, the formatter must match json-stringify-pretty-compact
+ * byte-for-byte at the same indent / maxLength. That library is what Vega
+ * Editor uses (with defaults: indent 2, maxLength 80).
+ */
+const expectParity = (value: unknown, maxLineLength = 80, tabSize = 2) => {
+    const source = JSON.stringify(value);
+    expect(formatJsoncCompact(source, { tabSize, maxLineLength })).toBe(
+        stringify(value, { indent: tabSize, maxLength: maxLineLength })
+    );
+};
+
+const BAR_CHART = {
+    $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+    data: { name: 'dataset' },
+    mark: { type: 'bar', tooltip: true },
+    encoding: {
+        x: { field: 'Category', type: 'nominal' },
+        y: { field: 'Sales', type: 'quantitative', aggregate: 'sum' },
+        color: {
+            field: 'Category',
+            type: 'nominal',
+            legend: null,
+            scale: { scheme: 'tableau10' }
+        }
+    }
+};
+
+describe('formatJsoncCompact — parity with json-stringify-pretty-compact', () => {
+    it('matches for a typical Vega-Lite spec', () => {
+        expectParity(BAR_CHART);
+    });
+
+    it('matches for empty containers', () => {
+        expectParity({});
+        expectParity([]);
+        expectParity({ a: {}, b: [], c: { d: [] } });
+    });
+
+    it('matches for arrays of scalars and nested arrays', () => {
+        expectParity({ values: [1, 2, 3, 4, 5] });
+        expectParity({ matrix: [[1, 2], [3, 4], [5, 6]] });
+        expectParity({ long: Array.from({ length: 40 }, (_, i) => i * 1000) });
+    });
+
+    it('matches for strings that cannot fit on one line', () => {
+        expectParity({
+            expr: 'datum.Sales > 100 && datum.Category !== "Other" && datum.Region === "North America"',
+            short: 'x'
+        });
+    });
+
+    it('matches at different max line lengths and tab sizes', () => {
+        expectParity(BAR_CHART, 40);
+        expectParity(BAR_CHART, 120);
+        expectParity(BAR_CHART, 200, 4);
+    });
+
+    it('matches for a root-level array and root-level scalar', () => {
+        expectParity([{ a: 1 }, { b: 2 }]);
+        expectParity(42);
+        expectParity('text');
+    });
+});
+
+describe('formatJsoncCompact — literal fidelity', () => {
+    it('preserves number lexemes exactly', () => {
+        expect(
+            formatJsoncCompact('{"a": 1.0, "b": 1e3, "c": -0}', OPTIONS)
+        ).toBe('{"a": 1.0, "b": 1e3, "c": -0}');
+    });
+
+    it('preserves string escapes and brace-like characters inside strings', () => {
+        const source =
+            '{"a": "\\u00e9", "b": "{not json}", "c": "// not a comment", "d": "/* x */"}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+});
+
+describe('formatJsoncCompact — invalid and empty input', () => {
+    it('returns invalid JSON unchanged', () => {
+        const broken = '{"a": 1,';
+        expect(formatJsoncCompact(broken, OPTIONS)).toBe(broken);
+    });
+
+    it('returns empty input unchanged', () => {
+        expect(formatJsoncCompact('', OPTIONS)).toBe('');
+        expect(formatJsoncCompact('   ', OPTIONS)).toBe('   ');
+    });
+
+    it('returns content with a trailing comma unchanged', () => {
+        const trailing = '{"a": 1,}';
+        expect(formatJsoncCompact(trailing, OPTIONS)).toBe(trailing);
+    });
+});
+
+describe('formatJsoncCompact — idempotence', () => {
+    it('formatting twice yields the same output', () => {
+        const once = formatJsoncCompact(JSON.stringify(BAR_CHART), OPTIONS);
+        expect(formatJsoncCompact(once, OPTIONS)).toBe(once);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -w @deneb-viz/utils -- src/lib/__tests__/jsonc-format.test.ts`
+Expected: FAIL — `Cannot find module '../jsonc-format'`.
+
+- [ ] **Step 3: Write the formatter (scaffolded for comments, but comments not yet attached)**
+
+```ts
+// packages/utils/src/lib/jsonc-format.ts
+import {
+    findNodeAtOffset,
+    parseTree,
+    visit,
+    type Node,
+    type ParseError
+} from 'jsonc-parser';
+
+/**
+ * Options for the compact JSONC formatter.
+ */
+export interface JsoncCompactFormatOptions {
+    /** Spaces per indent level. */
+    tabSize: number;
+    /**
+     * A container (object/array) whose single-line form — including its
+     * indent, key prefix and trailing comma — fits within this many characters
+     * is written on one line. Anything longer is expanded one child per line.
+     */
+    maxLineLength: number;
+}
+
+/** A span of the source text, in character offsets. */
+export interface JsoncRange {
+    offset: number;
+    length: number;
+}
+
+/** A replacement for a span of the source text. */
+export interface JsoncTextEdit extends JsoncRange {
+    content: string;
+}
+
+interface JsoncComment extends JsoncRange {
+    text: string;
+}
+
+/**
+ * Where every comment has been attached, keyed by AST node identity.
+ *
+ * - `leading`: emitted on their own line(s) immediately above the node.
+ * - `trailing`: emitted at the end of the node's line (after its comma).
+ * - `inner`: inside a container, after its last child, before the closer.
+ * - `after`: after the root value, at the end of the document.
+ */
+interface CommentAttachments {
+    leading: Map<Node, JsoncComment[]>;
+    trailing: Map<Node, JsoncComment[]>;
+    inner: Map<Node, JsoncComment[]>;
+    after: JsoncComment[];
+}
+
+interface RenderContext {
+    content: string;
+    root: Node;
+    comments: CommentAttachments;
+    options: JsoncCompactFormatOptions;
+}
+
+const isContainer = (node: Node) =>
+    node.type === 'object' || node.type === 'array';
+
+const nodeEnd = (node: Node) => node.offset + node.length;
+
+const contains = (node: Node, offset: number) =>
+    node.offset <= offset && offset < nodeEnd(node);
+
+const raw = (ctx: RenderContext, node: Node) =>
+    ctx.content.slice(node.offset, nodeEnd(node));
+
+const indentFor = (ctx: RenderContext, depth: number) =>
+    ' '.repeat(depth * ctx.options.tabSize);
+
+const bracketsFor = (node: Node): [string, string] =>
+    node.type === 'object' ? ['{', '}'] : ['[', ']'];
+
+/**
+ * Only horizontal whitespace and at most one comma may sit between the end of
+ * a node and a comment for that comment to count as trailing the node.
+ */
+const TRAILING_GAP = /^[ \t]*,?[ \t]*$/;
+
+const pushTo = (
+    map: Map<Node, JsoncComment[]>,
+    node: Node,
+    comment: JsoncComment
+) => {
+    const existing = map.get(node);
+    if (existing) {
+        existing.push(comment);
+    } else {
+        map.set(node, [comment]);
+    }
+};
+
+const collectComments = (content: string): JsoncComment[] => {
+    const comments: JsoncComment[] = [];
+    visit(content, {
+        onComment: (offset, length) => {
+            comments.push({
+                offset,
+                length,
+                text: content.slice(offset, offset + length)
+            });
+        }
+    });
+    return comments;
+};
+
+/**
+ * Deepest object/array whose span contains `offset`, or `undefined` when the
+ * offset lies outside the root value. Property nodes are passed through: an
+ * offset between a key and its value resolves to the enclosing object.
+ */
+const findEnclosingContainer = (
+    root: Node,
+    offset: number
+): Node | undefined => {
+    let enclosing: Node | undefined;
+    let node: Node | undefined = root;
+    while (node && contains(node, offset)) {
+        if (isContainer(node)) {
+            enclosing = node;
+        }
+        node = node.children?.find((child) => contains(child, offset));
+    }
+    return enclosing;
+};
+
+/**
+ * Attach every comment to a node. Candidates are the children of the
+ * container the comment sits in (property nodes for objects, element nodes for
+ * arrays), or the root when the comment is outside it.
+ */
+const attachComments = (content: string, root: Node): CommentAttachments => {
+    const attachments: CommentAttachments = {
+        leading: new Map(),
+        trailing: new Map(),
+        inner: new Map(),
+        after: []
+    };
+    for (const comment of collectComments(content)) {
+        const enclosing = findEnclosingContainer(root, comment.offset);
+        const candidates = enclosing ? (enclosing.children ?? []) : [root];
+        const previous = candidates
+            .filter((candidate) => nodeEnd(candidate) <= comment.offset)
+            .pop();
+        const next = candidates.find(
+            (candidate) => candidate.offset >= nodeEnd(comment)
+        );
+        const gapBefore = previous
+            ? content.slice(nodeEnd(previous), comment.offset)
+            : null;
+        if (previous && gapBefore !== null && TRAILING_GAP.test(gapBefore)) {
+            pushTo(attachments.trailing, previous, comment);
+        } else if (next) {
+            pushTo(attachments.leading, next, comment);
+        } else if (enclosing) {
+            pushTo(attachments.inner, enclosing, comment);
+        } else {
+            attachments.after.push(comment);
+        }
+    }
+    return attachments;
+};
+
+const parseDocument = (
+    content: string,
+    options: JsoncCompactFormatOptions
+): RenderContext | undefined => {
+    const errors: ParseError[] = [];
+    const root = parseTree(content, errors);
+    if (!root || errors.length > 0) {
+        return undefined;
+    }
+    return {
+        content,
+        root,
+        comments: attachComments(content, root),
+        options
+    };
+};
+
+/**
+ * Whether any comment is attached inside `node` (its inner comments, or any
+ * descendant's leading/trailing comments). The node's own leading/trailing
+ * comments do not count — they are emitted by its parent and do not prevent
+ * the node itself from being written on one line.
+ */
+const subtreeHasComments = (ctx: RenderContext, node: Node): boolean =>
+    ctx.comments.inner.has(node) ||
+    (node.children ?? []).some(
+        (child) =>
+            ctx.comments.leading.has(child) ||
+            ctx.comments.trailing.has(child) ||
+            subtreeHasComments(ctx, child)
+    );
+
+/**
+ * Single-line rendering of `node`, or `null` when a comment anywhere inside it
+ * rules that out. Spacing matches json-stringify-pretty-compact: a space after
+ * `:` and `,`, none inside the brackets.
+ */
+const renderFlat = (ctx: RenderContext, node: Node): string | null => {
+    if (node.type === 'property') {
+        const key = node.children?.[0];
+        const value = node.children?.[1];
+        if (!key || !value) {
+            return raw(ctx, node);
+        }
+        const flatValue = renderFlat(ctx, value);
+        return flatValue === null ? null : `${raw(ctx, key)}: ${flatValue}`;
+    }
+    if (!isContainer(node)) {
+        return raw(ctx, node);
+    }
+    if (subtreeHasComments(ctx, node)) {
+        return null;
+    }
+    const parts: string[] = [];
+    for (const child of node.children ?? []) {
+        const part = renderFlat(ctx, child);
+        if (part === null) {
+            return null;
+        }
+        parts.push(part);
+    }
+    const [open, close] = bracketsFor(node);
+    return `${open}${parts.join(', ')}${close}`;
+};
+
+/**
+ * Multi-line block comments have their continuation lines trimmed and
+ * re-aligned three columns in from the current indent (under the text that
+ * follows the opening `/* `). Single-line comments are emitted verbatim.
+ */
+const renderComment = (
+    ctx: RenderContext,
+    comment: JsoncComment,
+    depth: number
+) => {
+    const lines = comment.text.split(/\r?\n/);
+    if (lines.length === 1) {
+        return comment.text;
+    }
+    const continuation = `${indentFor(ctx, depth)}   `;
+    return [
+        lines[0],
+        ...lines.slice(1).map((line) => `${continuation}${line.trim()}`)
+    ].join('\n');
+};
+
+const trailingSuffix = (ctx: RenderContext, node: Node, depth: number) =>
+    (ctx.comments.trailing.get(node) ?? [])
+        .map((comment) => ` ${renderComment(ctx, comment, depth)}`)
+        .join('');
+
+/**
+ * Render `node` at structural `depth`. The first line is returned without
+ * indent (the caller positions it); continuation lines carry absolute indent.
+ * `reserved` is the width already committed on the first line — the `"key": `
+ * prefix and the trailing comma — mirroring json-stringify-pretty-compact's
+ * fit test.
+ */
+const renderNode = (
+    ctx: RenderContext,
+    node: Node,
+    depth: number,
+    reserved: number
+): string => {
+    if (node.type === 'property') {
+        const key = node.children?.[0];
+        const value = node.children?.[1];
+        if (!key || !value) {
+            return raw(ctx, node);
+        }
+        const keyPrefix = `${raw(ctx, key)}: `;
+        return `${keyPrefix}${renderNode(
+            ctx,
+            value,
+            depth,
+            reserved + keyPrefix.length
+        )}`;
+    }
+    if (!isContainer(node)) {
+        return raw(ctx, node);
+    }
+    const flat = renderFlat(ctx, node);
+    const indentWidth = depth * ctx.options.tabSize;
+    if (
+        flat !== null &&
+        indentWidth + reserved + flat.length <= ctx.options.maxLineLength
+    ) {
+        return flat;
+    }
+    const [open, close] = bracketsFor(node);
+    const children = node.children ?? [];
+    const inner = ctx.comments.inner.get(node) ?? [];
+    if (children.length === 0 && inner.length === 0) {
+        return `${open}${close}`;
+    }
+    const childDepth = depth + 1;
+    const childIndent = indentFor(ctx, childDepth);
+    const lines: string[] = [open];
+    children.forEach((child, index) => {
+        const isLast = index === children.length - 1;
+        for (const comment of ctx.comments.leading.get(child) ?? []) {
+            lines.push(`${childIndent}${renderComment(ctx, comment, childDepth)}`);
+        }
+        const rendered = renderNode(ctx, child, childDepth, isLast ? 0 : 1);
+        lines.push(
+            `${childIndent}${rendered}${isLast ? '' : ','}${trailingSuffix(
+                ctx,
+                child,
+                childDepth
+            )}`
+        );
+    });
+    for (const comment of inner) {
+        lines.push(`${childIndent}${renderComment(ctx, comment, childDepth)}`);
+    }
+    lines.push(`${indentFor(ctx, depth)}${close}`);
+    return lines.join('\n');
+};
+
+/**
+ * Format a whole JSONC document compactly, preserving comments. Invalid JSON
+ * (parse errors, trailing commas) is returned unchanged.
+ */
+export const formatJsoncCompact = (
+    content: string,
+    options: JsoncCompactFormatOptions
+): string => {
+    const ctx = parseDocument(content, options);
+    if (!ctx) {
+        return content;
+    }
+    const lines = (ctx.comments.leading.get(ctx.root) ?? []).map((comment) =>
+        renderComment(ctx, comment, 0)
+    );
+    lines.push(
+        `${renderNode(ctx, ctx.root, 0, 0)}${trailingSuffix(ctx, ctx.root, 0)}`
+    );
+    lines.push(
+        ...ctx.comments.after.map((comment) => renderComment(ctx, comment, 0))
+    );
+    return lines.join('\n');
+};
+
+const ancestryOf = (node: Node): Node[] => {
+    const chain: Node[] = [];
+    for (let current: Node | undefined = node; current; current = current.parent) {
+        chain.unshift(current);
+    }
+    return chain;
+};
+
+const commonAncestor = (a: Node, b: Node): Node => {
+    const chainA = ancestryOf(a);
+    const chainB = ancestryOf(b);
+    let common = chainA[0];
+    for (
+        let i = 0;
+        i < chainA.length && i < chainB.length && chainA[i] === chainB[i];
+        i++
+    ) {
+        common = chainA[i];
+    }
+    return common;
+};
+
+const countContainerAncestors = (node: Node) => {
+    let depth = 0;
+    for (let current = node.parent; current; current = current.parent) {
+        if (isContainer(current)) {
+            depth++;
+        }
+    }
+    return depth;
+};
+
+/**
+ * The smallest complete node containing the selection. A selection that lands
+ * on a property's key or value snaps to the whole property; a selection in
+ * whitespace outside the root snaps to the root.
+ */
+const findFormatTarget = (root: Node, range: JsoncRange): Node => {
+    const start = findNodeAtOffset(root, range.offset) ?? root;
+    const lastOffset =
+        range.length > 0 ? range.offset + range.length - 1 : range.offset;
+    const end = findNodeAtOffset(root, lastOffset) ?? root;
+    const ancestor = commonAncestor(start, end);
+    return ancestor.parent?.type === 'property' ? ancestor.parent : ancestor;
+};
+
+/**
+ * Format only the smallest complete value or property that contains `range`.
+ * Returns the single edit to apply, or `undefined` for invalid JSON. Comments
+ * outside the target node's span are untouched.
+ */
+export const formatJsoncCompactRange = (
+    content: string,
+    range: JsoncRange,
+    options: JsoncCompactFormatOptions
+): JsoncTextEdit | undefined => {
+    const ctx = parseDocument(content, options);
+    if (!ctx) {
+        return undefined;
+    }
+    const target = findFormatTarget(ctx.root, range);
+    const siblings = target.parent?.children ?? [];
+    const isLast =
+        siblings.length === 0 || siblings[siblings.length - 1] === target;
+    return {
+        offset: target.offset,
+        length: target.length,
+        content: renderNode(
+            ctx,
+            target,
+            countContainerAncestors(target),
+            isLast ? 0 : 1
+        )
+    };
+};
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test -w @deneb-viz/utils -- src/lib/__tests__/jsonc-format.test.ts`
+Expected: PASS (all parity, fidelity, invalid-input and idempotence tests).
+
+If a parity test fails, diff the two outputs: the usual culprits are the `reserved` width (must include the `"key": ` prefix **and** 1 for a non-last comma) and bracket spacing (`{"a": 1}` — no inner padding).
+
+- [ ] **Step 5: Lint and commit**
+
+Run: `npm run eslint -w @deneb-viz/utils`
+Expected: no errors.
+
+```bash
+git add packages/utils/src/lib/jsonc-format.ts packages/utils/src/lib/__tests__/jsonc-format.test.ts
+git commit -m "$(cat <<'EOF'
+feat(utils): compact JSONC formatter with pretty-compact parity
+
+Walks the jsonc-parser AST and applies json-stringify-pretty-compact's
+fit rule, copying literals as raw source slices. Comment attachment is
+scaffolded; behaviour is covered in the next commit.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Formatter — comment preservation
+
+**Files:**
+- Modify: `packages/utils/src/lib/__tests__/jsonc-format.test.ts`
+- (No implementation changes expected — Task 1 already wires attachment. This task proves it and fixes anything that falls out.)
+
+- [ ] **Step 1: Add the comment tests**
+
+Append to `jsonc-format.test.ts`:
+
+```ts
+describe('formatJsoncCompact — comments', () => {
+    it('keeps a leading comment above its property and expands the container', () => {
+        const source =
+            '{"mark": {\n  // keep bars thin\n  "type": "bar", "width": 4}, "data": {"name": "dataset"}}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            [
+                '{',
+                '  "mark": {',
+                '    // keep bars thin',
+                '    "type": "bar",',
+                '    "width": 4',
+                '  },',
+                '  "data": {"name": "dataset"}',
+                '}'
+            ].join('\n')
+        );
+    });
+
+    it('keeps a trailing comment on the same line, after the comma', () => {
+        const source = '{\n  "width": 400, // matches the report page\n  "height": 300\n}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('keeps a trailing comment on the last property (no comma)', () => {
+        const source = '{\n  "width": 400,\n  "height": 300 // tall\n}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('keeps a trailing comment after a nested container', () => {
+        const source = '{\n  "a": {"b": 1}, // nested\n  "c": 2\n}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('expands an array that contains a comment (same-line comment trails the preceding element)', () => {
+        const source = '{"values": [1, /* two */ 2, 3]}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            [
+                '{',
+                '  "values": [',
+                '    1, /* two */',
+                '    2,',
+                '    3',
+                '  ]',
+                '}'
+            ].join('\n')
+        );
+    });
+
+    it('places a comment on its own line above the element it precedes', () => {
+        const source = '{"values": [1,\n  // two\n  2, 3]}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            [
+                '{',
+                '  "values": [',
+                '    1,',
+                '    // two',
+                '    2,',
+                '    3',
+                '  ]',
+                '}'
+            ].join('\n')
+        );
+    });
+
+    it('keeps a comment that sits after the last child inside its container', () => {
+        const source = '{\n  "a": 1\n  // end of object\n}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('keeps comments inside an otherwise empty container', () => {
+        const source = '{\n  // nothing yet\n}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('emits comments before and after the root value on their own lines', () => {
+        const source = '// header\n{"a": 1} // same line as root\n// footer';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('re-indents the continuation lines of a multi-line block comment', () => {
+        const source = [
+            '{',
+            '  "transform": [',
+            '    /* Filter out',
+            '            nulls first */',
+            '    {"filter": "datum.Sales != null"}',
+            '  ]',
+            '}',
+            '// TODO: add a legend'
+        ].join('\n');
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            [
+                '{',
+                '  "transform": [',
+                '    /* Filter out',
+                '       nulls first */',
+                '    {"filter": "datum.Sales != null"}',
+                '  ]',
+                '}',
+                '// TODO: add a legend'
+            ].join('\n')
+        );
+    });
+
+    it('moves a comment between a key and its value above the next entry (documented quirk)', () => {
+        const source = '{"a": // odd place\n  1, "b": 2}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            ['{', '  "a": 1,', '  // odd place', '  "b": 2', '}'].join('\n')
+        );
+    });
+
+    it('moves a comment between the last key and its value to the end of the object (documented quirk)', () => {
+        const source = '{"a": 1, "b": // odd place\n  2}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            ['{', '  "a": 1,', '  "b": 2', '  // odd place', '}'].join('\n')
+        );
+    });
+
+    it('is idempotent with comments present', () => {
+        const source =
+            '// header\n{"mark": {\n  // keep bars thin\n  "type": "bar"}, "w": 1 // trailing\n}';
+        const once = formatJsoncCompact(source, OPTIONS);
+        expect(formatJsoncCompact(once, OPTIONS)).toBe(once);
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `npm test -w @deneb-viz/utils -- src/lib/__tests__/jsonc-format.test.ts`
+Expected: PASS. If any comment test fails, fix `attachComments` / `renderNode` in `jsonc-format.ts` — do not weaken the test; these outputs are the documented contract in the spec (R1 step 2 examples).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/utils/src/lib/__tests__/jsonc-format.test.ts packages/utils/src/lib/jsonc-format.ts
+git commit -m "$(cat <<'EOF'
+test(utils): comment preservation cases for compact JSONC formatter
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Formatter — range formatting and public re-export
+
+**Files:**
+- Modify: `packages/utils/src/lib/__tests__/jsonc-format.test.ts`
+- Modify: `packages/utils/src/lib/jsonc.ts`
+
+- [ ] **Step 1: Add the range tests**
+
+Append to `jsonc-format.test.ts` (and add `formatJsoncCompactRange` to the import from `'../jsonc-format'`):
+
+```ts
+describe('formatJsoncCompactRange', () => {
+    const DOC = [
+        '{',
+        '  "mark": "bar",',
+        '  "encoding": {',
+        '    "x": {',
+        '      "field": "Category",',
+        '      "type": "nominal"',
+        '    },',
+        '    "y": {"field": "Sales", "type": "quantitative"}',
+        '  },',
+        '  "data": [1,2,3]',
+        '}'
+    ].join('\n');
+
+    const apply = (doc: string, edit: { offset: number; length: number; content: string }) =>
+        doc.slice(0, edit.offset) + edit.content + doc.slice(edit.offset + edit.length);
+
+    const rangeOf = (doc: string, text: string) => ({
+        offset: doc.indexOf(text),
+        length: text.length
+    });
+
+    /** Offsets spanning from the start of `from` to the end of `to`. */
+    const spanOf = (doc: string, from: string, to: string) => {
+        const offset = doc.indexOf(from);
+        return { offset, length: doc.indexOf(to) + to.length - offset };
+    };
+
+    const X_BODY = spanOf(DOC, '"field": "Category"', '"nominal"');
+
+    it('snaps a selection on a scalar value to its property (which may already be formatted)', () => {
+        const edit = formatJsoncCompactRange(DOC, rangeOf(DOC, '"Category"'), OPTIONS)!;
+        expect(DOC.slice(edit.offset, edit.offset + edit.length)).toBe(
+            '"field": "Category"'
+        );
+        expect(edit.content).toBe('"field": "Category"');
+    });
+
+    it('snaps a selection spanning the children of a nested object to the enclosing property', () => {
+        const edit = formatJsoncCompactRange(DOC, X_BODY, OPTIONS);
+        expect(edit).toBeDefined();
+        expect(DOC.slice(edit!.offset, edit!.offset + edit!.length)).toBe(
+            '"x": {\n      "field": "Category",\n      "type": "nominal"\n    }'
+        );
+        expect(edit!.content).toBe('"x": {"field": "Category", "type": "nominal"}');
+    });
+
+    it('leaves the rest of the document untouched when applying the edit', () => {
+        const edit = formatJsoncCompactRange(DOC, X_BODY, OPTIONS)!;
+        expect(apply(DOC, edit)).toBe(
+            [
+                '{',
+                '  "mark": "bar",',
+                '  "encoding": {',
+                '    "x": {"field": "Category", "type": "nominal"},',
+                '    "y": {"field": "Sales", "type": "quantitative"}',
+                '  },',
+                '  "data": [1,2,3]',
+                '}'
+            ].join('\n')
+        );
+    });
+
+    it('snaps a selection spanning two siblings to their parent', () => {
+        const start = DOC.indexOf('"x"');
+        const end = DOC.indexOf('"quantitative"}') + '"quantitative"}'.length;
+        const edit = formatJsoncCompactRange(DOC, { offset: start, length: end - start }, OPTIONS)!;
+        expect(DOC.slice(edit.offset, edit.offset + edit.length).startsWith('"encoding": {')).toBe(true);
+        expect(edit.content).toBe(
+            [
+                '"encoding": {',
+                '    "x": {"field": "Category", "type": "nominal"},',
+                '    "y": {"field": "Sales", "type": "quantitative"}',
+                '  }'
+            ].join('\n')
+        );
+    });
+
+    it('snaps a selection on a key to the whole property', () => {
+        const edit = formatJsoncCompactRange(DOC, rangeOf(DOC, '"data"'), OPTIONS)!;
+        expect(DOC.slice(edit.offset, edit.offset + edit.length)).toBe('"data": [1,2,3]');
+        expect(edit.content).toBe('"data": [1, 2, 3]');
+    });
+
+    it('uses structural depth for continuation-line indent', () => {
+        const narrow = { tabSize: 2, maxLineLength: 30 };
+        const edit = formatJsoncCompactRange(
+            DOC,
+            spanOf(DOC, '"field": "Sales"', '"quantitative"'),
+            narrow
+        )!;
+        // "y" sits three containers deep (root → encoding → y's object), so its
+        // children indent to 6 and its closer to 4.
+        expect(edit.content).toBe(
+            ['"y": {', '      "field": "Sales",', '      "type": "quantitative"', '    }'].join('\n')
+        );
+    });
+
+    it('reserves a column for the comma when the target is not the last sibling', () => {
+        // "x" + comma is exactly 1 over the limit when packed at depth 2.
+        const flat = '"x": {"field": "Category", "type": "nominal"}';
+        const limit = 2 * 2 + flat.length; // indent + flat, no room for the comma
+        const edit = formatJsoncCompactRange(DOC, X_BODY, { tabSize: 2, maxLineLength: limit })!;
+        expect(edit.content.includes('\n')).toBe(true);
+        // One more column and it fits.
+        const roomy = formatJsoncCompactRange(DOC, X_BODY, { tabSize: 2, maxLineLength: limit + 1 })!;
+        expect(roomy.content).toBe(flat);
+    });
+
+    it('formats the whole document when the selection is outside the root', () => {
+        const doc = '{"a":1}\n\n';
+        const edit = formatJsoncCompactRange(doc, { offset: doc.length - 1, length: 0 }, OPTIONS)!;
+        expect(edit).toEqual({ offset: 0, length: 7, content: '{"a": 1}' });
+    });
+
+    it('returns undefined for invalid JSON', () => {
+        expect(formatJsoncCompactRange('{"a": 1,', { offset: 0, length: 1 }, OPTIONS)).toBeUndefined();
+    });
+
+    it('does not touch comments outside the target span', () => {
+        const doc = '{\n  "a": {"b":1}, // keep me\n  "c": 2\n}';
+        const edit = formatJsoncCompactRange(doc, rangeOf(doc, '"b"'), OPTIONS)!;
+        expect(apply(doc, edit)).toBe('{\n  "a": {"b": 1}, // keep me\n  "c": 2\n}');
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `npm test -w @deneb-viz/utils -- src/lib/__tests__/jsonc-format.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Re-export from `jsonc.ts`**
+
+Append to the end of `packages/utils/src/lib/jsonc.ts`:
+
+```ts
+export {
+    formatJsoncCompact,
+    formatJsoncCompactRange,
+    type JsoncCompactFormatOptions,
+    type JsoncRange,
+    type JsoncTextEdit
+} from './jsonc-format';
+```
+
+- [ ] **Step 4: Build utils and run its whole suite**
+
+Run: `npm run build -w @deneb-viz/utils && npm test -w @deneb-viz/utils`
+Expected: build succeeds (`dist/lib/jsonc-format.js` and `.d.ts` exist), all utils tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/utils/src/lib/jsonc.ts packages/utils/src/lib/__tests__/jsonc-format.test.ts
+git commit -m "$(cat <<'EOF'
+feat(utils): range formatting for compact JSONC formatter
+
+Snaps the selection outward to the smallest complete node and renders
+only that node at its structural depth. Re-exported via utils/jsonc.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Default + store property
+
+**Files:**
+- Modify: `packages/configuration/src/index.ts:50-64`
+- Modify: `packages/app-core/src/state/editor-preferences.ts:9-20,42-57`
+
+- [ ] **Step 1: Add the default**
+
+In `packages/configuration/src/index.ts`, inside `EDITOR_DEFAULTS`, after the `fontSize` entry add:
+
+```ts
+    formattingMaxLineLength: { default: 80, min: 40, max: 200 },
+```
+
+- [ ] **Step 2: Add the slice property**
+
+In `packages/app-core/src/state/editor-preferences.ts`:
+
+In `EditorPreferencesSliceProperties`, after `jsonEditorFontSize: number;` add:
+
+```ts
+    jsonEditorFormattingMaxLineLength: number;
+```
+
+In the initial state object (inside `createEditorPreferencesSlice`), after `jsonEditorFontSize: EDITOR_DEFAULTS.fontSize.default,` add:
+
+```ts
+            jsonEditorFormattingMaxLineLength:
+                EDITOR_DEFAULTS.formattingMaxLineLength.default,
+```
+
+- [ ] **Step 3: Build and typecheck**
+
+Run: `npm run build -w @deneb-viz/configuration && npm run typecheck -w @deneb-viz/app-core`
+Expected: both succeed. (If `typecheck` is not a script in app-core, run `npx tsc --noEmit -p packages/app-core/tsconfig.json`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/configuration/src/index.ts packages/app-core/src/state/editor-preferences.ts
+git commit -m "$(cat <<'EOF'
+feat(app-core): jsonEditorFormattingMaxLineLength preference (default 80)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Power BI property → formatting pane → sync
+
+**Files:**
+- Modify: `capabilities.json:291-295`
+- Modify: `src/lib/persistence/model/settings-editor.ts:98-120`
+- Modify: `stringResources/en-US/resources.resjson:100`
+- Modify: `src/lib/state/editor-preferences-sync-mappings.ts:27-33`
+
+- [ ] **Step 1: Capabilities**
+
+In `capabilities.json`, inside `objects.editor.properties`, directly after the `debouncePeriod` entry add:
+
+```json
+                "formattingMaxLineLength": {
+                    "type": {
+                        "numeric": true
+                    }
+                }
+```
+
+(Add the comma after `debouncePeriod`'s closing brace.)
+
+- [ ] **Step 2: Formatting model**
+
+In `src/lib/persistence/model/settings-editor.ts`, inside `SettingsEditorGroupJson`, after the `debouncePeriod` slice definition add:
+
+```ts
+    formattingMaxLineLength = new formattingSettings.NumUpDown({
+        name: 'formattingMaxLineLength',
+        displayNameKey: 'Objects_Editor_FormattingMaxLineLength',
+        descriptionKey: 'Objects_Editor_FormattingMaxLineLength_Description',
+        options: {
+            minValue: {
+                value: EDITOR_DEFAULTS.formattingMaxLineLength.min,
+                type: 0
+            },
+            maxValue: {
+                value: EDITOR_DEFAULTS.formattingMaxLineLength.max,
+                type: 1
+            }
+        },
+        value: EDITOR_DEFAULTS.formattingMaxLineLength.default
+    });
+```
+
+and add `this.formattingMaxLineLength` to the end of that group's `slices` array:
+
+```ts
+    slices = [
+        this.position,
+        this.fontSize,
+        this.wordWrap,
+        this.showLineNumbers,
+        this.debouncePeriod,
+        this.formattingMaxLineLength
+    ];
+```
+
+- [ ] **Step 3: Strings (en-US only — the other 44 locales do not carry the editor keys)**
+
+In `stringResources/en-US/resources.resjson`, after the `Objects_Editor_DebouncePeriod_Description` line add:
+
+```json
+    "Objects_Editor_FormattingMaxLineLength": "Maximum line length when formatting",
+    "Objects_Editor_FormattingMaxLineLength_Description": "When formatting JSON, objects and arrays that fit within this many characters are written on a single line; longer ones are expanded one entry per line. Comments always force expansion.",
+```
+
+- [ ] **Step 4: Sync mapping**
+
+In `src/lib/state/editor-preferences-sync-mappings.ts`, after the `jsonEditorFontSize` mapping add:
+
+```ts
+        {
+            sliceKey: 'jsonEditorFormattingMaxLineLength',
+            getVisualValue: (s) => s.editor.json.formattingMaxLineLength.value,
+            persistence: {
+                objectName: 'editor',
+                propertyName: 'formattingMaxLineLength'
+            }
+        },
+```
+
+- [ ] **Step 5: Build app-core (so the new slice type is visible to the root) and typecheck the root**
+
+Run: `npm run build -w @deneb-viz/app-core && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add capabilities.json src/lib/persistence/model/settings-editor.ts stringResources/en-US/resources.resjson src/lib/state/editor-preferences-sync-mappings.ts
+git commit -m "$(cat <<'EOF'
+feat: formattingMaxLineLength editor property (Advanced editor > JSON editor)
+
+NumUpDown 40-200, default 80, synced to the app-core store.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: json-processing delegates to the compact formatter
+
+**Files:**
+- Modify: `packages/json-processing/src/processing.ts:1-10,66-79`
+- Modify: `packages/json-processing/src/template-usermeta.ts:62-101,270-290,368-385,435-470`
+- Modify: `packages/json-processing/src/__test__/processing.test.ts:114-122`
+- Modify: `packages/json-processing/src/__test__/template-usermeta.test.ts:225-283,520-528,640-668,740-764`
+
+- [ ] **Step 1: Update the existing expectations first (they define the new contract)**
+
+`processing.test.ts` — replace the `getTextFormattedAsJsonC` describe block with:
+
+```ts
+describe('getTextFormattedAsJsonC', () => {
+    it('should pack content that fits within the default max line length onto one line', () => {
+        const content = '{"name": "John", "age": 30}';
+        expect(getTextFormattedAsJsonC(content, 4)).toBe(
+            '{"name": "John", "age": 30}'
+        );
+    });
+
+    it('should expand content that exceeds the supplied max line length using the tab size', () => {
+        const content = '{"name": "John", "age": 30}';
+        const tabSize = 4;
+        const indent = ' '.repeat(tabSize);
+        const expected = `{\n${indent}"name": "John",\n${indent}"age": 30\n}`;
+        expect(getTextFormattedAsJsonC(content, tabSize, 20)).toBe(expected);
+    });
+});
+```
+
+`template-usermeta.test.ts`:
+
+1. In `describe('getTemplateResolvedForLegacyConfig')`, first test: change `expectedTemplate` to
+
+   ```ts
+        const expectedTemplate =
+            '{ "usermeta": {"config": "{\\"foo\\": \\"bar\\"}" } }';
+   ```
+
+2. In `describe('getTemplateResolvedForPlaceholderAssignment')`, **both** tests: replace the `spec:` template literal in `expectedComponents` with
+
+   ```ts
+            spec: `{
+  "data": {"values": []},
+  "mark": {"type": "bar"},
+  "encoding": {
+    "x": {"field": "__0__", "type": "temporal"},
+    "y": {"field": "__1__", "type": "quantitative"}
+  }
+}`,
+   ```
+
+   (The `config:` values are unchanged — config is stored as a string and is not reformatted here.)
+
+3. In `describe('getExportTemplate')`: the expected string depends on mock constants, so assert content via the formatter rather than hand-laying-out the bytes. Add to the file's imports:
+
+   ```ts
+   import { formatJsoncCompact } from '@deneb-viz/utils/jsonc';
+   ```
+
+   and change the final assertion of that test from `expect(result).toEqual(expectedJsonc);` to
+
+   ```ts
+        expect(result).toEqual(
+            formatJsoncCompact(expectedJsonc, { tabSize: 2, maxLineLength: 80 })
+        );
+   ```
+
+   Leave `expectedJsonc` itself as-is — it still pins key order and content; layout is utils' responsibility and is covered there.
+
+- [ ] **Step 2: Run the json-processing tests to verify they fail**
+
+Run: `npm test -w @deneb-viz/json-processing`
+Expected: FAIL on the four updated expectations (everything else passes).
+
+- [ ] **Step 3: Delegate `getTextFormattedAsJsonC`**
+
+In `packages/json-processing/src/processing.ts`, change the imports at the top to:
+
+```ts
+import {
+    applyEdits,
+    getNodeValue,
+    modify,
+    parseTree,
+    Node
+} from 'jsonc-parser';
+import { JSONPath } from 'vscode-json-languageservice';
+import { EDITOR_DEFAULTS } from '@deneb-viz/configuration';
+import {
+    formatJsoncCompact,
+    stripJsoncComments
+} from '@deneb-viz/utils/jsonc';
+```
+
+and replace the `getTextFormattedAsJsonC` function (keep its existing doc comment) with:
+
+```ts
+export const getTextFormattedAsJsonC = (
+    content: string,
+    tabSize: number,
+    maxLineLength: number = EDITOR_DEFAULTS.formattingMaxLineLength.default
+) => formatJsoncCompact(content, { tabSize, maxLineLength });
+```
+
+- [ ] **Step 4: Thread `maxLineLength` through the template helpers**
+
+In `packages/json-processing/src/template-usermeta.ts`:
+
+`getExportTemplate` — add `maxLineLength?: number;` to its `options` type (after `trackedFields: TrackedFields;`), destructure it alongside the others, and change the return to:
+
+```ts
+    return getTextFormattedAsJsonC(withSchema, 2, maxLineLength);
+```
+
+`getTemplateResolvedForLegacyConfig` — signature becomes
+
+```ts
+export const getTemplateResolvedForLegacyConfig = (
+    template: string,
+    tabSize: number,
+    maxLineLength?: number
+) => {
+```
+
+and its `getTextFormattedAsJsonC(...)` call becomes
+
+```ts
+        const newConfig = getTextFormattedAsJsonC(
+            JSON.stringify(getJsoncNodeValue(tree)?.config || {}),
+            tabSize,
+            maxLineLength
+        );
+```
+
+`getTemplateResolvedForPlaceholderAssignment` — signature becomes
+
+```ts
+export const getTemplateResolvedForPlaceholderAssignment = (
+    template: string,
+    tabSize: number,
+    maxLineLength?: number
+): DenebTemplateAllocationComponents => {
+```
+
+and its `getTextFormattedAsJsonC(...)` call gains the third argument `maxLineLength`.
+
+`getValidatedTemplate` — signature becomes
+
+```ts
+export const getValidatedTemplate = (
+    content: string,
+    tabSize: number,
+    maxLineLength?: number
+): DenebTemplateSetImportFilePayload => {
+```
+
+and pass `maxLineLength` as the third argument to both its `getTemplateResolvedForLegacyConfig(...)` and `getTemplateResolvedForPlaceholderAssignment(...)` calls.
+
+(Passing `undefined` falls through to the default parameter in `getTextFormattedAsJsonC`, so callers that omit it keep today's signature.)
+
+- [ ] **Step 5: Run the json-processing tests**
+
+Run: `npm test -w @deneb-viz/json-processing`
+Expected: PASS.
+
+- [ ] **Step 6: Build and commit**
+
+Run: `npm run build -w @deneb-viz/json-processing`
+
+```bash
+git add packages/json-processing/src/processing.ts packages/json-processing/src/template-usermeta.ts packages/json-processing/src/__test__/processing.test.ts packages/json-processing/src/__test__/template-usermeta.test.ts
+git commit -m "$(cat <<'EOF'
+feat(json-processing): format templates with the compact JSONC formatter
+
+getTextFormattedAsJsonC delegates to utils; template export/import
+helpers accept an optional maxLineLength.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: app-core call sites pass the user's max line length
+
+**Files:**
+- Modify: `packages/app-core/src/features/project-export/components/export-buttons.tsx:113-131`
+- Modify: `packages/app-core/src/features/project-create/components/import-dropzone.tsx:203-214`
+- Modify: `packages/app-core/src/features/project-create/components/select-included-template.tsx:84-96`
+
+- [ ] **Step 1: Export**
+
+In `export-buttons.tsx`, inside `getProcessedExportTemplate`, change the store read and the call to:
+
+```ts
+    const {
+        i18n: { translate },
+        editorPreferences: { jsonEditorFormattingMaxLineLength }
+    } = getDenebState();
+    const informationTranslationPlaceholders = {
+        name: translate('Template_Export_Information_Name_Empty'),
+        description: translate('Template_Export_Information_Description_Empty'),
+        author: translate('Template_Export_Author_Name_Empty')
+    };
+    return getExportTemplate({
+        informationTranslationPlaceholders,
+        metadata,
+        supportFieldConfiguration,
+        tokenizedSpec,
+        trackedFields,
+        maxLineLength: jsonEditorFormattingMaxLineLength
+    });
+```
+
+- [ ] **Step 2: Import (dropzone)**
+
+In `import-dropzone.tsx`, inside `handleValidation`, change to:
+
+```ts
+const handleValidation = (content: string) => {
+    const {
+        create: { setImportFile, setImportState },
+        editorPreferences: { jsonEditorFormattingMaxLineLength }
+    } = getDenebState();
+    setImportState({ importState: 'Validating', refresh: true });
+    const validationResult = getValidatedTemplate(
+        content,
+        EDITOR_DEFAULTS.tabSize,
+        jsonEditorFormattingMaxLineLength
+    );
+    setImportFile(validationResult);
+};
+```
+
+- [ ] **Step 3: Import (included templates)**
+
+In `select-included-template.tsx`, add `getDenebState` to the existing state import:
+
+```ts
+import { getDenebState, useDenebState } from '../../../state';
+```
+
+and inside `dispatchSelectedTemplate` change the call to:
+
+```ts
+        const candidates = getTemplateResolvedForPlaceholderAssignment(
+            templateContent,
+            EDITOR_DEFAULTS.tabSize,
+            getDenebState().editorPreferences.jsonEditorFormattingMaxLineLength
+        );
+```
+
+- [ ] **Step 4: Typecheck and run the app-core suite**
+
+Run: `npm run build -w @deneb-viz/app-core && npm test -w @deneb-viz/app-core`
+Expected: build succeeds; tests PASS (no app-core test asserts on template layout — verified during planning).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/app-core/src/features/project-export/components/export-buttons.tsx packages/app-core/src/features/project-create/components/import-dropzone.tsx packages/app-core/src/features/project-create/components/select-included-template.tsx
+git commit -m "$(cat <<'EOF'
+feat(app-core): apply formattingMaxLineLength to template import/export
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Monaco — replace the worker formatter, add Format Selection, smart Ctrl+Alt+R
+
+**Files:**
+- Modify: `packages/app-core/src/lib/monaco/editor-init-service.ts`
+- Modify: `packages/app-core/src/lib/monaco/__tests__/editor-init-service.test.ts`
+- Modify: `packages/app-core/src/i18n/en-US.json`
+
+- [ ] **Step 1: Add the i18n label**
+
+In `packages/app-core/src/i18n/en-US.json`, add (alphabetically near the other `Text_` keys):
+
+```json
+    "Text_Editor_Action_Format": "Format Document or Selection",
+```
+
+- [ ] **Step 2: Update the test mocks and write the failing tests**
+
+In `editor-init-service.test.ts`, replace the mock declarations block (from `const mockSetDiagnosticsOptions` through the end of `vi.mock('../monaco-integration', ...)`) with:
+
+```ts
+const mockSetDiagnosticsOptions = vi.fn();
+const mockSetModeConfiguration = vi.fn();
+const mockDisposeCompletionProvider = vi.fn();
+const mockRegisterCompletionItemProvider = vi
+    .fn()
+    .mockReturnValue({ dispose: mockDisposeCompletionProvider });
+const mockDisposeFormattingProvider = vi.fn();
+const mockRegisterDocumentFormattingEditProvider = vi
+    .fn()
+    .mockReturnValue({ dispose: mockDisposeFormattingProvider });
+const mockRegisterDocumentRangeFormattingEditProvider = vi
+    .fn()
+    .mockReturnValue({ dispose: mockDisposeFormattingProvider });
+const mockAddEditorAction = vi
+    .fn()
+    .mockReturnValue({ dispose: mockDisposeFormattingProvider });
+const mockAddKeybindingRules = vi.fn();
+const mockSetupMonacoWorker = vi.fn();
+
+vi.mock('../monaco-integration', () => ({
+    monaco: {
+        languages: {
+            json: {
+                jsonDefaults: {
+                    setDiagnosticsOptions: mockSetDiagnosticsOptions,
+                    modeConfiguration: { diagnostics: true, hovers: true },
+                    setModeConfiguration: mockSetModeConfiguration
+                }
+            },
+            registerCompletionItemProvider: mockRegisterCompletionItemProvider,
+            registerDocumentFormattingEditProvider:
+                mockRegisterDocumentFormattingEditProvider,
+            registerDocumentRangeFormattingEditProvider:
+                mockRegisterDocumentRangeFormattingEditProvider,
+            CompletionItemKind: { Field: 5, Property: 9 }
+        },
+        editor: {
+            addKeybindingRules: mockAddKeybindingRules,
+            addEditorAction: mockAddEditorAction
+        },
+        Range: {
+            fromPositions: (start: unknown, end: unknown) => ({ start, end })
+        },
+        Uri: {
+            parse: (uri: string) => ({ toString: () => uri })
+        },
+        KeyMod: { CtrlCmd: 2048, Shift: 1024, Alt: 512 },
+        KeyCode: { Enter: 3, KeyR: 48, F1: 59 }
+    },
+    setupMonacoWorker: mockSetupMonacoWorker
+}));
+```
+
+Update the `vi.mock('../../../state', ...)` factory so `getDenebState` also returns `editorPreferences`:
+
+```ts
+vi.mock('../../../state', () => ({
+    getDenebState: vi.fn(() => ({
+        editorSelectedOperation: 'Spec',
+        dataset: { fields: {} },
+        editorPreferences: { jsonEditorFormattingMaxLineLength: 80 },
+        project: {
+            supportFieldConfiguration: {},
+            interactivity: undefined
+        },
+        i18n: { translate: vi.fn((key: string) => key) }
+    }))
+}));
+```
+
+Replace the `'should add custom keybinding rules'` test with:
+
+```ts
+    it('should add custom keybinding rules without the old formatDocument binding', async () => {
+        vi.resetModules();
+        mockAddKeybindingRules.mockClear();
+        const service = await import('../editor-init-service');
+        await service.initializeEditorDependencies();
+        const rules = mockAddKeybindingRules.mock.calls[0][0];
+        expect(rules).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ command: null }),
+                expect.objectContaining({
+                    command: 'editor.action.quickCommand'
+                })
+            ])
+        );
+        expect(rules).not.toContainEqual(
+            expect.objectContaining({ command: 'editor.action.formatDocument' })
+        );
+    });
+```
+
+Add a new describe block before `describe('retry behaviour', ...)`:
+
+```ts
+    describe('formatting', () => {
+        const makeModel = (value: string) => ({
+            getValue: () => value,
+            getOptions: () => ({ tabSize: 2 }),
+            getFullModelRange: () => 'FULL_RANGE',
+            getOffsetAt: (position: { offset: number }) => position.offset,
+            getPositionAt: (offset: number) => ({ offset })
+        });
+
+        it('should disable the worker formatter but keep its other features', async () => {
+            vi.resetModules();
+            mockSetModeConfiguration.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            expect(mockSetModeConfiguration).toHaveBeenCalledWith({
+                diagnostics: true,
+                hovers: true,
+                documentFormattingEdits: false,
+                documentRangeFormattingEdits: false
+            });
+        });
+
+        it('should register a document formatting provider that compacts JSON', async () => {
+            vi.resetModules();
+            mockRegisterDocumentFormattingEditProvider.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            expect(
+                mockRegisterDocumentFormattingEditProvider
+            ).toHaveBeenCalledWith('json', expect.any(Object));
+            const provider =
+                mockRegisterDocumentFormattingEditProvider.mock.calls[0][1];
+            const edits = provider.provideDocumentFormattingEdits(
+                makeModel('{"a":1,\n"b":2}')
+            );
+            expect(edits).toEqual([
+                { range: 'FULL_RANGE', text: '{"a": 1, "b": 2}' }
+            ]);
+        });
+
+        it('should return no edits when the document is already formatted', async () => {
+            vi.resetModules();
+            mockRegisterDocumentFormattingEditProvider.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            const provider =
+                mockRegisterDocumentFormattingEditProvider.mock.calls[0][1];
+            expect(
+                provider.provideDocumentFormattingEdits(
+                    makeModel('{"a": 1, "b": 2}')
+                )
+            ).toEqual([]);
+        });
+
+        it('should register a range formatting provider that snaps to the enclosing node', async () => {
+            vi.resetModules();
+            mockRegisterDocumentRangeFormattingEditProvider.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            const provider =
+                mockRegisterDocumentRangeFormattingEditProvider.mock
+                    .calls[0][1];
+            const doc = '{\n  "a": {\n    "b": 1\n  },\n  "c": 2\n}';
+            // Select from the opening brace of "a"'s value to its closing
+            // brace — the common ancestor is that object, which snaps to the
+            // "a" property.
+            const range = {
+                getStartPosition: () => ({ offset: doc.indexOf('{', 1) }),
+                getEndPosition: () => ({ offset: doc.indexOf('}') + 1 })
+            };
+            const edits = provider.provideDocumentRangeFormattingEdits(
+                makeModel(doc),
+                range
+            );
+            expect(edits).toEqual([
+                {
+                    range: {
+                        start: { offset: doc.indexOf('"a"') },
+                        end: { offset: doc.indexOf('},') + 1 }
+                    },
+                    text: '"a": {"b": 1}'
+                }
+            ]);
+        });
+
+        it('should add a Ctrl+Alt+R action that formats the selection when present, else the document', async () => {
+            vi.resetModules();
+            mockAddEditorAction.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            expect(mockAddEditorAction).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    id: 'deneb.formatDocumentOrSelection',
+                    label: 'Text_Editor_Action_Format',
+                    keybindings: [2048 | 512 | 48]
+                })
+            );
+            const { run } = mockAddEditorAction.mock.calls[0][0];
+            const actionRun = vi.fn();
+            const getAction = vi.fn(() => ({ run: actionRun }));
+
+            run({
+                getSelection: () => ({ isEmpty: () => false }),
+                getAction
+            });
+            expect(getAction).toHaveBeenLastCalledWith(
+                'editor.action.formatSelection'
+            );
+
+            run({
+                getSelection: () => ({ isEmpty: () => true }),
+                getAction
+            });
+            expect(getAction).toHaveBeenLastCalledWith(
+                'editor.action.formatDocument'
+            );
+            expect(actionRun).toHaveBeenCalledTimes(2);
+        });
+
+        it('should dispose previous formatting registrations before re-registering on retry', async () => {
+            vi.resetModules();
+            mockDisposeFormattingProvider.mockClear();
+            mockRegisterDocumentFormattingEditProvider.mockClear();
+            // Formatting is configured before keybindings; make keybindings
+            // throw so the first attempt fails after formatting is registered.
+            mockAddKeybindingRules.mockImplementationOnce(() => {
+                throw new Error('keybinding failure');
+            });
+            const service = await import('../editor-init-service');
+            await expect(
+                service.initializeEditorDependencies()
+            ).rejects.toThrow('keybinding failure');
+            expect(mockRegisterDocumentFormattingEditProvider).toHaveBeenCalledTimes(1);
+
+            await service.initializeEditorDependencies();
+            // Three disposables (document provider, range provider, action)
+            // from the first attempt are disposed on retry.
+            expect(mockDisposeFormattingProvider).toHaveBeenCalledTimes(3);
+            expect(mockRegisterDocumentFormattingEditProvider).toHaveBeenCalledTimes(2);
+        });
+    });
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npm test -w @deneb-viz/app-core -- src/lib/monaco/__tests__/editor-init-service.test.ts`
+Expected: FAIL — `mockSetModeConfiguration` not called, providers not registered, `addEditorAction` not called, and the keybinding test fails because the `formatDocument` rule is still present.
+
+- [ ] **Step 4: Implement**
+
+In `editor-init-service.ts`:
+
+Add to the imports (after the `logDebug` import):
+
+```ts
+import {
+    formatJsoncCompact,
+    formatJsoncCompactRange
+} from '@deneb-viz/utils/jsonc';
+```
+
+Add after `let completionProviderDisposable ...`:
+
+```ts
+let formattingDisposables: { dispose(): void }[] = [];
+
+/** Action id for the Ctrl+Alt+R "format selection, else document" command. */
+const FORMAT_ACTION_ID = 'deneb.formatDocumentOrSelection';
+```
+
+Add the following function after `configureMonacoCompletionProvider`:
+
+```ts
+/**
+ * Read formatting options at invocation time, so a change to the
+ * `formattingMaxLineLength` property applies to the next format without
+ * re-registering providers.
+ */
+const getFormattingOptions = (model: monaco.editor.ITextModel) => ({
+    tabSize: model.getOptions().tabSize,
+    maxLineLength:
+        getDenebState().editorPreferences.jsonEditorFormattingMaxLineLength
+});
+
+/**
+ * Replace the JSON worker's formatter (jsonc-parser `format`, which has no
+ * line-length control) with Deneb's comment-preserving compact formatter.
+ * Registers document and range providers and a Ctrl+Alt+R action that
+ * formats the selection when there is one, otherwise the whole document.
+ */
+const configureMonacoFormatting = () => {
+    // Dispose any previous registrations before re-registering to prevent
+    // stacking duplicate providers on retry.
+    formattingDisposables.forEach((disposable) => disposable.dispose());
+    formattingDisposables = [];
+
+    const { jsonDefaults } = monaco.languages.json;
+    jsonDefaults.setModeConfiguration({
+        ...jsonDefaults.modeConfiguration,
+        documentFormattingEdits: false,
+        documentRangeFormattingEdits: false
+    });
+
+    formattingDisposables.push(
+        monaco.languages.registerDocumentFormattingEditProvider('json', {
+            provideDocumentFormattingEdits: (model) => {
+                const content = model.getValue();
+                const formatted = formatJsoncCompact(
+                    content,
+                    getFormattingOptions(model)
+                );
+                if (formatted === content) {
+                    return [];
+                }
+                return [{ range: model.getFullModelRange(), text: formatted }];
+            }
+        }),
+        monaco.languages.registerDocumentRangeFormattingEditProvider('json', {
+            provideDocumentRangeFormattingEdits: (model, range) => {
+                const content = model.getValue();
+                const offset = model.getOffsetAt(range.getStartPosition());
+                const length =
+                    model.getOffsetAt(range.getEndPosition()) - offset;
+                const edit = formatJsoncCompactRange(
+                    content,
+                    { offset, length },
+                    getFormattingOptions(model)
+                );
+                if (
+                    !edit ||
+                    content.slice(edit.offset, edit.offset + edit.length) ===
+                        edit.content
+                ) {
+                    return [];
+                }
+                return [
+                    {
+                        range: monaco.Range.fromPositions(
+                            model.getPositionAt(edit.offset),
+                            model.getPositionAt(edit.offset + edit.length)
+                        ),
+                        text: edit.content
+                    }
+                ];
+            }
+        }),
+        monaco.editor.addEditorAction({
+            id: FORMAT_ACTION_ID,
+            label: getDenebState().i18n.translate('Text_Editor_Action_Format'),
+            keybindings: [
+                monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KeyR
+            ],
+            run: (editor) => {
+                const selection = editor.getSelection();
+                const actionId =
+                    selection && !selection.isEmpty()
+                        ? 'editor.action.formatSelection'
+                        : 'editor.action.formatDocument';
+                return editor.getAction(actionId)?.run();
+            }
+        })
+    );
+};
+```
+
+In `configureMonacoKeyBindings`, **remove** the rule object binding `CtrlCmd | Alt | KeyR` to `'editor.action.formatDocument'` (the action above owns that key now). Update the function's doc comment to:
+
+```ts
+/**
+ * Override default Monaco key bindings that clash with Deneb hotkeys and
+ * add the quick command binding. Format is bound by the editor action in
+ * `configureMonacoFormatting`.
+ */
+```
+
+In `doInitialize`, call the new function between completions and keybindings:
+
+```ts
+    configureMonacoDiagnostics();
+    configureMonacoCompletionProvider();
+    configureMonacoFormatting();
+    configureMonacoKeyBindings();
+```
+
+and update the numbered list in its doc comment: `5. Configure Monaco diagnostics, completions, formatting, and keybindings`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npm test -w @deneb-viz/app-core -- src/lib/monaco/__tests__/editor-init-service.test.ts`
+Expected: PASS (all pre-existing tests plus the new `formatting` block).
+
+- [ ] **Step 6: Lint, build, commit**
+
+Run: `npm run eslint -w @deneb-viz/app-core && npm run build -w @deneb-viz/app-core`
+Expected: clean.
+
+```bash
+git add packages/app-core/src/lib/monaco/editor-init-service.ts packages/app-core/src/lib/monaco/__tests__/editor-init-service.test.ts packages/app-core/src/i18n/en-US.json
+git commit -m "$(cat <<'EOF'
+feat(app-core): compact JSONC formatting in the Monaco editor (#578)
+
+Disables the JSON worker's formatter and registers document and range
+providers backed by the utils formatter. Ctrl+Alt+R now formats the
+selection when present, otherwise the document; Format Selection also
+appears in the context menu.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: Docs, full CI, manual verification
+
+**Files:**
+- Modify: `docs/DEVELOPMENT.md` (after the "Feature module boundaries (`app-core`)" subsection in section 5)
+
+- [ ] **Step 1: Add the developer-docs subsection**
+
+Insert after the "Feature module boundaries (`app-core`)" subsection:
+
+````markdown
+### JSON formatting (compact JSONC)
+
+All spec/config formatting — Format Document / Format Selection in the editor, and template import/export — goes through `formatJsoncCompact` / `formatJsoncCompactRange` in `@deneb-viz/utils/jsonc`. It walks the jsonc-parser AST and applies the same fit rule as `json-stringify-pretty-compact` (Vega Editor's formatter), but preserves comments. The Monaco JSON worker's own formatter is disabled in `editor-init-service.ts`; the `formattingMaxLineLength` editor property (default 80, range 40–200) sets the width.
+
+Behaviour to be aware of:
+
+- **Compaction rule** — a container is written on one line when its single-line form (including indent, `"key": ` prefix and trailing comma) fits within the max line length and contains no comments; otherwise one child per line. Nested containers are decided independently.
+- **Comments force expansion** — any comment inside a container expands it and every ancestor. Comments above a value stay above it; same-line trailing comments stay on the line (a comment following `1, ` on the same line trails `1`, not the next element); comments after the last entry stay before the closer. A comment between a key and its value is moved above the next entry (or to the end of the object if there is none).
+- **Range formatting snaps outward** — the smallest complete value or property containing the selection is reformatted. Selecting a key or value reformats the whole property.
+- **Invalid JSON is left untouched** — nothing happens until parse errors (including trailing commas) are resolved.
+- **Layout is deterministic** — existing line breaks are not preserved; formatting is idempotent.
+- **Literals are copied verbatim** — `1.0` stays `1.0`; escapes are not rewritten.
+
+Design record: [docs/brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md](brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md).
+````
+
+- [ ] **Step 2: Run the full local CI mirror**
+
+Run: `npm run ci:local`
+Expected: PASS (lint, prettier, tests across all packages, build). Fix anything it reports before continuing — commonly prettier reflow in the new test file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/DEVELOPMENT.md
+git commit -m "$(cat <<'EOF'
+docs: describe compact JSONC formatting behaviour and quirks
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Manual verification in Power BI Desktop (dev build)**
+
+Run `npm run dev`, load the dev visual, open the Advanced Editor, and confirm:
+
+1. Paste a fully-expanded Vega-Lite spec; **Ctrl+Alt+R** with no selection → whole document compacts; short encodings sit on one line.
+2. Expand one object by hand, select inside it, **Ctrl+Alt+R** → only that enclosing property reformats; the rest is untouched.
+3. Right-click → **Format Document** present always; **Format Selection** present with a selection; both behave as above.
+4. Add `// comment` lines above a property and at the end of a line; format → comments stay put; their containers expand.
+5. Formatting pane → Advanced editor → JSON editor → set **Maximum line length when formatting** to 40; format again → more expansion, no reload needed. Set back to 80.
+6. Export a template → downloaded JSON is compact. Import it via the dropzone → editor shows compact content. Create from an included template → compact.
+7. Press **F1** in the editor → "Format Document or Selection" appears in the command palette.
+
+Record any deviation as a follow-up issue; the feature is complete when all seven hold.
+
+---
+
+## Self-review against the spec
+
+| Spec | Task |
+| --- | --- |
+| R1 formatter + algorithm + range | Tasks 1–3 |
+| R2 setting (capabilities, model, strings, default, sync, slice) | Tasks 4–5 |
+| R3 Monaco (mode config, providers, smart action, language-scoped) | Task 8 |
+| R4 call sites (processing shim, template helpers, three app-core sites) | Tasks 6–7 |
+| R5 behaviour & quirks documentation | Task 9 (DEVELOPMENT.md; the user-docs site is a separate repo — reuse the same list) |
+| Testing: parity oracle, comments, fidelity, invalid, range, idempotence, existing test updates, manual checks | Tasks 1–3, 6, 8, 9 |
+| Out of scope honoured: no "never compact", no keepLines, no format-on-type, `utils/object.ts` untouched | — |

--- a/packages/app-core/src/features/project-create/components/import-dropzone.tsx
+++ b/packages/app-core/src/features/project-create/components/import-dropzone.tsx
@@ -204,12 +204,14 @@ const handleFileLoad = (file: FileWithPath | File) => {
  */
 const handleValidation = (content: string) => {
     const {
-        create: { setImportFile, setImportState }
+        create: { setImportFile, setImportState },
+        editorPreferences: { jsonEditorFormattingMaxLineLength }
     } = getDenebState();
     setImportState({ importState: 'Validating', refresh: true });
     const validationResult = getValidatedTemplate(
         content,
-        EDITOR_DEFAULTS.tabSize
+        EDITOR_DEFAULTS.tabSize,
+        jsonEditorFormattingMaxLineLength
     );
     setImportFile(validationResult);
 };

--- a/packages/app-core/src/features/project-create/components/select-included-template.tsx
+++ b/packages/app-core/src/features/project-create/components/select-included-template.tsx
@@ -23,7 +23,7 @@ import { type UsermetaTemplate } from '@deneb-viz/template-usermeta';
 import { type SpecProvider } from '@deneb-viz/vega-runtime/embed';
 import { logRender } from '@deneb-viz/utils/logging';
 import { getVegaProviderI18n } from '../../../lib/vega/i18n';
-import { useDenebState } from '../../../state';
+import { getDenebState, useDenebState } from '../../../state';
 import { EDITOR_DEFAULTS } from '@deneb-viz/configuration';
 
 type SelectIncludedTemplateProps = {
@@ -89,7 +89,8 @@ export const SelectIncludedTemplate = ({
         const templateContent = JSON.stringify(template);
         const candidates = getTemplateResolvedForPlaceholderAssignment(
             templateContent,
-            EDITOR_DEFAULTS.tabSize
+            EDITOR_DEFAULTS.tabSize,
+            getDenebState().editorPreferences.jsonEditorFormattingMaxLineLength
         );
         setTemplate({
             metadata: getTemplateMetadata(templateContent),

--- a/packages/app-core/src/features/project-export/components/export-buttons.tsx
+++ b/packages/app-core/src/features/project-export/components/export-buttons.tsx
@@ -116,7 +116,10 @@ const getProcessedExportTemplate = (
     tokenizedSpec: string,
     trackedFields: TrackedFields
 ) => {
-    const { translate } = getDenebState().i18n;
+    const {
+        i18n: { translate },
+        editorPreferences: { jsonEditorFormattingMaxLineLength }
+    } = getDenebState();
     const informationTranslationPlaceholders = {
         name: translate('Template_Export_Information_Name_Empty'),
         description: translate('Template_Export_Information_Description_Empty'),
@@ -127,6 +130,7 @@ const getProcessedExportTemplate = (
         metadata,
         supportFieldConfiguration,
         tokenizedSpec,
-        trackedFields
+        trackedFields,
+        maxLineLength: jsonEditorFormattingMaxLineLength
     });
 };

--- a/packages/app-core/src/i18n/en-US.json
+++ b/packages/app-core/src/i18n/en-US.json
@@ -139,6 +139,7 @@
     "Text_Compiled_Vega_Switch": "Convert my spec to Vega",
     "Text_Compiled_Vega_Switch_Confirm": "This will replace your Vega-Lite specification with the compiled Vega output. THIS CANNOT BE UNDONE.",
     "Text_Compiled_Vega_Toggle": "Show compiled Vega",
+    "Text_Editor_Action_Format": "Format Document or Selection",
     "Text_Editor_Error_Message": "An error occurred in the editor.",
     "Text_Editor_Error_Retry": "Retry",
     "Text_Export_Tokenizing": "Updating your specification with placeholders for your dataset. Please wait...",

--- a/packages/app-core/src/lib/monaco/__tests__/editor-init-service.test.ts
+++ b/packages/app-core/src/lib/monaco/__tests__/editor-init-service.test.ts
@@ -233,12 +233,13 @@ describe('editor-init-service', () => {
     });
 
     describe('formatting', () => {
-        const makeModel = (value: string) => ({
+        const makeModel = (value: string, eol = '\n') => ({
             getValue: () => value,
             getOptions: () => ({ tabSize: 2 }),
             getFullModelRange: () => 'FULL_RANGE',
             getOffsetAt: (position: { offset: number }) => position.offset,
-            getPositionAt: (offset: number) => ({ offset })
+            getPositionAt: (offset: number) => ({ offset }),
+            getEOL: () => eol
         });
 
         it('should disable the worker formatter but keep its other features', async () => {
@@ -284,6 +285,39 @@ describe('editor-init-service', () => {
                     makeModel('{"a": 1, "b": 2}')
                 )
             ).toEqual([]);
+        });
+
+        it('should return no edits for an already formatted CRLF document', async () => {
+            vi.resetModules();
+            mockRegisterDocumentFormattingEditProvider.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            const provider =
+                mockRegisterDocumentFormattingEditProvider.mock.calls[0][1];
+            const longValue = 'x'.repeat(90);
+            const doc = `{\r\n  "expr": "${longValue}"\r\n}`;
+            expect(
+                provider.provideDocumentFormattingEdits(makeModel(doc, '\r\n'))
+            ).toEqual([]);
+        });
+
+        it('should emit CRLF line endings when the model uses CRLF', async () => {
+            vi.resetModules();
+            mockRegisterDocumentFormattingEditProvider.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            const provider =
+                mockRegisterDocumentFormattingEditProvider.mock.calls[0][1];
+            const longValue = 'x'.repeat(90);
+            const doc = `{"expr": "${longValue}"}`;
+            expect(
+                provider.provideDocumentFormattingEdits(makeModel(doc, '\r\n'))
+            ).toEqual([
+                {
+                    range: 'FULL_RANGE',
+                    text: `{\r\n  "expr": "${longValue}"\r\n}`
+                }
+            ]);
         });
 
         it('should register a range formatting provider that snaps to the enclosing node', async () => {

--- a/packages/app-core/src/lib/monaco/__tests__/editor-init-service.test.ts
+++ b/packages/app-core/src/lib/monaco/__tests__/editor-init-service.test.ts
@@ -287,6 +287,19 @@ describe('editor-init-service', () => {
             ).toEqual([]);
         });
 
+        it('should return no edits for invalid JSON in a CRLF document', async () => {
+            vi.resetModules();
+            mockRegisterDocumentFormattingEditProvider.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            const provider =
+                mockRegisterDocumentFormattingEditProvider.mock.calls[0][1];
+            const doc = '{\r\n  "a": 1,\r\n}';
+            expect(
+                provider.provideDocumentFormattingEdits(makeModel(doc, '\r\n'))
+            ).toEqual([]);
+        });
+
         it('should return no edits for an already formatted CRLF document', async () => {
             vi.resetModules();
             mockRegisterDocumentFormattingEditProvider.mockClear();

--- a/packages/app-core/src/lib/monaco/__tests__/editor-init-service.test.ts
+++ b/packages/app-core/src/lib/monaco/__tests__/editor-init-service.test.ts
@@ -4,16 +4,28 @@ import { describe, expect, it, vi } from 'vitest';
  * Editor init service tests. These verify the orchestration requirements:
  * - Editor dependencies initialize without error
  * - Monaco diagnostics are configured with schemas after init
- * - Monaco completion provider and key bindings are registered
+ * - Monaco completion provider, formatting providers, and key bindings are
+ *   registered
  * - Initialization is idempotent
  */
 
 // Mock Monaco integration
 const mockSetDiagnosticsOptions = vi.fn();
+const mockSetModeConfiguration = vi.fn();
 const mockDisposeCompletionProvider = vi.fn();
 const mockRegisterCompletionItemProvider = vi
     .fn()
     .mockReturnValue({ dispose: mockDisposeCompletionProvider });
+const mockDisposeFormattingProvider = vi.fn();
+const mockRegisterDocumentFormattingEditProvider = vi
+    .fn()
+    .mockReturnValue({ dispose: mockDisposeFormattingProvider });
+const mockRegisterDocumentRangeFormattingEditProvider = vi
+    .fn()
+    .mockReturnValue({ dispose: mockDisposeFormattingProvider });
+const mockAddEditorAction = vi
+    .fn()
+    .mockReturnValue({ dispose: mockDisposeFormattingProvider });
 const mockAddKeybindingRules = vi.fn();
 const mockSetupMonacoWorker = vi.fn();
 
@@ -22,14 +34,24 @@ vi.mock('../monaco-integration', () => ({
         languages: {
             json: {
                 jsonDefaults: {
-                    setDiagnosticsOptions: mockSetDiagnosticsOptions
+                    setDiagnosticsOptions: mockSetDiagnosticsOptions,
+                    modeConfiguration: { diagnostics: true, hovers: true },
+                    setModeConfiguration: mockSetModeConfiguration
                 }
             },
             registerCompletionItemProvider: mockRegisterCompletionItemProvider,
+            registerDocumentFormattingEditProvider:
+                mockRegisterDocumentFormattingEditProvider,
+            registerDocumentRangeFormattingEditProvider:
+                mockRegisterDocumentRangeFormattingEditProvider,
             CompletionItemKind: { Field: 5, Property: 9 }
         },
         editor: {
-            addKeybindingRules: mockAddKeybindingRules
+            addKeybindingRules: mockAddKeybindingRules,
+            addEditorAction: mockAddEditorAction
+        },
+        Range: {
+            fromPositions: (start: unknown, end: unknown) => ({ start, end })
         },
         Uri: {
             parse: (uri: string) => ({ toString: () => uri })
@@ -75,6 +97,7 @@ vi.mock('../../../state', () => ({
             supportFieldConfiguration: {},
             interactivity: undefined
         },
+        editorPreferences: { jsonEditorFormattingMaxLineLength: 80 },
         i18n: { translate: vi.fn((key: string) => key) }
     }))
 }));
@@ -148,21 +171,22 @@ describe('editor-init-service', () => {
         );
     });
 
-    it('should add custom keybinding rules', async () => {
+    it('should add custom keybinding rules without the old formatDocument binding', async () => {
         vi.resetModules();
         mockAddKeybindingRules.mockClear();
         const service = await import('../editor-init-service');
         await service.initializeEditorDependencies();
-        expect(mockAddKeybindingRules).toHaveBeenCalledWith(
+        const rules = mockAddKeybindingRules.mock.calls[0][0];
+        expect(rules).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({ command: null }),
-                expect.objectContaining({
-                    command: 'editor.action.formatDocument'
-                }),
                 expect.objectContaining({
                     command: 'editor.action.quickCommand'
                 })
             ])
+        );
+        expect(rules).not.toContainEqual(
+            expect.objectContaining({ command: 'editor.action.formatDocument' })
         );
     });
 
@@ -206,6 +230,152 @@ describe('editor-init-service', () => {
         await service.initializeEditorDependencies();
         expect(firstDispose).toHaveBeenCalledTimes(1);
         expect(mockRegisterCompletionItemProvider).toHaveBeenCalledTimes(1);
+    });
+
+    describe('formatting', () => {
+        const makeModel = (value: string) => ({
+            getValue: () => value,
+            getOptions: () => ({ tabSize: 2 }),
+            getFullModelRange: () => 'FULL_RANGE',
+            getOffsetAt: (position: { offset: number }) => position.offset,
+            getPositionAt: (offset: number) => ({ offset })
+        });
+
+        it('should disable the worker formatter but keep its other features', async () => {
+            vi.resetModules();
+            mockSetModeConfiguration.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            expect(mockSetModeConfiguration).toHaveBeenCalledWith({
+                diagnostics: true,
+                hovers: true,
+                documentFormattingEdits: false,
+                documentRangeFormattingEdits: false
+            });
+        });
+
+        it('should register a document formatting provider that compacts JSON', async () => {
+            vi.resetModules();
+            mockRegisterDocumentFormattingEditProvider.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            expect(
+                mockRegisterDocumentFormattingEditProvider
+            ).toHaveBeenCalledWith('json', expect.any(Object));
+            const provider =
+                mockRegisterDocumentFormattingEditProvider.mock.calls[0][1];
+            const edits = provider.provideDocumentFormattingEdits(
+                makeModel('{"a":1,\n"b":2}')
+            );
+            expect(edits).toEqual([
+                { range: 'FULL_RANGE', text: '{"a": 1, "b": 2}' }
+            ]);
+        });
+
+        it('should return no edits when the document is already formatted', async () => {
+            vi.resetModules();
+            mockRegisterDocumentFormattingEditProvider.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            const provider =
+                mockRegisterDocumentFormattingEditProvider.mock.calls[0][1];
+            expect(
+                provider.provideDocumentFormattingEdits(
+                    makeModel('{"a": 1, "b": 2}')
+                )
+            ).toEqual([]);
+        });
+
+        it('should register a range formatting provider that snaps to the enclosing node', async () => {
+            vi.resetModules();
+            mockRegisterDocumentRangeFormattingEditProvider.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            const provider =
+                mockRegisterDocumentRangeFormattingEditProvider.mock
+                    .calls[0][1];
+            const doc = '{\n  "a": {\n    "b": 1\n  },\n  "c": 2\n}';
+            // Select from the opening brace of "a"'s value to its closing
+            // brace — the common ancestor is that object, which snaps to the
+            // "a" property.
+            const range = {
+                getStartPosition: () => ({ offset: doc.indexOf('{', 1) }),
+                getEndPosition: () => ({ offset: doc.indexOf('}') + 1 })
+            };
+            const edits = provider.provideDocumentRangeFormattingEdits(
+                makeModel(doc),
+                range
+            );
+            expect(edits).toEqual([
+                {
+                    range: {
+                        start: { offset: doc.indexOf('"a"') },
+                        end: { offset: doc.indexOf('},') + 1 }
+                    },
+                    text: '"a": {"b": 1}'
+                }
+            ]);
+        });
+
+        it('should add a Ctrl+Alt+R action that formats the selection when present, else the document', async () => {
+            vi.resetModules();
+            mockAddEditorAction.mockClear();
+            const service = await import('../editor-init-service');
+            await service.initializeEditorDependencies();
+            expect(mockAddEditorAction).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    id: 'deneb.formatDocumentOrSelection',
+                    label: 'Text_Editor_Action_Format',
+                    keybindings: [2048 | 512 | 48]
+                })
+            );
+            const { run } = mockAddEditorAction.mock.calls[0][0];
+            const actionRun = vi.fn();
+            const getAction = vi.fn(() => ({ run: actionRun }));
+
+            run({
+                getSelection: () => ({ isEmpty: () => false }),
+                getAction
+            });
+            expect(getAction).toHaveBeenLastCalledWith(
+                'editor.action.formatSelection'
+            );
+
+            run({
+                getSelection: () => ({ isEmpty: () => true }),
+                getAction
+            });
+            expect(getAction).toHaveBeenLastCalledWith(
+                'editor.action.formatDocument'
+            );
+            expect(actionRun).toHaveBeenCalledTimes(2);
+        });
+
+        it('should dispose previous formatting registrations before re-registering on retry', async () => {
+            vi.resetModules();
+            mockDisposeFormattingProvider.mockClear();
+            mockRegisterDocumentFormattingEditProvider.mockClear();
+            // Formatting is configured before keybindings; make keybindings
+            // throw so the first attempt fails after formatting is registered.
+            mockAddKeybindingRules.mockImplementationOnce(() => {
+                throw new Error('keybinding failure');
+            });
+            const service = await import('../editor-init-service');
+            await expect(
+                service.initializeEditorDependencies()
+            ).rejects.toThrow('keybinding failure');
+            expect(
+                mockRegisterDocumentFormattingEditProvider
+            ).toHaveBeenCalledTimes(1);
+
+            await service.initializeEditorDependencies();
+            // Three disposables (document provider, range provider, action)
+            // from the first attempt are disposed on retry.
+            expect(mockDisposeFormattingProvider).toHaveBeenCalledTimes(3);
+            expect(
+                mockRegisterDocumentFormattingEditProvider
+            ).toHaveBeenCalledTimes(2);
+        });
     });
 
     describe('retry behaviour', () => {

--- a/packages/app-core/src/lib/monaco/editor-init-service.ts
+++ b/packages/app-core/src/lib/monaco/editor-init-service.ts
@@ -2,6 +2,10 @@ import { loader } from '@monaco-editor/react';
 
 import { toBoolean } from '@deneb-viz/utils/type-conversion';
 import { logDebug } from '@deneb-viz/utils/logging';
+import {
+    formatJsoncCompact,
+    formatJsoncCompactRange
+} from '@deneb-viz/utils/jsonc';
 import { getProviderSchemaUrl } from '@deneb-viz/vega-runtime/embed';
 import {
     resolveFieldDefaults,
@@ -16,10 +20,7 @@ import {
     PARAMETER_NAMES_SUFFIX
 } from '@deneb-viz/data-core/field';
 
-import {
-    monaco,
-    setupMonacoWorker
-} from './monaco-integration';
+import { monaco, setupMonacoWorker } from './monaco-integration';
 import { getDenebState } from '../../state';
 import { getFieldDocumentationByName } from '../../lib/dataset';
 import { initializeSchemas, getProcessedSchema } from '../schema';
@@ -30,6 +31,10 @@ import { initializeSchemas, getProcessedSchema } from '../schema';
 let editorReady = false;
 let initPromise: Promise<void> | null = null;
 let completionProviderDisposable: { dispose(): void } | null = null;
+let formattingDisposables: { dispose(): void }[] = [];
+
+/** Action id for the Ctrl+Alt+R "format selection, else document" command. */
+const FORMAT_ACTION_ID = 'deneb.formatDocumentOrSelection';
 
 /**
  * Configure Monaco JSON diagnostics with the pre-processed Vega/Vega-Lite
@@ -174,8 +179,100 @@ const configureMonacoCompletionProvider = () => {
 };
 
 /**
+ * Read formatting options at invocation time, so a change to the
+ * `formattingMaxLineLength` property applies to the next format without
+ * re-registering providers.
+ */
+const getFormattingOptions = (model: monaco.editor.ITextModel) => ({
+    tabSize: model.getOptions().tabSize,
+    maxLineLength:
+        getDenebState().editorPreferences.jsonEditorFormattingMaxLineLength
+});
+
+/**
+ * Replace the JSON worker's formatter (jsonc-parser `format`, which has no
+ * line-length control) with Deneb's comment-preserving compact formatter.
+ * Registers document and range providers and a Ctrl+Alt+R action that
+ * formats the selection when there is one, otherwise the whole document.
+ */
+const configureMonacoFormatting = () => {
+    // Dispose any previous registrations before re-registering to prevent
+    // stacking duplicate providers on retry.
+    formattingDisposables.forEach((disposable) => disposable.dispose());
+    formattingDisposables = [];
+
+    const { jsonDefaults } = monaco.languages.json;
+    jsonDefaults.setModeConfiguration({
+        ...jsonDefaults.modeConfiguration,
+        documentFormattingEdits: false,
+        documentRangeFormattingEdits: false
+    });
+
+    formattingDisposables.push(
+        monaco.languages.registerDocumentFormattingEditProvider('json', {
+            provideDocumentFormattingEdits: (model) => {
+                const content = model.getValue();
+                const formatted = formatJsoncCompact(
+                    content,
+                    getFormattingOptions(model)
+                );
+                if (formatted === content) {
+                    return [];
+                }
+                return [{ range: model.getFullModelRange(), text: formatted }];
+            }
+        }),
+        monaco.languages.registerDocumentRangeFormattingEditProvider('json', {
+            provideDocumentRangeFormattingEdits: (model, range) => {
+                const content = model.getValue();
+                const offset = model.getOffsetAt(range.getStartPosition());
+                const length =
+                    model.getOffsetAt(range.getEndPosition()) - offset;
+                const edit = formatJsoncCompactRange(
+                    content,
+                    { offset, length },
+                    getFormattingOptions(model)
+                );
+                if (
+                    !edit ||
+                    content.slice(edit.offset, edit.offset + edit.length) ===
+                        edit.content
+                ) {
+                    return [];
+                }
+                return [
+                    {
+                        range: monaco.Range.fromPositions(
+                            model.getPositionAt(edit.offset),
+                            model.getPositionAt(edit.offset + edit.length)
+                        ),
+                        text: edit.content
+                    }
+                ];
+            }
+        }),
+        monaco.editor.addEditorAction({
+            id: FORMAT_ACTION_ID,
+            label: getDenebState().i18n.translate('Text_Editor_Action_Format'),
+            keybindings: [
+                monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KeyR
+            ],
+            run: (editor) => {
+                const selection = editor.getSelection();
+                const actionId =
+                    selection && !selection.isEmpty()
+                        ? 'editor.action.formatSelection'
+                        : 'editor.action.formatDocument';
+                return editor.getAction(actionId)?.run();
+            }
+        })
+    );
+};
+
+/**
  * Override default Monaco key bindings that clash with Deneb hotkeys and
- * add custom bindings for format and quick command.
+ * add the quick command binding. Format is bound by the editor action in
+ * `configureMonacoFormatting`.
  */
 const configureMonacoKeyBindings = () => {
     monaco.editor.addKeybindingRules([
@@ -189,11 +286,6 @@ const configureMonacoKeyBindings = () => {
         {
             keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
             command: null
-        },
-        {
-            keybinding:
-                monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KeyR,
-            command: 'editor.action.formatDocument'
         },
         {
             keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.F1,
@@ -227,7 +319,7 @@ const waitForPaint = () =>
  * 2. Set up the Monaco worker environment
  * 3. Initialize schemas (async — heavy AJV compilation)
  * 4. Initialize Monaco loader (async)
- * 5. Configure Monaco diagnostics, completions, and keybindings
+ * 5. Configure Monaco diagnostics, completions, formatting, and keybindings
  */
 const doInitialize = async (): Promise<void> => {
     // Ensure the Suspense fallback is visible before heavy work blocks
@@ -244,6 +336,7 @@ const doInitialize = async (): Promise<void> => {
     // Configure Monaco with the now-ready schemas
     configureMonacoDiagnostics();
     configureMonacoCompletionProvider();
+    configureMonacoFormatting();
     configureMonacoKeyBindings();
 
     editorReady = true;

--- a/packages/app-core/src/lib/monaco/editor-init-service.ts
+++ b/packages/app-core/src/lib/monaco/editor-init-service.ts
@@ -33,9 +33,6 @@ let initPromise: Promise<void> | null = null;
 let completionProviderDisposable: { dispose(): void } | null = null;
 let formattingDisposables: { dispose(): void }[] = [];
 
-/** Action id for the Ctrl+Alt+R "format selection, else document" command. */
-const FORMAT_ACTION_ID = 'deneb.formatDocumentOrSelection';
-
 /**
  * Configure Monaco JSON diagnostics with the pre-processed Vega/Vega-Lite
  * schemas. Enables schema-based validation and intellisense in the editor.
@@ -263,7 +260,7 @@ const configureMonacoFormatting = () => {
             }
         }),
         monaco.editor.addEditorAction({
-            id: FORMAT_ACTION_ID,
+            id: 'deneb.formatDocumentOrSelection',
             label: getDenebState().i18n.translate('Text_Editor_Action_Format'),
             keybindings: [
                 monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KeyR

--- a/packages/app-core/src/lib/monaco/editor-init-service.ts
+++ b/packages/app-core/src/lib/monaco/editor-init-service.ts
@@ -194,6 +194,7 @@ const getFormattingOptions = (model: monaco.editor.ITextModel) => ({
  * line-length control) with Deneb's comment-preserving compact formatter.
  * Registers document and range providers and a Ctrl+Alt+R action that
  * formats the selection when there is one, otherwise the whole document.
+ * Output line endings are normalized to the model's EOL.
  */
 const configureMonacoFormatting = () => {
     // Dispose any previous registrations before re-registering to prevent
@@ -215,7 +216,7 @@ const configureMonacoFormatting = () => {
                 const formatted = formatJsoncCompact(
                     content,
                     getFormattingOptions(model)
-                );
+                ).replace(/\n/g, model.getEOL());
                 if (formatted === content) {
                     return [];
                 }
@@ -233,10 +234,13 @@ const configureMonacoFormatting = () => {
                     { offset, length },
                     getFormattingOptions(model)
                 );
+                if (!edit) {
+                    return [];
+                }
+                const text = edit.content.replace(/\n/g, model.getEOL());
                 if (
-                    !edit ||
                     content.slice(edit.offset, edit.offset + edit.length) ===
-                        edit.content
+                    text
                 ) {
                     return [];
                 }
@@ -246,7 +250,7 @@ const configureMonacoFormatting = () => {
                             model.getPositionAt(edit.offset),
                             model.getPositionAt(edit.offset + edit.length)
                         ),
-                        text: edit.content
+                        text
                     }
                 ];
             }

--- a/packages/app-core/src/lib/monaco/editor-init-service.ts
+++ b/packages/app-core/src/lib/monaco/editor-init-service.ts
@@ -216,11 +216,18 @@ const configureMonacoFormatting = () => {
                 const formatted = formatJsoncCompact(
                     content,
                     getFormattingOptions(model)
-                ).replace(/\n/g, model.getEOL());
+                );
                 if (formatted === content) {
+                    // Invalid JSON is echoed back unchanged, and already-
+                    // formatted LF documents match directly — no edits.
                     return [];
                 }
-                return [{ range: model.getFullModelRange(), text: formatted }];
+                const text = formatted.replace(/\n/g, model.getEOL());
+                if (text === content) {
+                    // Valid, already formatted — just authored with CRLF.
+                    return [];
+                }
+                return [{ range: model.getFullModelRange(), text }];
             }
         }),
         monaco.languages.registerDocumentRangeFormattingEditProvider('json', {

--- a/packages/app-core/src/state/editor-preferences.ts
+++ b/packages/app-core/src/state/editor-preferences.ts
@@ -10,6 +10,7 @@ export type EditorPreferencesSliceProperties = {
     dataViewerRowsPerPage: number;
     jsonEditorDebouncePeriod: number;
     jsonEditorFontSize: number;
+    jsonEditorFormattingMaxLineLength: number;
     jsonEditorPosition: EditorPanePosition;
     jsonEditorShowLineNumbers: boolean;
     jsonEditorWordWrap: boolean;
@@ -45,6 +46,8 @@ export const createEditorPreferencesSlice =
                 DATA_VIEWER_CONFIGURATION.rowsPerPage.default,
             jsonEditorDebouncePeriod: EDITOR_DEFAULTS.debouncePeriod.default,
             jsonEditorFontSize: EDITOR_DEFAULTS.fontSize.default,
+            jsonEditorFormattingMaxLineLength:
+                EDITOR_DEFAULTS.formattingMaxLineLength.default,
             jsonEditorPosition: EDITOR_DEFAULTS.position as EditorPanePosition,
             jsonEditorShowLineNumbers: EDITOR_DEFAULTS.showLineNumbers,
             jsonEditorWordWrap: EDITOR_DEFAULTS.wordWrap,

--- a/packages/configuration/src/index.ts
+++ b/packages/configuration/src/index.ts
@@ -54,6 +54,7 @@ export const EDITOR_DEFAULTS = {
         min: 8,
         max: 30
     },
+    formattingMaxLineLength: { default: 80, min: 40, max: 200 },
     previewAreaShowBorder: true,
     previewAreaShowScrollbarsOnOverflow: true,
     previewAreaTransparentBackground: true,

--- a/packages/json-processing/src/__test__/processing.test.ts
+++ b/packages/json-processing/src/__test__/processing.test.ts
@@ -112,11 +112,18 @@ describe('getModifiedJsoncByPath', () => {
 });
 
 describe('getTextFormattedAsJsonC', () => {
-    it('should format the JSONC content with the specified tab size', () => {
+    it('should pack content that fits within the default max line length onto one line', () => {
+        const content = '{"name": "John", "age": 30}';
+        expect(getTextFormattedAsJsonC(content, 4)).toBe(
+            '{"name": "John", "age": 30}'
+        );
+    });
+
+    it('should expand content that exceeds the supplied max line length using the tab size', () => {
         const content = '{"name": "John", "age": 30}';
         const tabSize = 4;
         const indent = ' '.repeat(tabSize);
         const expected = `{\n${indent}"name": "John",\n${indent}"age": 30\n}`;
-        expect(getTextFormattedAsJsonC(content, tabSize)).toBe(expected);
+        expect(getTextFormattedAsJsonC(content, tabSize, 20)).toBe(expected);
     });
 });

--- a/packages/json-processing/src/__test__/template-usermeta.test.ts
+++ b/packages/json-processing/src/__test__/template-usermeta.test.ts
@@ -21,6 +21,7 @@ import {
     type UsermetaTemplate
 } from '@deneb-viz/template-usermeta';
 import { getBase64ImagePngBlank } from '@deneb-viz/utils/base64';
+import { formatJsoncCompact } from '@deneb-viz/utils/jsonc';
 import {
     getProviderSchemaUrl,
     type SpecProvider
@@ -285,7 +286,9 @@ describe('getExportTemplate', () => {
             trackedFields: TRACKED_FIELDS
         });
 
-        expect(result).toEqual(expectedJsonc);
+        expect(result).toEqual(
+            formatJsoncCompact(expectedJsonc, { tabSize: 2, maxLineLength: 80 })
+        );
     });
 });
 
@@ -519,7 +522,7 @@ describe('getTemplateResolvedForLegacyConfig', () => {
     const tabSize = 2;
     it('should return the template with resolved legacy config in the usermeta object', () => {
         const expectedTemplate =
-            '{ "usermeta": {"config": "{\\n  \\"foo\\": \\"bar\\"\\n}" } }';
+            '{ "usermeta": {"config": "{\\"foo\\": \\"bar\\"}" } }';
         const result = getTemplateResolvedForLegacyConfig(
             templateLegacy,
             tabSize
@@ -643,21 +646,11 @@ describe('getTemplateResolvedForPlaceholderAssignment', () => {
     it('should allocate the spec and config objects if config is in the usermeta object', () => {
         const expectedComponents: DenebTemplateAllocationComponents = {
             spec: `{
-  "data": {
-    "values": []
-  },
-  "mark": {
-    "type": "bar"
-  },
+  "data": {"values": []},
+  "mark": {"type": "bar"},
   "encoding": {
-    "x": {
-      "field": "__0__",
-      "type": "temporal"
-    },
-    "y": {
-      "field": "__1__",
-      "type": "quantitative"
-    }
+    "x": {"field": "__0__", "type": "temporal"},
+    "y": {"field": "__1__", "type": "quantitative"}
   }
 }`,
             config: `{\n  // Config\n  "font": "Arial"\n}`
@@ -732,21 +725,11 @@ describe('getTemplateResolvedForPlaceholderAssignment', () => {
 
         const expectedComponents: DenebTemplateAllocationComponents = {
             spec: `{
-  "data": {
-    "values": []
-  },
-  "mark": {
-    "type": "bar"
-  },
+  "data": {"values": []},
+  "mark": {"type": "bar"},
   "encoding": {
-    "x": {
-      "field": "__0__",
-      "type": "temporal"
-    },
-    "y": {
-      "field": "__1__",
-      "type": "quantitative"
-    }
+    "x": {"field": "__0__", "type": "temporal"},
+    "y": {"field": "__1__", "type": "quantitative"}
   }
 }`,
             config: `{}`

--- a/packages/json-processing/src/processing.ts
+++ b/packages/json-processing/src/processing.ts
@@ -1,13 +1,13 @@
 import {
     applyEdits,
-    format,
     getNodeValue,
     modify,
     parseTree,
     Node
 } from 'jsonc-parser';
 import { JSONPath } from 'vscode-json-languageservice';
-import { stripJsoncComments } from '@deneb-viz/utils/jsonc';
+import { EDITOR_DEFAULTS } from '@deneb-viz/configuration';
+import { formatJsoncCompact, stripJsoncComments } from '@deneb-viz/utils/jsonc';
 
 /**
  * For the supplied JSONC tree, return the JavaScript object value of the node.
@@ -70,10 +70,8 @@ export const getModifiedJsoncByPath = (
  * debugging tables, {@link getObjectFormattedAsText} should be used instead. This doesn't have as much overhead and is
  * better for cases where we need to process many objects.
  */
-export const getTextFormattedAsJsonC = (content: string, tabSize: number) => {
-    const formatted = format(content, undefined, {
-        tabSize,
-        insertSpaces: true
-    });
-    return applyEdits(content, formatted);
-};
+export const getTextFormattedAsJsonC = (
+    content: string,
+    tabSize: number,
+    maxLineLength: number = EDITOR_DEFAULTS.formattingMaxLineLength.default
+) => formatJsoncCompact(content, { tabSize, maxLineLength });

--- a/packages/json-processing/src/template-usermeta.ts
+++ b/packages/json-processing/src/template-usermeta.ts
@@ -68,13 +68,15 @@ export const getExportTemplate = (options: {
     supportFieldConfiguration?: SupportFieldConfiguration;
     tokenizedSpec: string;
     trackedFields: TrackedFields;
+    maxLineLength?: number;
 }) => {
     const {
         informationTranslationPlaceholders,
         metadata,
         supportFieldConfiguration,
         tokenizedSpec,
-        trackedFields
+        trackedFields,
+        maxLineLength
     } = options;
     const newMetadata = getPublishableUsermeta(metadata, {
         informationTranslationPlaceholders,
@@ -98,7 +100,7 @@ export const getExportTemplate = (options: {
             }
         )
     );
-    return getTextFormattedAsJsonC(withSchema, 2);
+    return getTextFormattedAsJsonC(withSchema, 2, maxLineLength);
 };
 
 const getFieldPatternByKey = (key: string) =>
@@ -269,14 +271,16 @@ export const getTemplateReplacedForDataset = (
  */
 export const getTemplateResolvedForLegacyConfig = (
     template: string,
-    tabSize: number
+    tabSize: number,
+    maxLineLength?: number
 ) => {
     const { config } = getTemplateMetadata(template);
     if (!config) {
         const tree = getJsoncTree(template);
         const newConfig = getTextFormattedAsJsonC(
             JSON.stringify(getJsoncNodeValue(tree)?.config || {}),
-            tabSize
+            tabSize,
+            maxLineLength
         );
         const appliedConfig = getModifiedJsoncByPath(
             template,
@@ -367,7 +371,8 @@ export const getTemplateResolvedForLegacyVersions = (
  */
 export const getTemplateResolvedForPlaceholderAssignment = (
     template: string,
-    tabSize: number
+    tabSize: number,
+    maxLineLength?: number
 ): DenebTemplateAllocationComponents => {
     const config = getTemplateMetadata(template)?.config || '{}';
     const keysToRemove = ['$schema', 'usermeta'];
@@ -376,7 +381,8 @@ export const getTemplateResolvedForPlaceholderAssignment = (
             (result, key) => getModifiedJsoncByPath(result, [key], undefined),
             template
         ),
-        tabSize
+        tabSize,
+        maxLineLength
     );
     return {
         spec,
@@ -434,7 +440,8 @@ export const getUpdatedExportMetadata = (
  */
 export const getValidatedTemplate = (
     content: string,
-    tabSize: number
+    tabSize: number,
+    maxLineLength?: number
 ): DenebTemplateSetImportFilePayload => {
     try {
         if (!getJsoncStringAsObject(content)) return INVALID_TEMPLATE_OPTIONS;
@@ -445,7 +452,8 @@ export const getValidatedTemplate = (
         );
         const templateResolvedLegacyConfig = getTemplateResolvedForLegacyConfig(
             templateResolvedLegacy,
-            tabSize
+            tabSize,
+            maxLineLength
         );
         const templateResolvedLegacyDataset =
             getTemplateResolvedForLegacyDataset(templateResolvedLegacyConfig);
@@ -455,7 +463,8 @@ export const getValidatedTemplate = (
         if (valid) {
             const candidates = getTemplateResolvedForPlaceholderAssignment(
                 templateResolvedLegacyDataset,
-                tabSize
+                tabSize,
+                maxLineLength
             );
             return {
                 candidates,

--- a/packages/utils/src/lib/__tests__/jsonc-format.test.ts
+++ b/packages/utils/src/lib/__tests__/jsonc-format.test.ts
@@ -417,4 +417,63 @@ describe('formatJsoncCompactRange', () => {
             '{\n  "a": {"b": 1}, // keep me\n  "c": 2\n}'
         );
     });
+
+    // A comment between a property's key and its value sits INSIDE the
+    // property's source span, but attaches to the NEXT sibling (or the
+    // enclosing container when there is none) — outside the property's
+    // subtree. Replacing only the property's span must not swallow it: the
+    // target widens until the replacement re-renders the comment.
+    describe('comments inside the target span but attached outside it', () => {
+        it('key–value gap with a following sibling: widens so the comment survives', () => {
+            const doc = '{"a" /* keep */: 1, "b": 2}';
+            const edit = formatJsoncCompactRange(
+                doc,
+                rangeOf(doc, '"a"'),
+                OPTIONS
+            )!;
+            const result = apply(doc, edit);
+            expect(result).toContain('/* keep */');
+            // Widening lands on the root object here, so the applied result
+            // matches whole-document formatting.
+            expect(result).toBe(formatJsoncCompact(doc, OPTIONS));
+        });
+
+        it('colon–value gap on the only property: widens so the comment survives', () => {
+            const doc = '{\n  "a": /* keep */ 1\n}';
+            const edit = formatJsoncCompactRange(
+                doc,
+                rangeOf(doc, '1'),
+                OPTIONS
+            )!;
+            expect(apply(doc, edit)).toContain('/* keep */');
+        });
+
+        it('does not widen when the comment lies outside the target span', () => {
+            const doc = '{"a": {\n  /* keep */ "x": 1\n}, "b": 2}';
+            const edit = formatJsoncCompactRange(
+                doc,
+                rangeOf(doc, '"x"'),
+                OPTIONS
+            )!;
+            // The comment leads "x", sitting BEFORE the property's span —
+            // the edit stays narrow and the comment survives in place.
+            expect(doc.slice(edit.offset, edit.offset + edit.length)).toBe(
+                '"x": 1'
+            );
+            expect(apply(doc, edit)).toContain('/* keep */');
+        });
+
+        it('does not widen for a gap comment elsewhere in the document', () => {
+            const doc = '{"a" /* keep */: 1, "b": {"c":1}}';
+            const edit = formatJsoncCompactRange(
+                doc,
+                rangeOf(doc, '"c"'),
+                OPTIONS
+            )!;
+            expect(doc.slice(edit.offset, edit.offset + edit.length)).toBe(
+                '"c":1'
+            );
+            expect(apply(doc, edit)).toContain('/* keep */');
+        });
+    });
 });

--- a/packages/utils/src/lib/__tests__/jsonc-format.test.ts
+++ b/packages/utils/src/lib/__tests__/jsonc-format.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import stringify from 'json-stringify-pretty-compact';
+import { formatJsoncCompact } from '../jsonc-format';
+
+const OPTIONS = { tabSize: 2, maxLineLength: 80 };
+
+/**
+ * For comment-free JSON, the formatter must match json-stringify-pretty-compact
+ * byte-for-byte at the same indent / maxLength. That library is what Vega
+ * Editor uses (with defaults: indent 2, maxLength 80).
+ */
+const expectParity = (value: unknown, maxLineLength = 80, tabSize = 2) => {
+    const source = JSON.stringify(value);
+    expect(formatJsoncCompact(source, { tabSize, maxLineLength })).toBe(
+        stringify(value, { indent: tabSize, maxLength: maxLineLength })
+    );
+};
+
+const BAR_CHART = {
+    $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+    data: { name: 'dataset' },
+    mark: { type: 'bar', tooltip: true },
+    encoding: {
+        x: { field: 'Category', type: 'nominal' },
+        y: { field: 'Sales', type: 'quantitative', aggregate: 'sum' },
+        color: {
+            field: 'Category',
+            type: 'nominal',
+            legend: null,
+            scale: { scheme: 'tableau10' }
+        }
+    }
+};
+
+describe('formatJsoncCompact — parity with json-stringify-pretty-compact', () => {
+    it('matches for a typical Vega-Lite spec', () => {
+        expectParity(BAR_CHART);
+    });
+
+    it('matches for empty containers', () => {
+        expectParity({});
+        expectParity([]);
+        expectParity({ a: {}, b: [], c: { d: [] } });
+    });
+
+    it('matches for arrays of scalars and nested arrays', () => {
+        expectParity({ values: [1, 2, 3, 4, 5] });
+        expectParity({
+            matrix: [
+                [1, 2],
+                [3, 4],
+                [5, 6]
+            ]
+        });
+        expectParity({ long: Array.from({ length: 40 }, (_, i) => i * 1000) });
+    });
+
+    it('matches for strings that cannot fit on one line', () => {
+        expectParity({
+            expr: 'datum.Sales > 100 && datum.Category !== "Other" && datum.Region === "North America"',
+            short: 'x'
+        });
+    });
+
+    it('matches at different max line lengths and tab sizes', () => {
+        expectParity(BAR_CHART, 40);
+        expectParity(BAR_CHART, 120);
+        expectParity(BAR_CHART, 200, 4);
+    });
+
+    it('matches for a root-level array and root-level scalar', () => {
+        expectParity([{ a: 1 }, { b: 2 }]);
+        expectParity(42);
+        expectParity('text');
+    });
+});
+
+describe('formatJsoncCompact — literal fidelity', () => {
+    it('preserves number lexemes exactly', () => {
+        expect(
+            formatJsoncCompact('{"a": 1.0, "b": 1e3, "c": -0}', OPTIONS)
+        ).toBe('{"a": 1.0, "b": 1e3, "c": -0}');
+    });
+
+    it('preserves string escapes and brace-like characters inside strings', () => {
+        const source =
+            '{"a": "\\u00e9", "b": "{not json}", "c": "// not a comment", "d": "/* x */"}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+});
+
+describe('formatJsoncCompact — invalid and empty input', () => {
+    it('returns invalid JSON unchanged', () => {
+        const broken = '{"a": 1,';
+        expect(formatJsoncCompact(broken, OPTIONS)).toBe(broken);
+    });
+
+    it('returns empty input unchanged', () => {
+        expect(formatJsoncCompact('', OPTIONS)).toBe('');
+        expect(formatJsoncCompact('   ', OPTIONS)).toBe('   ');
+    });
+
+    it('returns content with a trailing comma unchanged', () => {
+        const trailing = '{"a": 1,}';
+        expect(formatJsoncCompact(trailing, OPTIONS)).toBe(trailing);
+    });
+});
+
+describe('formatJsoncCompact — idempotence', () => {
+    it('formatting twice yields the same output', () => {
+        const once = formatJsoncCompact(JSON.stringify(BAR_CHART), OPTIONS);
+        expect(formatJsoncCompact(once, OPTIONS)).toBe(once);
+    });
+});

--- a/packages/utils/src/lib/__tests__/jsonc-format.test.ts
+++ b/packages/utils/src/lib/__tests__/jsonc-format.test.ts
@@ -112,3 +112,130 @@ describe('formatJsoncCompact — idempotence', () => {
         expect(formatJsoncCompact(once, OPTIONS)).toBe(once);
     });
 });
+
+describe('formatJsoncCompact — comments', () => {
+    it('keeps a leading comment above its property and expands the container', () => {
+        const source =
+            '{"mark": {\n  // keep bars thin\n  "type": "bar", "width": 4}, "data": {"name": "dataset"}}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            [
+                '{',
+                '  "mark": {',
+                '    // keep bars thin',
+                '    "type": "bar",',
+                '    "width": 4',
+                '  },',
+                '  "data": {"name": "dataset"}',
+                '}'
+            ].join('\n')
+        );
+    });
+
+    it('keeps a trailing comment on the same line, after the comma', () => {
+        const source =
+            '{\n  "width": 400, // matches the report page\n  "height": 300\n}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('keeps a trailing comment on the last property (no comma)', () => {
+        const source = '{\n  "width": 400,\n  "height": 300 // tall\n}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('keeps a trailing comment after a nested container', () => {
+        const source = '{\n  "a": {"b": 1}, // nested\n  "c": 2\n}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('expands an array that contains a comment (same-line comment trails the preceding element)', () => {
+        const source = '{"values": [1, /* two */ 2, 3]}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            [
+                '{',
+                '  "values": [',
+                '    1, /* two */',
+                '    2,',
+                '    3',
+                '  ]',
+                '}'
+            ].join('\n')
+        );
+    });
+
+    it('places a comment on its own line above the element it precedes', () => {
+        const source = '{"values": [1,\n  // two\n  2, 3]}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            [
+                '{',
+                '  "values": [',
+                '    1,',
+                '    // two',
+                '    2,',
+                '    3',
+                '  ]',
+                '}'
+            ].join('\n')
+        );
+    });
+
+    it('keeps a comment that sits after the last child inside its container', () => {
+        const source = '{\n  "a": 1\n  // end of object\n}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('keeps comments inside an otherwise empty container', () => {
+        const source = '{\n  // nothing yet\n}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('emits comments before and after the root value on their own lines', () => {
+        const source = '// header\n{"a": 1} // same line as root\n// footer';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(source);
+    });
+
+    it('re-indents the continuation lines of a multi-line block comment', () => {
+        const source = [
+            '{',
+            '  "transform": [',
+            '    /* Filter out',
+            '            nulls first */',
+            '    {"filter": "datum.Sales != null"}',
+            '  ]',
+            '}',
+            '// TODO: add a legend'
+        ].join('\n');
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            [
+                '{',
+                '  "transform": [',
+                '    /* Filter out',
+                '       nulls first */',
+                '    {"filter": "datum.Sales != null"}',
+                '  ]',
+                '}',
+                '// TODO: add a legend'
+            ].join('\n')
+        );
+    });
+
+    it('moves a comment between a key and its value above the next entry (documented quirk)', () => {
+        const source = '{"a": // odd place\n  1, "b": 2}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            ['{', '  "a": 1,', '  // odd place', '  "b": 2', '}'].join('\n')
+        );
+    });
+
+    it('moves a comment between the last key and its value to the end of the object (documented quirk)', () => {
+        const source = '{"a": 1, "b": // odd place\n  2}';
+        expect(formatJsoncCompact(source, OPTIONS)).toBe(
+            ['{', '  "a": 1,', '  "b": 2', '  // odd place', '}'].join('\n')
+        );
+    });
+
+    it('is idempotent with comments present', () => {
+        const source =
+            '// header\n{"mark": {\n  // keep bars thin\n  "type": "bar"}, "w": 1 // trailing\n}';
+        const once = formatJsoncCompact(source, OPTIONS);
+        expect(formatJsoncCompact(once, OPTIONS)).toBe(once);
+    });
+});

--- a/packages/utils/src/lib/__tests__/jsonc-format.test.ts
+++ b/packages/utils/src/lib/__tests__/jsonc-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import stringify from 'json-stringify-pretty-compact';
-import { formatJsoncCompact } from '../jsonc-format';
+import { formatJsoncCompact, formatJsoncCompactRange } from '../jsonc-format';
 
 const OPTIONS = { tabSize: 2, maxLineLength: 80 };
 
@@ -237,5 +237,184 @@ describe('formatJsoncCompact — comments', () => {
             '// header\n{"mark": {\n  // keep bars thin\n  "type": "bar"}, "w": 1 // trailing\n}';
         const once = formatJsoncCompact(source, OPTIONS);
         expect(formatJsoncCompact(once, OPTIONS)).toBe(once);
+    });
+});
+
+describe('formatJsoncCompactRange', () => {
+    const DOC = [
+        '{',
+        '  "mark": "bar",',
+        '  "encoding": {',
+        '    "x": {',
+        '      "field": "Category",',
+        '      "type": "nominal"',
+        '    },',
+        '    "y": {"field": "Sales", "type": "quantitative"}',
+        '  },',
+        '  "data": [1,2,3]',
+        '}'
+    ].join('\n');
+
+    const apply = (
+        doc: string,
+        edit: { offset: number; length: number; content: string }
+    ) =>
+        doc.slice(0, edit.offset) +
+        edit.content +
+        doc.slice(edit.offset + edit.length);
+
+    const rangeOf = (doc: string, text: string) => ({
+        offset: doc.indexOf(text),
+        length: text.length
+    });
+
+    /** Offsets spanning from the start of `from` to the end of `to`. */
+    const spanOf = (doc: string, from: string, to: string) => {
+        const offset = doc.indexOf(from);
+        return { offset, length: doc.indexOf(to) + to.length - offset };
+    };
+
+    const X_BODY = spanOf(DOC, '"field": "Category"', '"nominal"');
+
+    it('snaps a selection on a scalar value to its property (which may already be formatted)', () => {
+        const edit = formatJsoncCompactRange(
+            DOC,
+            rangeOf(DOC, '"Category"'),
+            OPTIONS
+        )!;
+        expect(DOC.slice(edit.offset, edit.offset + edit.length)).toBe(
+            '"field": "Category"'
+        );
+        expect(edit.content).toBe('"field": "Category"');
+    });
+
+    it('snaps a selection spanning the children of a nested object to the enclosing property', () => {
+        const edit = formatJsoncCompactRange(DOC, X_BODY, OPTIONS);
+        expect(edit).toBeDefined();
+        expect(DOC.slice(edit!.offset, edit!.offset + edit!.length)).toBe(
+            '"x": {\n      "field": "Category",\n      "type": "nominal"\n    }'
+        );
+        expect(edit!.content).toBe(
+            '"x": {"field": "Category", "type": "nominal"}'
+        );
+    });
+
+    it('leaves the rest of the document untouched when applying the edit', () => {
+        const edit = formatJsoncCompactRange(DOC, X_BODY, OPTIONS)!;
+        expect(apply(DOC, edit)).toBe(
+            [
+                '{',
+                '  "mark": "bar",',
+                '  "encoding": {',
+                '    "x": {"field": "Category", "type": "nominal"},',
+                '    "y": {"field": "Sales", "type": "quantitative"}',
+                '  },',
+                '  "data": [1,2,3]',
+                '}'
+            ].join('\n')
+        );
+    });
+
+    it('snaps a selection spanning two siblings to their parent', () => {
+        const start = DOC.indexOf('"x"');
+        const end = DOC.indexOf('"quantitative"}') + '"quantitative"}'.length;
+        const edit = formatJsoncCompactRange(
+            DOC,
+            { offset: start, length: end - start },
+            OPTIONS
+        )!;
+        expect(
+            DOC.slice(edit.offset, edit.offset + edit.length).startsWith(
+                '"encoding": {'
+            )
+        ).toBe(true);
+        expect(edit.content).toBe(
+            [
+                '"encoding": {',
+                '    "x": {"field": "Category", "type": "nominal"},',
+                '    "y": {"field": "Sales", "type": "quantitative"}',
+                '  }'
+            ].join('\n')
+        );
+    });
+
+    it('snaps a selection on a key to the whole property', () => {
+        const edit = formatJsoncCompactRange(
+            DOC,
+            rangeOf(DOC, '"data"'),
+            OPTIONS
+        )!;
+        expect(DOC.slice(edit.offset, edit.offset + edit.length)).toBe(
+            '"data": [1,2,3]'
+        );
+        expect(edit.content).toBe('"data": [1, 2, 3]');
+    });
+
+    it('uses structural depth for continuation-line indent', () => {
+        const narrow = { tabSize: 2, maxLineLength: 30 };
+        const edit = formatJsoncCompactRange(
+            DOC,
+            spanOf(DOC, '"field": "Sales"', '"quantitative"'),
+            narrow
+        )!;
+        // "y" sits two containers deep (root → encoding's object), so its
+        // children indent to 6 and its closer to 4.
+        expect(edit.content).toBe(
+            [
+                '"y": {',
+                '      "field": "Sales",',
+                '      "type": "quantitative"',
+                '    }'
+            ].join('\n')
+        );
+    });
+
+    it('reserves a column for the comma when the target is not the last sibling', () => {
+        // "x" + comma is exactly 1 over the limit when packed at depth 2.
+        const flat = '"x": {"field": "Category", "type": "nominal"}';
+        const limit = 2 * 2 + flat.length; // indent + flat, no room for the comma
+        const edit = formatJsoncCompactRange(DOC, X_BODY, {
+            tabSize: 2,
+            maxLineLength: limit
+        })!;
+        expect(edit.content.includes('\n')).toBe(true);
+        // One more column and it fits.
+        const roomy = formatJsoncCompactRange(DOC, X_BODY, {
+            tabSize: 2,
+            maxLineLength: limit + 1
+        })!;
+        expect(roomy.content).toBe(flat);
+    });
+
+    it('formats the whole document when the selection is outside the root', () => {
+        const doc = '{"a":1}\n\n';
+        const edit = formatJsoncCompactRange(
+            doc,
+            { offset: doc.length - 1, length: 0 },
+            OPTIONS
+        )!;
+        expect(edit).toEqual({ offset: 0, length: 7, content: '{"a": 1}' });
+    });
+
+    it('returns undefined for invalid JSON', () => {
+        expect(
+            formatJsoncCompactRange(
+                '{"a": 1,',
+                { offset: 0, length: 1 },
+                OPTIONS
+            )
+        ).toBeUndefined();
+    });
+
+    it('does not touch comments outside the target span', () => {
+        const doc = '{\n  "a": {"b":1}, // keep me\n  "c": 2\n}';
+        const edit = formatJsoncCompactRange(
+            doc,
+            rangeOf(doc, '"b"'),
+            OPTIONS
+        )!;
+        expect(apply(doc, edit)).toBe(
+            '{\n  "a": {"b": 1}, // keep me\n  "c": 2\n}'
+        );
     });
 });

--- a/packages/utils/src/lib/jsonc-format.ts
+++ b/packages/utils/src/lib/jsonc-format.ts
@@ -33,9 +33,7 @@ export interface JsoncTextEdit extends JsoncRange {
     content: string;
 }
 
-interface JsoncComment extends JsoncRange {
-    text: string;
-}
+type JsoncComment = JsoncRange;
 
 /**
  * Where every comment has been attached, keyed by AST node identity.
@@ -67,8 +65,8 @@ const nodeEnd = (span: JsoncRange) => span.offset + span.length;
 const contains = (node: Node, offset: number) =>
     node.offset <= offset && offset < nodeEnd(node);
 
-const raw = (ctx: RenderContext, node: Node) =>
-    ctx.content.slice(node.offset, nodeEnd(node));
+const raw = (ctx: RenderContext, span: JsoncRange) =>
+    ctx.content.slice(span.offset, nodeEnd(span));
 
 const indentFor = (ctx: RenderContext, depth: number) =>
     ' '.repeat(depth * ctx.options.tabSize);
@@ -86,24 +84,13 @@ const pushTo = (
     map: Map<Node, JsoncComment[]>,
     node: Node,
     comment: JsoncComment
-) => {
-    const existing = map.get(node);
-    if (existing) {
-        existing.push(comment);
-    } else {
-        map.set(node, [comment]);
-    }
-};
+) => map.set(node, [...(map.get(node) ?? []), comment]);
 
 const collectComments = (content: string): JsoncComment[] => {
     const comments: JsoncComment[] = [];
     visit(content, {
         onComment: (offset, length) => {
-            comments.push({
-                offset,
-                length,
-                text: content.slice(offset, offset + length)
-            });
+            comments.push({ offset, length });
         }
     });
     return comments;
@@ -242,9 +229,10 @@ const renderComment = (
     comment: JsoncComment,
     depth: number
 ) => {
-    const lines = comment.text.split(/\r?\n/);
+    const text = raw(ctx, comment);
+    const lines = text.split(/\r?\n/);
     if (lines.length === 1) {
-        return comment.text;
+        return text;
     }
     const continuation = `${indentFor(ctx, depth)}   `;
     return [

--- a/packages/utils/src/lib/jsonc-format.ts
+++ b/packages/utils/src/lib/jsonc-format.ts
@@ -390,10 +390,60 @@ const findFormatTarget = (root: Node, range: JsoncRange): Node => {
     return ancestor.parent?.type === 'property' ? ancestor.parent : ancestor;
 };
 
+const isWithinSubtree = (node: Node, ancestor: Node): boolean => {
+    for (
+        let current: Node | undefined = node;
+        current;
+        current = current.parent
+    ) {
+        if (current === ancestor) {
+            return true;
+        }
+    }
+    return false;
+};
+
+const spanContainsComment = (span: JsoncRange, comment: JsoncComment) =>
+    comment.offset >= span.offset && nodeEnd(comment) <= nodeEnd(span);
+
+/**
+ * Whether replacing `target`'s span with `renderNode(target)` would delete a
+ * comment. A comment between a property's key and its value lies INSIDE the
+ * property's source span but attaches to the NEXT sibling (or the enclosing
+ * container when there is none) — outside the property's subtree — so the
+ * replacement would swallow its bytes without re-rendering it anywhere.
+ */
+const rangeRenderDropsComments = (
+    ctx: RenderContext,
+    target: Node
+): boolean => {
+    const maps = [
+        ctx.comments.leading,
+        ctx.comments.trailing,
+        ctx.comments.inner
+    ];
+    for (const map of maps) {
+        for (const [node, comments] of map) {
+            for (const comment of comments) {
+                if (
+                    spanContainsComment(target, comment) &&
+                    !isWithinSubtree(node, target)
+                ) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+};
+
 /**
  * Format only the smallest complete value or property that contains `range`.
  * Returns the single edit to apply, or `undefined` for invalid JSON. Comments
- * outside the target node's span are untouched.
+ * outside the target node's span are untouched. The target widens to an
+ * ancestor when its own span contains a comment the rendered replacement
+ * would not carry (see {@link rangeRenderDropsComments}) — at the root every
+ * in-span comment is attached within the subtree, so widening terminates.
  */
 export const formatJsoncCompactRange = (
     content: string,
@@ -404,7 +454,10 @@ export const formatJsoncCompactRange = (
     if (!ctx) {
         return undefined;
     }
-    const target = findFormatTarget(ctx.root, range);
+    let target = findFormatTarget(ctx.root, range);
+    while (target.parent && rangeRenderDropsComments(ctx, target)) {
+        target = target.parent;
+    }
     const siblings = target.parent?.children ?? [];
     const isLast =
         siblings.length === 0 || siblings[siblings.length - 1] === target;

--- a/packages/utils/src/lib/jsonc-format.ts
+++ b/packages/utils/src/lib/jsonc-format.ts
@@ -1,0 +1,431 @@
+import {
+    findNodeAtOffset,
+    parseTree,
+    visit,
+    type Node,
+    type ParseError
+} from 'jsonc-parser';
+
+/**
+ * Options for the compact JSONC formatter.
+ */
+export interface JsoncCompactFormatOptions {
+    /** Spaces per indent level. */
+    tabSize: number;
+    /**
+     * A container (object/array) whose single-line form — including its
+     * indent, key prefix and trailing comma — fits within this many characters
+     * is written on one line. Anything longer is expanded one child per line.
+     */
+    maxLineLength: number;
+}
+
+/** A span of the source text, in character offsets. */
+export interface JsoncRange {
+    offset: number;
+    length: number;
+}
+
+/** A replacement for a span of the source text. */
+export interface JsoncTextEdit extends JsoncRange {
+    content: string;
+}
+
+interface JsoncComment extends JsoncRange {
+    text: string;
+}
+
+/**
+ * Where every comment has been attached, keyed by AST node identity.
+ *
+ * - `leading`: emitted on their own line(s) immediately above the node.
+ * - `trailing`: emitted at the end of the node's line (after its comma).
+ * - `inner`: inside a container, after its last child, before the closer.
+ * - `after`: after the root value, at the end of the document.
+ */
+interface CommentAttachments {
+    leading: Map<Node, JsoncComment[]>;
+    trailing: Map<Node, JsoncComment[]>;
+    inner: Map<Node, JsoncComment[]>;
+    after: JsoncComment[];
+}
+
+interface RenderContext {
+    content: string;
+    root: Node;
+    comments: CommentAttachments;
+    options: JsoncCompactFormatOptions;
+}
+
+const isContainer = (node: Node) =>
+    node.type === 'object' || node.type === 'array';
+
+const nodeEnd = (span: JsoncRange) => span.offset + span.length;
+
+const contains = (node: Node, offset: number) =>
+    node.offset <= offset && offset < nodeEnd(node);
+
+const raw = (ctx: RenderContext, node: Node) =>
+    ctx.content.slice(node.offset, nodeEnd(node));
+
+const indentFor = (ctx: RenderContext, depth: number) =>
+    ' '.repeat(depth * ctx.options.tabSize);
+
+const bracketsFor = (node: Node): [string, string] =>
+    node.type === 'object' ? ['{', '}'] : ['[', ']'];
+
+/**
+ * Only horizontal whitespace and at most one comma may sit between the end of
+ * a node and a comment for that comment to count as trailing the node.
+ */
+const TRAILING_GAP = /^[ \t]*,?[ \t]*$/;
+
+const pushTo = (
+    map: Map<Node, JsoncComment[]>,
+    node: Node,
+    comment: JsoncComment
+) => {
+    const existing = map.get(node);
+    if (existing) {
+        existing.push(comment);
+    } else {
+        map.set(node, [comment]);
+    }
+};
+
+const collectComments = (content: string): JsoncComment[] => {
+    const comments: JsoncComment[] = [];
+    visit(content, {
+        onComment: (offset, length) => {
+            comments.push({
+                offset,
+                length,
+                text: content.slice(offset, offset + length)
+            });
+        }
+    });
+    return comments;
+};
+
+/**
+ * Deepest object/array whose span contains `offset`, or `undefined` when the
+ * offset lies outside the root value. Property nodes are passed through: an
+ * offset between a key and its value resolves to the enclosing object.
+ */
+const findEnclosingContainer = (
+    root: Node,
+    offset: number
+): Node | undefined => {
+    let enclosing: Node | undefined;
+    let node: Node | undefined = root;
+    while (node && contains(node, offset)) {
+        if (isContainer(node)) {
+            enclosing = node;
+        }
+        node = node.children?.find((child) => contains(child, offset));
+    }
+    return enclosing;
+};
+
+/**
+ * Attach every comment to a node. Candidates are the children of the
+ * container the comment sits in (property nodes for objects, element nodes for
+ * arrays), or the root when the comment is outside it.
+ */
+const attachComments = (content: string, root: Node): CommentAttachments => {
+    const attachments: CommentAttachments = {
+        leading: new Map(),
+        trailing: new Map(),
+        inner: new Map(),
+        after: []
+    };
+    for (const comment of collectComments(content)) {
+        const enclosing = findEnclosingContainer(root, comment.offset);
+        const candidates = enclosing ? (enclosing.children ?? []) : [root];
+        const previous = candidates
+            .filter((candidate) => nodeEnd(candidate) <= comment.offset)
+            .pop();
+        const next = candidates.find(
+            (candidate) => candidate.offset >= nodeEnd(comment)
+        );
+        const gapBefore = previous
+            ? content.slice(nodeEnd(previous), comment.offset)
+            : null;
+        if (previous && gapBefore !== null && TRAILING_GAP.test(gapBefore)) {
+            pushTo(attachments.trailing, previous, comment);
+        } else if (next) {
+            pushTo(attachments.leading, next, comment);
+        } else if (enclosing) {
+            pushTo(attachments.inner, enclosing, comment);
+        } else {
+            attachments.after.push(comment);
+        }
+    }
+    return attachments;
+};
+
+const parseDocument = (
+    content: string,
+    options: JsoncCompactFormatOptions
+): RenderContext | undefined => {
+    const errors: ParseError[] = [];
+    const root = parseTree(content, errors);
+    if (!root || errors.length > 0) {
+        return undefined;
+    }
+    return {
+        content,
+        root,
+        comments: attachComments(content, root),
+        options
+    };
+};
+
+/**
+ * Whether any comment is attached inside `node` (its inner comments, or any
+ * descendant's leading/trailing comments). The node's own leading/trailing
+ * comments do not count — they are emitted by its parent and do not prevent
+ * the node itself from being written on one line.
+ */
+const subtreeHasComments = (ctx: RenderContext, node: Node): boolean =>
+    ctx.comments.inner.has(node) ||
+    (node.children ?? []).some(
+        (child) =>
+            ctx.comments.leading.has(child) ||
+            ctx.comments.trailing.has(child) ||
+            subtreeHasComments(ctx, child)
+    );
+
+/**
+ * Single-line rendering of `node`, or `null` when a comment anywhere inside it
+ * rules that out. Spacing matches json-stringify-pretty-compact: a space after
+ * `:` and `,`, none inside the brackets.
+ */
+const renderFlat = (ctx: RenderContext, node: Node): string | null => {
+    if (node.type === 'property') {
+        const key = node.children?.[0];
+        const value = node.children?.[1];
+        if (!key || !value) {
+            return raw(ctx, node);
+        }
+        const flatValue = renderFlat(ctx, value);
+        return flatValue === null ? null : `${raw(ctx, key)}: ${flatValue}`;
+    }
+    if (!isContainer(node)) {
+        return raw(ctx, node);
+    }
+    if (subtreeHasComments(ctx, node)) {
+        return null;
+    }
+    const parts: string[] = [];
+    for (const child of node.children ?? []) {
+        const part = renderFlat(ctx, child);
+        if (part === null) {
+            return null;
+        }
+        parts.push(part);
+    }
+    const [open, close] = bracketsFor(node);
+    return `${open}${parts.join(', ')}${close}`;
+};
+
+/**
+ * Multi-line block comments have their continuation lines trimmed and
+ * re-aligned three columns in from the current indent (under the text that
+ * follows the opening block-comment marker). Single-line comments are emitted
+ * verbatim.
+ */
+const renderComment = (
+    ctx: RenderContext,
+    comment: JsoncComment,
+    depth: number
+) => {
+    const lines = comment.text.split(/\r?\n/);
+    if (lines.length === 1) {
+        return comment.text;
+    }
+    const continuation = `${indentFor(ctx, depth)}   `;
+    return [
+        lines[0],
+        ...lines.slice(1).map((line) => `${continuation}${line.trim()}`)
+    ].join('\n');
+};
+
+const trailingSuffix = (ctx: RenderContext, node: Node, depth: number) =>
+    (ctx.comments.trailing.get(node) ?? [])
+        .map((comment) => ` ${renderComment(ctx, comment, depth)}`)
+        .join('');
+
+/**
+ * Render `node` at structural `depth`. The first line is returned without
+ * indent (the caller positions it); continuation lines carry absolute indent.
+ * `reserved` is the width already committed on the first line — the `"key": `
+ * prefix and the trailing comma — mirroring json-stringify-pretty-compact's
+ * fit test.
+ */
+const renderNode = (
+    ctx: RenderContext,
+    node: Node,
+    depth: number,
+    reserved: number
+): string => {
+    if (node.type === 'property') {
+        const key = node.children?.[0];
+        const value = node.children?.[1];
+        if (!key || !value) {
+            return raw(ctx, node);
+        }
+        const keyPrefix = `${raw(ctx, key)}: `;
+        return `${keyPrefix}${renderNode(
+            ctx,
+            value,
+            depth,
+            reserved + keyPrefix.length
+        )}`;
+    }
+    if (!isContainer(node)) {
+        return raw(ctx, node);
+    }
+    const flat = renderFlat(ctx, node);
+    const indentWidth = depth * ctx.options.tabSize;
+    if (
+        flat !== null &&
+        indentWidth + reserved + flat.length <= ctx.options.maxLineLength
+    ) {
+        return flat;
+    }
+    const [open, close] = bracketsFor(node);
+    const children = node.children ?? [];
+    const inner = ctx.comments.inner.get(node) ?? [];
+    if (children.length === 0 && inner.length === 0) {
+        return `${open}${close}`;
+    }
+    const childDepth = depth + 1;
+    const childIndent = indentFor(ctx, childDepth);
+    const lines: string[] = [open];
+    children.forEach((child, index) => {
+        const isLast = index === children.length - 1;
+        for (const comment of ctx.comments.leading.get(child) ?? []) {
+            lines.push(
+                `${childIndent}${renderComment(ctx, comment, childDepth)}`
+            );
+        }
+        const rendered = renderNode(ctx, child, childDepth, isLast ? 0 : 1);
+        lines.push(
+            `${childIndent}${rendered}${isLast ? '' : ','}${trailingSuffix(
+                ctx,
+                child,
+                childDepth
+            )}`
+        );
+    });
+    for (const comment of inner) {
+        lines.push(`${childIndent}${renderComment(ctx, comment, childDepth)}`);
+    }
+    lines.push(`${indentFor(ctx, depth)}${close}`);
+    return lines.join('\n');
+};
+
+/**
+ * Format a whole JSONC document compactly, preserving comments. Invalid JSON
+ * (parse errors, trailing commas) is returned unchanged.
+ */
+export const formatJsoncCompact = (
+    content: string,
+    options: JsoncCompactFormatOptions
+): string => {
+    const ctx = parseDocument(content, options);
+    if (!ctx) {
+        return content;
+    }
+    const lines = (ctx.comments.leading.get(ctx.root) ?? []).map((comment) =>
+        renderComment(ctx, comment, 0)
+    );
+    lines.push(
+        `${renderNode(ctx, ctx.root, 0, 0)}${trailingSuffix(ctx, ctx.root, 0)}`
+    );
+    lines.push(
+        ...ctx.comments.after.map((comment) => renderComment(ctx, comment, 0))
+    );
+    return lines.join('\n');
+};
+
+const ancestryOf = (node: Node): Node[] => {
+    const chain: Node[] = [];
+    for (
+        let current: Node | undefined = node;
+        current;
+        current = current.parent
+    ) {
+        chain.unshift(current);
+    }
+    return chain;
+};
+
+const commonAncestor = (a: Node, b: Node): Node => {
+    const chainA = ancestryOf(a);
+    const chainB = ancestryOf(b);
+    let common = chainA[0] ?? a;
+    for (
+        let i = 0;
+        i < chainA.length && i < chainB.length && chainA[i] === chainB[i];
+        i++
+    ) {
+        common = chainA[i] ?? common;
+    }
+    return common;
+};
+
+const countContainerAncestors = (node: Node) => {
+    let depth = 0;
+    for (let current = node.parent; current; current = current.parent) {
+        if (isContainer(current)) {
+            depth++;
+        }
+    }
+    return depth;
+};
+
+/**
+ * The smallest complete node containing the selection. A selection that lands
+ * on a property's key or value snaps to the whole property; a selection in
+ * whitespace outside the root snaps to the root.
+ */
+const findFormatTarget = (root: Node, range: JsoncRange): Node => {
+    const start = findNodeAtOffset(root, range.offset) ?? root;
+    const lastOffset =
+        range.length > 0 ? range.offset + range.length - 1 : range.offset;
+    const end = findNodeAtOffset(root, lastOffset) ?? root;
+    const ancestor = commonAncestor(start, end);
+    return ancestor.parent?.type === 'property' ? ancestor.parent : ancestor;
+};
+
+/**
+ * Format only the smallest complete value or property that contains `range`.
+ * Returns the single edit to apply, or `undefined` for invalid JSON. Comments
+ * outside the target node's span are untouched.
+ */
+export const formatJsoncCompactRange = (
+    content: string,
+    range: JsoncRange,
+    options: JsoncCompactFormatOptions
+): JsoncTextEdit | undefined => {
+    const ctx = parseDocument(content, options);
+    if (!ctx) {
+        return undefined;
+    }
+    const target = findFormatTarget(ctx.root, range);
+    const siblings = target.parent?.children ?? [];
+    const isLast =
+        siblings.length === 0 || siblings[siblings.length - 1] === target;
+    return {
+        offset: target.offset,
+        length: target.length,
+        content: renderNode(
+            ctx,
+            target,
+            countContainerAncestors(target),
+            isLast ? 0 : 1
+        )
+    };
+};

--- a/packages/utils/src/lib/jsonc-format.ts
+++ b/packages/utils/src/lib/jsonc-format.ts
@@ -16,6 +16,8 @@ export interface JsoncCompactFormatOptions {
      * A container (object/array) whose single-line form — including its
      * indent, key prefix and trailing comma — fits within this many characters
      * is written on one line. Anything longer is expanded one child per line.
+     * Trailing comments are appended after the fit test and may extend a line
+     * beyond this width.
      */
     maxLineLength: number;
 }

--- a/packages/utils/src/lib/jsonc.ts
+++ b/packages/utils/src/lib/jsonc.ts
@@ -53,10 +53,4 @@ export const parseJsoncWithResult = (
     }
 };
 
-export {
-    formatJsoncCompact,
-    formatJsoncCompactRange,
-    type JsoncCompactFormatOptions,
-    type JsoncRange,
-    type JsoncTextEdit
-} from './jsonc-format';
+export { formatJsoncCompact, formatJsoncCompactRange } from './jsonc-format';

--- a/packages/utils/src/lib/jsonc.ts
+++ b/packages/utils/src/lib/jsonc.ts
@@ -52,3 +52,11 @@ export const parseJsoncWithResult = (
         };
     }
 };
+
+export {
+    formatJsoncCompact,
+    formatJsoncCompactRange,
+    type JsoncCompactFormatOptions,
+    type JsoncRange,
+    type JsoncTextEdit
+} from './jsonc-format';

--- a/src/lib/persistence/model/settings-editor.ts
+++ b/src/lib/persistence/model/settings-editor.ts
@@ -112,12 +112,29 @@ class SettingsEditorGroupJson extends formattingSettings.Group {
         },
         value: EDITOR_DEFAULTS.debouncePeriod.default
     });
+    formattingMaxLineLength = new formattingSettings.NumUpDown({
+        name: 'formattingMaxLineLength',
+        displayNameKey: 'Objects_Editor_FormattingMaxLineLength',
+        descriptionKey: 'Objects_Editor_FormattingMaxLineLength_Description',
+        options: {
+            minValue: {
+                value: EDITOR_DEFAULTS.formattingMaxLineLength.min,
+                type: 0
+            },
+            maxValue: {
+                value: EDITOR_DEFAULTS.formattingMaxLineLength.max,
+                type: 1
+            }
+        },
+        value: EDITOR_DEFAULTS.formattingMaxLineLength.default
+    });
     slices = [
         this.position,
         this.fontSize,
         this.wordWrap,
         this.showLineNumbers,
-        this.debouncePeriod
+        this.debouncePeriod,
+        this.formattingMaxLineLength
     ];
 }
 

--- a/src/lib/state/editor-preferences-sync-mappings.ts
+++ b/src/lib/state/editor-preferences-sync-mappings.ts
@@ -40,6 +40,14 @@ export const EDITOR_PREFERENCES_SYNC_MAPPINGS: SliceSyncMapping<EditorPreference
             }
         },
         {
+            sliceKey: 'jsonEditorFormattingMaxLineLength',
+            getVisualValue: (s) => s.editor.json.formattingMaxLineLength.value,
+            persistence: {
+                objectName: 'editor',
+                propertyName: 'formattingMaxLineLength'
+            }
+        },
+        {
             sliceKey: 'jsonEditorPosition',
             getVisualValue: (s) => s.editor.json.position.value,
             persistence: {

--- a/stringResources/en-US/resources.resjson
+++ b/stringResources/en-US/resources.resjson
@@ -98,6 +98,8 @@
     "Objects_Editor_DebugTableRowsPerPage_Description": "The number of rows to show in the Data and Signals tables in the debug pane.",
     "Objects_Editor_DebouncePeriod": "Change event detect interval",
     "Objects_Editor_DebouncePeriod_Description": "The interval at which to process change events in the editor. You can increase this to a longer interval if experiencing performance issues.",
+    "Objects_Editor_FormattingMaxLineLength": "Maximum line length when formatting",
+    "Objects_Editor_FormattingMaxLineLength_Description": "When formatting JSON, objects and arrays that fit within this many characters are written on a single line; longer ones are expanded one entry per line. Comments always force expansion.",
     "Objects_DataLimit": "Data management",
     "Objects_DataLimit_Description": "Options for managing how data is loaded and processed by the visual.",
     "Objects_DataLimit_Group_Loading": "Query limit",


### PR DESCRIPTION
## What this does

Fixes #578. Replaces the verbose one-value-per-line JSON formatting (jsonc-parser `format()`) with a **comment-preserving compact formatter** that packs objects and arrays onto a single line when they fit — the same layout Vega Editor produces via `json-stringify-pretty-compact` — while keeping full JSONC comment support.

```jsonc
// before                                   // after
{                                           {
  "mark": {                                   "mark": {"type": "bar", "tooltip": true},
    "type": "bar",                            "encoding": {
    "tooltip": true                             "x": {"field": "Category", "type": "nominal"},
  },                                            "y": {"field": "Sales", "type": "quantitative"}
  ...                                         }
}                                           }
```

## Changes

- **New formatter** (`@deneb-viz/utils/jsonc`): walks the jsonc-parser AST and applies the pretty-compact fit rule — a container stays on one line when its single-line form (indent + `"key": ` prefix + trailing comma included) fits within the max line length *and* contains no comments. Literals are copied as raw source slices, so `1.0`, `1e3`, and string escapes survive untouched. Invalid JSON is returned unchanged.
- **New property — “Maximum line length when formatting”** (Advanced editor → JSON editor): 40–200, default 80 (Vega Editor's effective default). Changes apply to the next format without reloading.
- **Monaco integration**: the JSON worker's built-in formatter is disabled and replaced with document + range providers backed by the new formatter. **Format Selection** now appears in the context menu, and <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>R</kbd> formats the selection when one exists; otherwise, it formats the whole document. Output adopts the document's existing line-ending style (CRLF-safe, including the invalid-JSON no-op path).
- **Template import/export** use the same formatter and honor the property, so exported templates and imported specs are as readable as the editor.

## Behavior notes (documented in DEVELOPMENT.md §5)

- Comments force expansion of their container (and every ancestor). Leading comments stay above their value; same-line trailing comments stay on the line; a comment between a key and its value is moved above the next entry.
- Range formatting snaps outward to the smallest complete value/property containing the selection.
- Layout is deterministic and idempotent — existing line breaks are not preserved.

## Testing

- **Parity oracle**: comment-free output is asserted byte-for-byte against `json-stringify-pretty-compact` (already a dependency) across Vega-Lite fixtures, edge cases, and multiple width/tab settings.
- 35 formatter unit tests (comment attachment, literal fidelity, range snapping incl. the comma-reserve fit boundary, idempotence, invalid input) + 6 Monaco provider tests exercising the *real* formatter (no mocks), including CRLF regression pins.
- Full suite green: utils 133, json-processing 102, app-core 664, root 565; `npm run ci:local` passes.
- Manual verification in Desktop: format document/selection via hotkey and context menu, live property changes, template export→import round-trip, comment preservation.

## Notes

- No new dependencies; net bundle impact ≈ 0 (the worker's unused formatter remains in the worker bundle — not tree-shakeable).
- Targeted at **2.1** — hold merge until the 2.0 certification cut is taken from `main`.
- Design record: `docs/brainstorms/2026-08-21-compact-jsonc-formatting-requirements.md`; implementation plan: `docs/plans/2026-08-21-001-compact-jsonc-formatting-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
