### PR TITLE
fix: ensure that partial supportFieldConfiguration will validate (#755)

### DIFF
--- a/packages/app-core/src/lib/project/__tests__/utils.test.ts
+++ b/packages/app-core/src/lib/project/__tests__/utils.test.ts
@@ -143,3 +143,32 @@ describe('remapSupportFieldConfigurationForImport', () => {
         });
     });
 });
+
+describe('remapSupportFieldConfigurationForImport — partial template config (#755)', () => {
+    it('should normalize a partial config to the full flag set with missing flags off', () => {
+        const dataset: UsermetaDatasetField[] = [
+            {
+                key: '__dataset.0__',
+                name: 'Metric Fields',
+                suppliedObjectName: 'Metric Fields',
+                kind: 'parameter',
+                type: 'other',
+                supportFieldConfiguration: {
+                    format: true,
+                    formatted: true,
+                    names: true
+                }
+            }
+        ];
+        expect(remapSupportFieldConfigurationForImport(dataset)).toEqual({
+            'Metric Fields': {
+                highlight: false,
+                highlightStatus: false,
+                highlightComparator: false,
+                format: true,
+                formatted: true,
+                names: true
+            }
+        });
+    });
+});

--- a/packages/app-core/src/lib/project/utils.ts
+++ b/packages/app-core/src/lib/project/utils.ts
@@ -2,7 +2,10 @@ import { PROJECT_DEFAULTS } from '@deneb-viz/configuration';
 import { DenebProject } from './types';
 import { logDebug } from '@deneb-viz/utils/logging';
 import { type UsermetaDatasetField } from '@deneb-viz/data-core/field';
-import { type SupportFieldConfiguration } from '@deneb-viz/data-core/support-fields';
+import {
+    getNormalizedSupportFieldFlags,
+    type SupportFieldConfiguration
+} from '@deneb-viz/data-core/support-fields';
 
 export const isProjectInitialized = (project: DenebProject): boolean => {
     const isInitialized =
@@ -29,7 +32,9 @@ export const remapSupportFieldConfigurationForImport = (
     const result: SupportFieldConfiguration = {};
     for (const field of dataset) {
         if (field.supportFieldConfiguration && field.suppliedObjectName) {
-            result[field.suppliedObjectName] = field.supportFieldConfiguration;
+            result[field.suppliedObjectName] = getNormalizedSupportFieldFlags(
+                field.supportFieldConfiguration
+            );
         }
     }
     return result;

--- a/packages/data-core/doc/support-fields.md
+++ b/packages/data-core/doc/support-fields.md
@@ -580,7 +580,7 @@ When consolidation is enabled, users can mark a regular field as "treat as field
 
 ### Template integration
 
-Field parameters are exported with `kind: 'parameter'` in the template dataset metadata. The `__names` suffix is included in the tokenization regex alternation patterns so template export/import correctly handles `__names` references in specs. The `treatAsParameter` and `names` flags are included in `supportFieldConfiguration` when explicitly configured.
+Field parameters are exported with `kind: 'parameter'` in the template dataset metadata. The `__names` suffix is included in the tokenization regex alternation patterns so template export/import correctly handles `__names` references in specs. The `treatAsParameter` and `names` flags are included in `supportFieldConfiguration` when explicitly configured. The five core flags are optional in the template schema; a missing flag is treated as `false`. Both export and import pass the entry through `getNormalizedSupportFieldFlags()` so that Deneb always writes the complete set and always imports a complete set into state (#755).
 
 ---
 

--- a/packages/data-core/src/lib/field/types.ts
+++ b/packages/data-core/src/lib/field/types.ts
@@ -144,7 +144,7 @@ export type UsermetaDatasetField = {
      * Optional — only present for fields with explicit (non-default) configuration.
      * @ignore
      */
-    supportFieldConfiguration?: SupportFieldFlags;
+    supportFieldConfiguration?: Partial<SupportFieldFlags>;
 };
 
 /**

--- a/packages/data-core/src/lib/support-fields/__tests__/resolve-defaults.test.ts
+++ b/packages/data-core/src/lib/support-fields/__tests__/resolve-defaults.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { resolveFieldDefaults } from '../resolve-defaults';
+import {
+    getNormalizedSupportFieldFlags,
+    resolveFieldDefaults
+} from '../resolve-defaults';
 import type { SupportFieldMasterSettings } from '../types';
 
 const HIGHLIGHT_ON: SupportFieldMasterSettings = {
@@ -148,5 +151,42 @@ describe('resolveFieldDefaults', () => {
             expect(result.format).toBe(false);
             expect(result.formatted).toBe(false);
         });
+    });
+});
+
+describe('getNormalizedSupportFieldFlags', () => {
+    it('should fill missing core flags with false and keep provided values', () => {
+        expect(
+            getNormalizedSupportFieldFlags({ format: true, formatted: true })
+        ).toEqual({
+            highlight: false,
+            highlightStatus: false,
+            highlightComparator: false,
+            format: true,
+            formatted: true
+        });
+    });
+
+    it('should return all-false for an empty object', () => {
+        expect(getNormalizedSupportFieldFlags({})).toEqual({
+            highlight: false,
+            highlightStatus: false,
+            highlightComparator: false,
+            format: false,
+            formatted: false
+        });
+    });
+
+    it('should only carry optional flags when they were supplied', () => {
+        const result = getNormalizedSupportFieldFlags({
+            names: true,
+            treatAsParameter: false
+        });
+        expect(result.names).toBe(true);
+        expect(result.treatAsParameter).toBe(false);
+        expect(getNormalizedSupportFieldFlags({})).not.toHaveProperty('names');
+        expect(getNormalizedSupportFieldFlags({})).not.toHaveProperty(
+            'treatAsParameter'
+        );
     });
 });

--- a/packages/data-core/src/lib/support-fields/index.ts
+++ b/packages/data-core/src/lib/support-fields/index.ts
@@ -11,6 +11,7 @@ export type {
 export { createDefaultProvider } from './default-provider';
 export {
     resolveFieldDefaults,
+    getNormalizedSupportFieldFlags,
     type ResolveFieldDefaultsParams
 } from './resolve-defaults';
 export {

--- a/packages/data-core/src/lib/support-fields/resolve-defaults.ts
+++ b/packages/data-core/src/lib/support-fields/resolve-defaults.ts
@@ -58,3 +58,22 @@ export const resolveFieldDefaults = ({
         formatted: false
     };
 };
+
+/**
+ * Fill any missing flags with `false`. Templates and PBIR-authored state may
+ * carry only the flags that are switched on (#755); the plan builder already
+ * treats an absent flag as off, so this makes that contract explicit.
+ */
+export const getNormalizedSupportFieldFlags = (
+    flags: Partial<SupportFieldFlags>
+): SupportFieldFlags => ({
+    highlight: flags.highlight ?? false,
+    highlightStatus: flags.highlightStatus ?? false,
+    highlightComparator: flags.highlightComparator ?? false,
+    format: flags.format ?? false,
+    formatted: flags.formatted ?? false,
+    ...(flags.names !== undefined && { names: flags.names }),
+    ...(flags.treatAsParameter !== undefined && {
+        treatAsParameter: flags.treatAsParameter
+    })
+});

--- a/packages/json-processing/src/__test__/template-usermeta.test.ts
+++ b/packages/json-processing/src/__test__/template-usermeta.test.ts
@@ -1593,3 +1593,126 @@ describe('getPublishableUsermeta — supportFieldConfiguration inline in dataset
         });
     });
 });
+
+describe('getValidatedTemplate — partial supportFieldConfiguration (#755)', () => {
+    const MOCK_TAB_SIZE = 2;
+    const getTemplateWithConfig = (config: Record<string, unknown>) =>
+        JSON.stringify({
+            $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+            usermeta: {
+                information: {
+                    uuid: '81573f77-e87c-4d9c-993a-d70fb28c275e',
+                    generated: '2026-08-27T19:47:37.295Z',
+                    previewImageBase64PNG: 'data:image/png;base64,',
+                    name: 'n',
+                    description: 'd',
+                    author: 'a'
+                },
+                deneb: {
+                    build: '2.0.0',
+                    metaVersion: 2,
+                    provider: 'vegaLite',
+                    providerVersion: '6.4.3'
+                },
+                interactivity: {
+                    tooltip: true,
+                    contextMenu: true,
+                    contextMenuSelector: true,
+                    selection: false,
+                    selectionMode: 'simple',
+                    highlight: false,
+                    dataPointLimit: 50
+                },
+                config: '{}',
+                datasets: {
+                    dataset: [
+                        {
+                            key: '__dataset.0__',
+                            name: 'Metric Fields',
+                            description: '',
+                            kind: 'parameter',
+                            type: 'other',
+                            supportFieldConfiguration: config
+                        }
+                    ]
+                }
+            },
+            data: { name: 'dataset' },
+            mark: 'bar'
+        });
+
+    it('should accept a config that only carries the enabled flags', () => {
+        const result = getValidatedTemplate(
+            getTemplateWithConfig({
+                format: true,
+                formatted: true,
+                names: true
+            }),
+            MOCK_TAB_SIZE
+        );
+        expect(result.importState).toBe('Success');
+    });
+
+    it('should accept an empty config object', () => {
+        const result = getValidatedTemplate(
+            getTemplateWithConfig({}),
+            MOCK_TAB_SIZE
+        );
+        expect(result.importState).toBe('Success');
+    });
+
+    it('should still reject non-boolean flag values', () => {
+        const result = getValidatedTemplate(
+            getTemplateWithConfig({ format: 'yes' }),
+            MOCK_TAB_SIZE
+        );
+        expect(result.importState).toBe('Error');
+    });
+
+    it('should still reject unknown flag names', () => {
+        const result = getValidatedTemplate(
+            getTemplateWithConfig({ format: true, bogus: true }),
+            MOCK_TAB_SIZE
+        );
+        expect(result.importState).toBe('Error');
+    });
+});
+
+describe('getPublishableUsermeta — normalizes partial supportFieldConfiguration on export (#755)', () => {
+    it('should write the complete flag set when state only carries enabled flags', () => {
+        const usermeta: UsermetaTemplate = {
+            ...EXPECTED_METADATA_BASE,
+            datasets: {
+                dataset: [
+                    {
+                        key: '__dataset.0__',
+                        name: '$ Sales',
+                        namePlaceholder: '$ Sales',
+                        description: '',
+                        kind: 'measure',
+                        type: 'numeric'
+                    }
+                ]
+            }
+        };
+        const result = getPublishableUsermeta(usermeta, {
+            informationTranslationPlaceholders: {
+                name: 'n',
+                description: 'd',
+                author: 'a'
+            },
+            supportFieldConfiguration: {
+                '$ Sales': { format: true, names: true } as never
+            },
+            trackedFields: TRACKED_FIELDS_BY_QUERYNAME
+        });
+        expect(result.datasets.dataset[0].supportFieldConfiguration).toEqual({
+            highlight: false,
+            highlightStatus: false,
+            highlightComparator: false,
+            format: true,
+            formatted: false,
+            names: true
+        });
+    });
+});

--- a/packages/json-processing/src/template-usermeta.ts
+++ b/packages/json-processing/src/template-usermeta.ts
@@ -35,7 +35,10 @@ import {
     getPlaceholderKey,
     type UsermetaDatasetField
 } from '@deneb-viz/data-core/field';
-import { type SupportFieldConfiguration } from '@deneb-viz/data-core/support-fields';
+import {
+    getNormalizedSupportFieldFlags,
+    type SupportFieldConfiguration
+} from '@deneb-viz/data-core/support-fields';
 import {
     type SelectionMode,
     INTERACTIVITY_DEFAULTS
@@ -217,7 +220,8 @@ export const getPublishableUsermeta = (
                     const fieldConfig =
                         options.supportFieldConfiguration?.[sfcKey];
                     if (fieldConfig) {
-                        item.supportFieldConfiguration = fieldConfig;
+                        item.supportFieldConfiguration =
+                            getNormalizedSupportFieldFlags(fieldConfig);
                     }
                     return omit(item as unknown as Record<string, unknown>, [
                         'namePlaceholder'


### PR DESCRIPTION
Per details in #755, if `supportFieldConfiguration` is authored outside the UI, it may be in a partial state. This PR adds validation for partials and populates sensible defaults if missing.