### PR TITLE
chore: promote data-core bench gate from advisory to hard fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,11 +130,23 @@ jobs:
               run: |
                   echo "::error::Benchmark comparison script failed (compare_exit=${{ steps.bench.outputs.compare_exit }}, data-core=${{ steps.bench.outputs.data_core_compare_exit }}, app-core=${{ steps.bench.outputs.app_core_compare_exit }}). A bench crash produces ENOENT in compare.mjs which exits 2. See 'Run benchmarks and compare' step for details."
                   exit 1
-            - name: Flag regression (advisory)
-              if: steps.bench.outputs.compare_exit == '1'
+            # app-core stays advisory: its dataset-search flag-label
+            # benchmark has shown ~47% swings on unchanged code, so a
+            # hard gate would produce false-red CI. Promote it only
+            # after a per-benchmark threshold override or a stable
+            # refreshed baseline lands (see #623). This step runs
+            # before the data-core gate so the warning still surfaces
+            # when both packages regress.
+            - name: Flag app-core regression (advisory)
+              if: steps.bench.outputs.app_core_compare_exit == '1'
               continue-on-error: true
               run: |
-                  echo "::warning::Benchmark regression detected — see comparison table in the 'Run benchmarks and compare' step (data-core=${{ steps.bench.outputs.data_core_compare_exit }}, app-core=${{ steps.bench.outputs.app_core_compare_exit }}). During advisory rollout, regressions are reported but do NOT block merges."
+                  echo "::warning::app-core benchmark regression detected — see comparison table in the 'Run benchmarks and compare' step. app-core benchmarks are advisory and do NOT block merges (#623)."
+                  exit 1
+            - name: Fail on data-core regression
+              if: steps.bench.outputs.data_core_compare_exit == '1'
+              run: |
+                  echo "::error::data-core benchmark regression detected — see comparison table in the 'Run benchmarks and compare' step. data-core bench regressions block merges (#623). If the regression is an accepted trade-off, refresh the baseline via the bench-update-baseline workflow."
                   exit 1
 
     prerelease:


### PR DESCRIPTION
## Summary

Partially completes #623: **data-core benchmark regressions now block merges.** The single advisory step is split into per-package guards:

- **data-core** — regression → `::error::` + `exit 1` (hard fail)
- **app-core** — regression → `::warning::` + `continue-on-error` (still advisory)

⚠️ **Heads-up for contributors: bench failures in data-core now block merges.** If a regression is an accepted trade-off, refresh the baseline via the `bench-update-baseline` workflow.

## Why data-core only

Reviewing the last 10 `main` runs of the advisory rollout (~4 months of observation):

- **data-core**: 0 regressions; passing deltas mostly single-digit, worst ~11% vs. the 20% threshold. Stable enough to gate.
- **app-core**: the `dataset-search.bench.ts` › flag-label match ("highlight") benchmark hit **47% deltas on unchanged code in 2 of 10 runs** (runs 33120458449, 32089404514). Hard-gating it would produce false-red CI. It stays advisory until a per-benchmark threshold override or a stable refreshed baseline lands — tracked in #623, which stays open for that.

The advisory app-core step is ordered before the data-core gate so its warning still surfaces when both packages regress. The script-error guard (`compare_exit == 2`) is unchanged.

## Verification

- `npm run ci:local` passes (includes `test:benchmarks` covering `compare.mjs` exit codes).
- Workflow YAML parse-checked; step conditions use the existing `data_core_compare_exit` / `app_core_compare_exit` outputs already emitted by the bench step.
- The #623 acceptance check (draft PR with an injected regression in `buildDataRow` gets blocked) can be run against this branch on request — the `pull_request` trigger uses the head branch's workflow, so it exercises the new gate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)