### PR TITLE
fix: correct __highlightStatus and __highlightComparator for un-highlighted rows (#753)

### DIFF
--- a/packages/data-core/src/lib/support-fields/__tests__/build-data-row.test.ts
+++ b/packages/data-core/src/lib/support-fields/__tests__/build-data-row.test.ts
@@ -185,6 +185,31 @@ describe('buildDataRow', () => {
             expect(result[`Sales${HIGHLIGHT_STATUS_SUFFIX}`]).toBe('on');
         });
 
+        // Issue #753: an un-highlighted row (null-padded highlights array)
+        // must report 'off' while a highlight is active elsewhere.
+        it('should emit off when the provider returns a null highlight value', () => {
+            const provider = makeProvider({
+                getHighlightValue: vi.fn().mockReturnValue(null)
+            });
+            const plan = makePlan(
+                [
+                    makeInstruction({
+                        encodedName: 'Sales',
+                        emitHighlightStatus: true
+                    })
+                ],
+                { hasHighlights: true }
+            );
+            const result = buildDataRow({
+                plan,
+                provider,
+                baseValues: [100],
+                rowIndex: 0,
+                locale: 'en-US'
+            });
+            expect(result[`Sales${HIGHLIGHT_STATUS_SUFFIX}`]).toBe('off');
+        });
+
         it('should resolve highlight value internally even when emitHighlight is false', () => {
             const provider = makeProvider({
                 getHighlightValue: vi.fn().mockReturnValue(75)

--- a/packages/data-core/src/lib/value/__tests__/highlight.test.ts
+++ b/packages/data-core/src/lib/value/__tests__/highlight.test.ts
@@ -78,4 +78,27 @@ describe('getHighlightComparatorValue', () => {
             getHighlightComparatorValue(asValue(100), asValue(undefined))
         ).toBe('neq');
     });
+
+    // Issue #753: a null comparator (un-highlighted row) is "no value", not
+    // zero. Without an explicit guard, JS coercion produced 'lt' for positive
+    // bases, 'gt' for negative and 'neq' for zero/text — sign-dependent noise.
+    it('returns neq for a null comparator regardless of base value sign', () => {
+        expect(getHighlightComparatorValue(asValue(8.4), asValue(null))).toBe(
+            'neq'
+        );
+        expect(getHighlightComparatorValue(asValue(-5), asValue(null))).toBe(
+            'neq'
+        );
+        expect(getHighlightComparatorValue(asValue(0), asValue(null))).toBe(
+            'neq'
+        );
+    });
+
+    // Both null stays 'eq', consistent with getHighlightStatusValue keeping
+    // the both-null shape as 'on' (a null measure inside the highlight).
+    it('returns eq when both base value and comparator are null', () => {
+        expect(getHighlightComparatorValue(asValue(null), asValue(null))).toBe(
+            'eq'
+        );
+    });
 });

--- a/packages/data-core/src/lib/value/__tests__/highlight.test.ts
+++ b/packages/data-core/src/lib/value/__tests__/highlight.test.ts
@@ -30,6 +30,24 @@ describe('getHighlightStatusValue', () => {
         ).toBe('off');
     });
 
+    // Issue #753: Power BI null-pads the highlights array, so a row outside
+    // an active highlight arrives as a present base value with a null
+    // comparator. It must report 'off', not 'on'.
+    it('is off for a present base value with a null comparator', () => {
+        expect(
+            getHighlightStatusValue(true, asValue(8.4), asValue(null))
+        ).toBe('off');
+    });
+
+    // Ambiguous shape (deliberate): a null base with a null comparator is
+    // indistinguishable from a null measure inside the highlight, so the
+    // long-standing 'on' result is preserved.
+    it('remains on when both base value and comparator are null', () => {
+        expect(
+            getHighlightStatusValue(true, asValue(null), asValue(null))
+        ).toBe('on');
+    });
+
     // Audit L13: a highlights array shorter than values yields an undefined
     // comparator via an out-of-bounds read; it must not be reported as 'on'.
     it('is off (not on) for an undefined out-of-bounds comparator', () => {

--- a/packages/data-core/src/lib/value/highlight.ts
+++ b/packages/data-core/src/lib/value/highlight.ts
@@ -21,6 +21,12 @@ export const getHighlightComparatorValue = (
             return 'neq';
         case fieldValue == comparatorValue:
             return 'eq';
+        // A null comparator (un-highlighted row) has no value to compare
+        // against; without this guard, coercion made the result depend on the
+        // base value's sign. Ordered after the equality check so a both-null
+        // shape still resolves to 'eq'.
+        case comparatorValue === null:
+            return 'neq';
         case comparatorValue < fieldValue:
             return 'lt';
         case comparatorValue > fieldValue:

--- a/packages/data-core/src/lib/value/highlight.ts
+++ b/packages/data-core/src/lib/value/highlight.ts
@@ -50,6 +50,8 @@ export const getHighlightStatusValue = (
             return 'off';
         case hasHighlights && fieldValue === null && comparatorValue !== null:
             return 'off';
+        case hasHighlights && fieldValue !== null && comparatorValue === null:
+            return 'off';
         default:
             return 'on';
     }


### PR DESCRIPTION
## Summary

Fixes #753. Two related defects in `getHighlightStatusValue` / `getHighlightComparatorValue` (`@deneb-viz/data-core`), both present since cross-highlighting shipped in 1.1 (2022) and carried into the 2.0 data processing:

1. **`__highlightStatus` reported `'on'` for every row during an active cross-highlight.** The only `'off'` branch tested for a null base value with a present highlight value — a shape Power BI never sends (highlights are aggregates over a subset of the rows behind the base value, so it is effectively dead code). An un-highlighted row actually arrives as a present base value with a null-padded highlight value, which fell through to `'on'`. A symmetric branch now returns `'off'` for that shape.
2. **`__highlightComparator` resolved a `null` highlight value via JS coercion**, producing `'lt'` for positive base values, `'gt'` for negative ones, and `'neq'` for zero/text — sign-dependent noise. A `null` comparator now resolves explicitly to `'neq'`, matching the existing `undefined` out-of-bounds guard and the documented meaning ("not directly comparable").

Deliberate edge decisions:
- A both-null shape (null measure) keeps its long-standing results — status `'on'`, comparator `'eq'` — as it is indistinguishable from a null measure inside the highlight.
- Grouping-component passthrough in field parameters is unaffected.

## ⚠️ Behavior change — hold for 2.1

**Do not merge for the 2.0 release.** Because `__highlightStatus` has never worked, specs in the wild distinguish highlighted rows via the comparator (e.g. `=== 'lt'` on un-highlighted rows — the workaround documented in #753). This PR changes that observable value to `'neq'`, so specs testing `'lt'`/`'gt'` for that purpose need updating to `__highlightStatus === 'off'` (or `!== 'eq'`). As this is not a 2.0 regression and beta testing is nearly complete, it is held for 2.1 to allow targeted beta feedback and remediation time. Needs a release-note entry when it lands.

## Testing

- New unit tests in `highlight.test.ts` covering the reported shape (`(true, 8.4, null)` → `'off'`), null-comparator resolution across positive/negative/zero bases, and the preserved both-null cases — all verified failing before the fix.
- Row-builder-level test in `build-data-row.test.ts` locking `__highlightStatus: 'off'` when the provider returns a null highlight value.
- Full suite and `npm run ci:local` green; fix verified against the issue reproduction in Power BI Desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)